### PR TITLE
Refine side buttons and harden story fetch

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -17,7 +17,7 @@
     .container {
       max-width: 800px;
       margin: 0 auto;
-      padding: 2em;
+      padding: 4.5em 2em 2em;
       text-align: center;
     }
 
@@ -42,17 +42,35 @@
       text-decoration: none;
     }
 
+    .back-button {
+      position: fixed;
+      top: 1.5em;
+      left: 1.5em;
+      z-index: 1000;
+    }
+
     a { color: #dabfff; }
+
+    @media (max-width: 600px) {
+      .container {
+        padding: 5em 1.5em 2em;
+      }
+
+      .back-button {
+        top: 1em;
+        left: 1em;
+      }
+    }
   </style>
 </head>
 <body>
+  <a class="link-button back-button" href="index.html">⬅️ Back home</a>
   <div class="container">
     <h1>📓 Blog Pupdates</h1>
     <p>All the cozy ramblings, collected in one snuggly spot.</p>
     <div id="blog-posts">
       <p>Loading posts…</p>
     </div>
-    <a class="link-button" href="index.html">⬅️ Back home</a>
   </div>
 
   <script>

--- a/index.html
+++ b/index.html
@@ -60,27 +60,47 @@
     }
 
     .side-button {
-      position: fixed;
-      right: 0;
-      transform: translateY(-50%);
       background: white;
       color: #6a0dad;
-      height: 140px;
-      width: 5px;
+      min-height: 140px;
       display: flex;
       justify-content: center;
       align-items: center;
       font-weight: bold;
       font-size: 0.8em;
       border: 2px solid white;
-      border-radius: 15px 0 0 15px;
       text-decoration: none;
       padding: 0.7em 1.4em;
+      border-radius: 15px;
+    }
+
+    .side-button--right {
+      border-radius: 15px 0 0 15px;
+    }
+
+    #right-side-buttons {
+      position: fixed;
+      top: 50%;
+      right: 0;
+      transform: translateY(-50%);
+      display: flex;
+      flex-direction: column;
+      gap: 1.5em;
       z-index: 1000;
     }
 
-    #blog-link { top: 45%; }
-    #paw-open { top: 65%; }
+    .side-button--left {
+      position: fixed;
+      top: 50%;
+      left: 0;
+      transform: translateY(-50%);
+      border-radius: 0 15px 15px 0;
+      z-index: 1000;
+    }
+
+    .side-button--left .vertical-text {
+      writing-mode: vertical-lr;
+    }
 
     #paw-panel {
       position: fixed;
@@ -165,15 +185,10 @@
 
     .vertical-text {
       writing-mode: vertical-rl;
-      text-orientation: mixed;
-    }
-
-    #paw-open .vertical-text {
-      transform: rotate(90deg);
-    }
-
-    #blog-link .vertical-text {
-      transform: rotate(270deg);
+      text-orientation: upright;
+      display: inline-block;
+      letter-spacing: 0.15em;
+      white-space: nowrap;
     }
 
     body.blur .container,
@@ -194,8 +209,11 @@
   </div>
 
   <!-- Side Buttons -->
-  <a id="blog-link" class="side-button" href="blog.html"><span class="vertical-text">📓 Blog</span></a>
-  <div id="paw-open" class="side-button"><span class="vertical-text">🐾 Pawprints</span></div>
+  <div id="right-side-buttons">
+    <a id="blog-link" class="side-button side-button--right" href="blog.html"><span class="vertical-text">📓 Blog</span></a>
+    <a id="story-link" class="side-button side-button--right" href="story.html"><span class="vertical-text">📖 Story</span></a>
+  </div>
+  <div id="paw-open" class="side-button side-button--left"><span class="vertical-text">🐾 Pawprints</span></div>
 
   <!-- Paw Print Panel -->
   <div id="paw-panel">
@@ -239,8 +257,6 @@
       <a class="link-button" href="https://www.tumblr.com/nele-likes-stuff" target="_blank">Tumblr</a>
       <a class="link-button" href="https://www.reddit.com/user/CapFuture_/" target="_blank">Reddit</a>
       <a class="link-button" href="https://steamcommunity.com/id/RCKT_GRL/" target="_blank">Steam</a>
-      <a class="link-button" href="story.html">Read our story</a>
-      <a class="link-button" href="blog.html">Blog archive</a>
     </div>
 
     <div class="textbox">

--- a/story.html
+++ b/story.html
@@ -17,7 +17,7 @@
     .container {
       max-width: 800px;
       margin: 0 auto;
-      padding: 2em;
+      padding: 4.5em 2em 2em;
       text-align: center;
     }
 
@@ -42,15 +42,33 @@
       text-decoration: none;
     }
 
+    .back-button {
+      position: fixed;
+      top: 1.5em;
+      left: 1.5em;
+      z-index: 1000;
+    }
+
     a { color: #dabfff; }
+
+    @media (max-width: 600px) {
+      .container {
+        padding: 5em 1.5em 2em;
+      }
+
+      .back-button {
+        top: 1em;
+        left: 1em;
+      }
+    }
   </style>
 </head>
 <body>
+  <a class="link-button back-button" href="index.html">⬅️ Back home</a>
   <div class="container">
     <h1>Story Time</h1>
     <p>Grab a blanket, get comfy, and enjoy the latest adventure from the Puppy Pillow Fortress!</p>
     <div id="story-content" class="textbox">Loading story…</div>
-    <a class="link-button" href="index.html">⬅️ Back home</a>
   </div>
 
   <script>
@@ -59,24 +77,42 @@
     // NOTE: Replace the IDs below with the values from Google Docs and keep the doc published to the web.
     const publishedDocId = 'YOUR_PUBLISHED_DOC_ID_HERE';
     const fallbackDocId = 'YOUR_GOOGLE_DOC_ID_HERE';
+    const fallbackUrl = fallbackDocId === 'YOUR_GOOGLE_DOC_ID_HERE'
+      ? null
+      : `https://docs.google.com/document/d/${fallbackDocId}/view`;
 
-    function escapeHTML(str) {
-      return str.replace(/[&<>"']/g, tag => ({
-        '&': '&amp;',
-        '<': '&lt;',
-        '>': '&gt;',
-        '"': '&quot;',
-        "'": '&#39;',
-      }[tag]));
+    function renderParagraphs(paragraphs) {
+      storyContent.innerHTML = '';
+      let appended = false;
+
+      paragraphs.forEach(text => {
+        const trimmed = text.trim();
+        if (!trimmed) {
+          return;
+        }
+
+        const paragraphEl = document.createElement('p');
+        paragraphEl.textContent = trimmed;
+        storyContent.appendChild(paragraphEl);
+        appended = true;
+      });
+
+      if (!appended) {
+        storyContent.innerHTML = '<p>The story is currently empty.</p>';
+      }
+    }
+
+    function showError(extraMessage = '') {
+      const details = fallbackUrl
+        ? `<a href="${fallbackUrl}" target="_blank" rel="noopener">Read it on Google Docs</a>.`
+        : 'Please double-check that the Google Doc is published and publicly accessible.';
+      storyContent.innerHTML = `<p>We couldn't load the story automatically. ${details}${extraMessage}</p>`;
     }
 
     if (publishedDocId === 'YOUR_PUBLISHED_DOC_ID_HERE') {
-      storyContent.innerHTML = '<p>Please publish your Google Doc and replace the placeholder IDs in <code>story.html</code>.</p>';
+      showError(' Please publish your Google Doc and replace the placeholder IDs in <code>story.html</code>.');
     } else {
       const docUrl = `https://docs.google.com/document/d/e/${publishedDocId}/pub?output=txt`;
-      const fallbackUrl = fallbackDocId === 'YOUR_GOOGLE_DOC_ID_HERE'
-        ? null
-        : `https://docs.google.com/document/d/${fallbackDocId}/view`;
 
       fetch(docUrl)
         .then(response => {
@@ -87,22 +123,37 @@
         })
         .then(text => {
           const trimmed = text.trim();
+
           if (!trimmed) {
-            throw new Error('Story is empty');
+            renderParagraphs([]);
+            return;
           }
 
-          const paragraphs = trimmed.split(/\n\s*\n/);
-          storyContent.innerHTML = paragraphs
-            .map(paragraph => `<p>${escapeHTML(paragraph)}</p>`)
-            .join('');
+          if (/^<!doctype html/i.test(trimmed) || /^<html/i.test(trimmed)) {
+            const htmlError = new Error('html-response');
+            htmlError.isHTMLResponse = true;
+            throw htmlError;
+          }
+
+          let paragraphs = trimmed.split(/\n\s*\n/).map(part => part.trim()).filter(Boolean);
+
+          if (!paragraphs.length && trimmed.includes('\n')) {
+            paragraphs = trimmed.split(/\r?\n/).map(part => part.trim()).filter(Boolean);
+          }
+
+          if (!paragraphs.length) {
+            renderParagraphs([trimmed]);
+            return;
+          }
+
+          renderParagraphs(paragraphs);
         })
         .catch(error => {
           console.error(error);
-          storyContent.innerHTML = `
-            <p>We couldn't load the story automatically. ${fallbackUrl
-              ? `<a href="${fallbackUrl}" target="_blank" rel="noopener">Read it on Google Docs</a>.`
-              : 'Please double-check that the Google Doc is published and publicly accessible.'}
-            </p>`;
+          const extra = error?.isHTMLResponse
+            ? ' Please make sure the document is published to the web and that you are using the ID from the published link.'
+            : '';
+          showError(extra);
         });
     }
   </script>


### PR DESCRIPTION
## Summary
- keep the vertical side button labels upright with additional spacing so pawprints/blog/story read correctly
- rework the story loader to render fetched paragraphs safely and surface clearer guidance when Google Docs isn’t ready

## Testing
- python -m http.server 8000 (manual verification)


------
https://chatgpt.com/codex/tasks/task_e_68c9be76cc448324b95b9e546094bd00