### PR TITLE
Add animated hero background carousel and pastel blur overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,12 +38,42 @@
       padding: calc(1.75em + var(--hero-gap) / 2) 2em 2.5em;
       text-align: center;
       z-index: 1;
-      background: rgba(32, 0, 58, 0.4);
+      background: rgba(231, 210, 255, 0.55);
       border-radius: 24px;
-      box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+      box-shadow: 0 20px 60px rgba(126, 77, 202, 0.35);
       backdrop-filter: blur(6px);
       -webkit-backdrop-filter: blur(6px);
-      border: 1px solid rgba(255, 255, 255, 0.3);
+      border: 1px solid rgba(255, 255, 255, 0.6);
+    }
+
+    .background-controls {
+      display: flex;
+      justify-content: flex-end;
+      margin: 0 0 1.5em;
+    }
+
+    .next-background-button {
+      cursor: pointer;
+      padding: 0.6em 1.4em;
+      background: rgba(255, 255, 255, 0.85);
+      color: #5a1a9c;
+      font-weight: 700;
+      border: 2px solid #f3e5ff;
+      border-radius: 999px;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      transition: background 0.3s ease, transform 0.3s ease;
+    }
+
+    .next-background-button:hover,
+    .next-background-button:focus-visible {
+      background: #f3e5ff;
+      transform: translateY(-2px);
+    }
+
+    .next-background-button:focus-visible {
+      outline: 3px solid rgba(158, 94, 222, 0.55);
+      outline-offset: 2px;
     }
 
     .hero-layer {
@@ -52,21 +82,50 @@
       left: 50%;
       transform: translateX(-50%);
       width: clamp(280px, 90vw, 1200px);
-      display: flex;
-      flex-direction: column;
-      gap: var(--hero-gap);
+      display: block;
       z-index: 0;
       pointer-events: none;
     }
 
-    .hero-layer__image {
+    .hero-layer__slider {
+      position: relative;
       width: 100%;
-      height: auto;
-      max-height: none;
-      object-fit: contain;
+      aspect-ratio: 3 / 2;
+      border-radius: 20px;
+      overflow: hidden;
+      box-shadow: 0 16px 45px rgba(126, 77, 202, 0.4);
+      background: linear-gradient(135deg, rgba(226, 200, 255, 0.8), rgba(167, 133, 255, 0.55));
+    }
+
+    .hero-layer__image {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
       border-radius: 20px;
       margin: 0;
-      box-shadow: 0 12px 36px rgba(0, 0, 0, 0.45);
+      opacity: 0;
+      transform: translateX(0);
+      transition: transform 0.7s ease, opacity 0.7s ease;
+    }
+
+    .hero-layer__image--current {
+      opacity: 1;
+    }
+
+    .hero-layer__image--incoming {
+      transform: translateX(100%);
+    }
+
+    .hero-layer__image--slide-in {
+      transform: translateX(0);
+      opacity: 1;
+    }
+
+    .hero-layer__image--slide-out {
+      transform: translateX(-100%);
+      opacity: 0;
     }
 
     .textbox {
@@ -269,8 +328,7 @@
 </head>
 <body>
   <div class="hero-layer" aria-hidden="true">
-    <img class="hero-layer__image" src="Untitled_Artwork.jpeg" alt="">
-    <img class="hero-layer__image" src="Pumpkin and Nyx.jpg" alt="">
+    <div class="hero-layer__slider"></div>
   </div>
   <!-- Cookie Popup -->
   <div id="cookie-popup">
@@ -316,6 +374,9 @@
 
   <!-- Main Content -->
   <div class="container">
+    <div class="background-controls">
+      <button id="next-background" class="next-background-button" type="button">Next background</button>
+    </div>
     <h1>Puppy pillow fortress</h1>
 
     <div class="textbox">
@@ -391,6 +452,128 @@
     const volumeControl = document.getElementById('volume-control');
     const volumeLabel = document.getElementById('volume-label');
     const volumeIcon = document.getElementById('volume-icon');
+    const heroSlider = document.querySelector('.hero-layer__slider');
+    const nextBackgroundButton = document.getElementById('next-background');
+
+    const heroImages = [
+      { src: 'Untitled_Artwork.jpeg', alt: 'Pastel illustration of Pumpkin and Nyx snuggling amongst pillows.' },
+      { src: 'Pumpkin and Nyx.jpg', alt: 'Pumpkin and Nyx cuddling together on a cozy sofa.' },
+      { src: 'IMG_9672.png', alt: 'Pumpkin relaxing on a fluffy purple pillow.' },
+      { src: 'IMG_9672(1).png', alt: 'Close-up of Pumpkin looking curiously at the camera.' },
+      { src: 'IMG_96721.webp', alt: 'Pumpkin posing playfully with a plush toy.' },
+    ];
+
+    const reduceMotionQuery = window.matchMedia ? window.matchMedia('(prefers-reduced-motion: reduce)') : null;
+    let prefersReducedMotion = reduceMotionQuery?.matches ?? false;
+    if (reduceMotionQuery) {
+      const updateMotionPreference = (event) => {
+        prefersReducedMotion = event.matches;
+      };
+
+      if (typeof reduceMotionQuery.addEventListener === 'function') {
+        reduceMotionQuery.addEventListener('change', updateMotionPreference);
+      } else if (typeof reduceMotionQuery.addListener === 'function') {
+        reduceMotionQuery.addListener(updateMotionPreference);
+      }
+    }
+    let currentHeroIndex = heroImages.length ? Math.floor(Math.random() * heroImages.length) : 0;
+    let activeHeroImage = null;
+    let isHeroAnimating = false;
+
+    const createHeroImageElement = (image, additionalClass = '') => {
+      const img = document.createElement('img');
+      img.className = `hero-layer__image ${additionalClass}`.trim();
+      img.src = image.src;
+      img.alt = image.alt;
+      return img;
+    };
+
+    const showHeroImage = (index, { animate = true } = {}) => {
+      if (!heroSlider || heroImages.length === 0) {
+        nextBackgroundButton?.setAttribute('disabled', 'true');
+        return;
+      }
+
+      const nextIndex = (index + heroImages.length) % heroImages.length;
+      const shouldAnimate = animate && !prefersReducedMotion && !!activeHeroImage;
+
+      if (isHeroAnimating && shouldAnimate) {
+        return;
+      }
+
+      const imageData = heroImages[nextIndex];
+      const newImage = createHeroImageElement(
+        imageData,
+        shouldAnimate ? 'hero-layer__image--incoming' : 'hero-layer__image--current',
+      );
+
+      if (!shouldAnimate) {
+        heroSlider.appendChild(newImage);
+        if (activeHeroImage && activeHeroImage.parentElement === heroSlider) {
+          heroSlider.removeChild(activeHeroImage);
+        }
+        activeHeroImage = newImage;
+        currentHeroIndex = nextIndex;
+        nextBackgroundButton?.removeAttribute('disabled');
+        return;
+      }
+
+      isHeroAnimating = true;
+      heroSlider.appendChild(newImage);
+
+      const startTransition = () => {
+        requestAnimationFrame(() => {
+          newImage.classList.add('hero-layer__image--slide-in');
+          activeHeroImage?.classList.add('hero-layer__image--slide-out');
+        });
+      };
+
+      if (typeof newImage.decode === 'function') {
+        newImage
+          .decode()
+          .catch(() => {})
+          .finally(startTransition);
+      } else if (!newImage.complete) {
+        newImage.addEventListener('load', startTransition, { once: true });
+        newImage.addEventListener('error', startTransition, { once: true });
+      } else {
+        startTransition();
+      }
+
+      const handleTransitionEnd = (event) => {
+        if (event.propertyName !== 'transform') return;
+
+        newImage.removeEventListener('transitionend', handleTransitionEnd);
+        newImage.classList.remove('hero-layer__image--incoming', 'hero-layer__image--slide-in');
+        newImage.classList.add('hero-layer__image--current');
+
+        if (activeHeroImage && activeHeroImage.parentElement === heroSlider) {
+          heroSlider.removeChild(activeHeroImage);
+        }
+
+        activeHeroImage = newImage;
+        currentHeroIndex = nextIndex;
+        isHeroAnimating = false;
+      };
+
+      newImage.addEventListener('transitionend', handleTransitionEnd);
+    };
+
+    const initialiseHeroSlider = () => {
+      if (!heroSlider || heroImages.length === 0) {
+        nextBackgroundButton?.setAttribute('disabled', 'true');
+        return;
+      }
+
+      showHeroImage(currentHeroIndex, { animate: false });
+
+      nextBackgroundButton?.addEventListener('click', () => {
+        const nextIndex = (currentHeroIndex + 1) % heroImages.length;
+        showHeroImage(nextIndex, { animate: true });
+      });
+    };
+
+    initialiseHeroSlider();
 
     const COOKIE_NAME = 'cookieConsent';
     const COOKIE_ACCEPTED_VALUE = 'accepted';


### PR DESCRIPTION
## Summary
- replace the static hero collage with a dynamic slider that picks a random starting background
- add a looping "Next background" control that slides in the following image while respecting reduced-motion preferences
- refresh the frosted container styling with a pastel purple finish to match the desired aesthetic

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cacb7a20588324a7623c4cbfc3c260