### PR TITLE
Center bear reset button and update hero background

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,12 +38,12 @@
       padding: calc(1.75em + var(--hero-gap) / 2) 2em 2.5em;
       text-align: center;
       z-index: 1;
-      background: rgba(231, 210, 255, 0.55);
+      background: rgba(32, 6, 63, 0.9);
       border-radius: 24px;
-      box-shadow: 0 20px 60px rgba(126, 77, 202, 0.35);
+      box-shadow: 0 20px 60px rgba(16, 2, 37, 0.65);
       backdrop-filter: blur(6px);
       -webkit-backdrop-filter: blur(6px);
-      border: 1px solid rgba(255, 255, 255, 0.6);
+      border: 1px solid rgba(230, 210, 255, 0.45);
     }
 
     .background-controls {
@@ -77,24 +77,25 @@
     }
 
     .hero-layer {
-      position: absolute;
-      top: 0;
-      left: 50%;
-      transform: translateX(-50%);
-      width: clamp(280px, 90vw, 1200px);
-      display: block;
+      position: fixed;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 100vw;
+      height: 100vh;
       z-index: 0;
       pointer-events: none;
     }
 
     .hero-layer__slider {
       position: relative;
-      width: 100%;
-      aspect-ratio: 3 / 2;
+      width: min(1200px, 96vw);
+      height: min(900px, 90vh);
       border-radius: 20px;
       overflow: hidden;
-      box-shadow: 0 16px 45px rgba(126, 77, 202, 0.4);
-      background: linear-gradient(135deg, rgba(226, 200, 255, 0.8), rgba(167, 133, 255, 0.55));
+      box-shadow: 0 16px 60px rgba(70, 20, 130, 0.55);
+      background: linear-gradient(135deg, rgba(54, 18, 92, 0.9), rgba(101, 45, 168, 0.7));
     }
 
     .hero-layer__image {
@@ -148,10 +149,11 @@
       background: none;
       border: none;
       padding: 0;
-      margin: 1em 0;
-      display: block;
+      margin: 1.5em auto;
+      display: inline-block;
       cursor: pointer;
       position: relative;
+      max-width: min(420px, 100%);
     }
 
     .bear-cookie-button:focus-visible {
@@ -164,6 +166,7 @@
       margin: 0;
       display: block;
       width: 100%;
+      border-radius: 18px;
       transition: transform 0.2s ease, box-shadow 0.2s ease;
     }
 
@@ -473,8 +476,9 @@
         padding: calc(1.4em + var(--hero-gap) / 2) 1.5em 2em;
       }
 
-      .hero-layer {
-        width: 90%;
+      .hero-layer__slider {
+        width: min(520px, 92vw);
+        height: min(70vh, 520px);
       }
     }
   </style>


### PR DESCRIPTION
## Summary
- darken the main content container styling to a richer purple with deeper shadows
- anchor the hero background slider to cover the full viewport with responsive sizing tweaks
- center the bear cookie reset button with a constrained width and rounded image styling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cad0892c6c8324a2aae41d12771518