### PR TITLE
Fix cookie popup layout and consent handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -286,7 +286,8 @@
       z-index: 9999;
       text-align: center;
       box-shadow: 0 15px 40px rgba(0, 0, 0, 0.25);
-      min-width: min(90vw, 320px);
+      width: min(92vw, 360px);
+      box-sizing: border-box;
       outline: none;
     }
 
@@ -353,6 +354,27 @@
     .cookie-info-button:focus-visible {
       transform: translateY(-2px) rotate(-6deg);
       box-shadow: 0 12px 22px rgba(106, 13, 173, 0.35);
+    }
+
+    @media (max-width: 480px) {
+      #cookie-popup {
+        padding: 1.1em 1.4em 1em;
+      }
+
+      #cookie-popup button {
+        width: 100%;
+        margin: 0.6em 0 0 0;
+      }
+
+      .cookie-popup__actions {
+        flex-direction: column;
+        align-items: stretch;
+      }
+
+      .cookie-info-button {
+        top: -10px;
+        right: -10px;
+      }
     }
 
     #cookie-info-modal {
@@ -657,7 +679,7 @@
     const cookieBearButton = document.getElementById('cookie-bear-button');
     const volumeControl = document.getElementById('volume-control');
     const volumeLabel = document.getElementById('volume-label');
-    const volumeIcon = document.getElementById('volume-icon');koni 
+    const volumeIcon = document.getElementById('volume-icon');
     const heroSlider = document.querySelector('.hero-layer__slider');
     const nextBackgroundButton = document.getElementById('next-background');
 


### PR DESCRIPTION
## Summary
- adjust the cookie banner sizing and layout so it fits on small screens
- tweak mobile styling to stack actions and keep the info button within the banner
- remove stray text that stopped the consent handler from running, letting the "yes" button work again

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cad5e8a53c8324b9b50bc61d63b3ac