### PR TITLE
Refine glass styling for buttons

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -6,12 +6,59 @@
   <title>Puppy pillow fortress – Blog</title>
   <link rel="icon" type="image/x-icon" href="/favicon.ico">
   <style>
+    :root {
+      --glass-background: rgba(255, 255, 255, 0.16);
+      --glass-background-hover: rgba(255, 255, 255, 0.28);
+      --glass-border: rgba(255, 255, 255, 0.5);
+      --glass-border-strong: rgba(255, 255, 255, 0.65);
+      --glass-shadow: 0 14px 38px rgba(16, 2, 37, 0.32);
+    }
+
     html, body {
       margin: 0;
       padding: 0;
       font-family: comic sans, sans-serif;
       background-color: #8a2be2;
       color: white;
+    }
+
+    .link-button,
+    .side-button {
+      position: relative;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.3em;
+      padding: 0.55em 1.6em;
+      font-weight: 700;
+      line-height: 1.2;
+      color: #fdf9ff;
+      text-decoration: none;
+      background: linear-gradient(135deg, var(--glass-background), rgba(255, 255, 255, 0.08));
+      border: 1.5px solid var(--glass-border);
+      border-radius: 18px;
+      box-shadow: var(--glass-shadow);
+      backdrop-filter: blur(14px) saturate(170%);
+      -webkit-backdrop-filter: blur(14px) saturate(170%);
+      text-shadow: 0 1px 3px rgba(16, 2, 37, 0.45);
+      transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease,
+        background 0.25s ease;
+    }
+
+    .link-button:hover,
+    .side-button:hover,
+    .link-button:focus-visible,
+    .side-button:focus-visible {
+      background: linear-gradient(135deg, var(--glass-background-hover), rgba(255, 255, 255, 0.18));
+      border-color: var(--glass-border-strong);
+      box-shadow: 0 18px 44px rgba(16, 2, 37, 0.4);
+      transform: translateY(-2px);
+    }
+
+    .link-button:focus-visible,
+    .side-button:focus-visible {
+      outline: 3px solid rgba(230, 210, 255, 0.55);
+      outline-offset: 3px;
     }
 
     .container {
@@ -38,32 +85,21 @@
     }
 
     .link-button {
-      display: inline-block;
       margin: 0.5em;
-      padding: 0.7em 1.4em;
-      background-color: white;
-      color: #6a0dad;
-      font-weight: bold;
-      border: 2px solid white;
-      border-radius: 25px;
-      text-decoration: none;
+      border-radius: 999px;
+      letter-spacing: 0.08em;
     }
 
 
     .side-button {
-      background: white;
-      color: #6a0dad;
-      min-height: 140px;
-      width: 60px;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      font-weight: bold;
-      font-size: 0.85em;
-      border: 2px solid white;
-      text-decoration: none;
-      padding: 0.7em 0.5em;
-      border-radius: 15px;
+      flex-direction: column;
+      min-height: 120px;
+      width: 30px;
+      padding: 0.45em 0.28em;
+      font-size: 0.75em;
+      letter-spacing: 0.18em;
+      border-radius: 18px;
+      box-shadow: 0 14px 40px rgba(16, 2, 37, 0.38);
     }
 
     .side-button--left {
@@ -71,7 +107,7 @@
       top: 50%;
       left: 0;
       transform: translateY(-50%);
-      border-radius: 0 15px 15px 0;
+      border-radius: 0 18px 18px 0;
       z-index: 1000;
     }
 
@@ -99,6 +135,10 @@
     }
 
     a { color: #dabfff; }
+
+    a.link-button {
+      color: #fdf9ff;
+    }
 
     @media (max-width: 600px) {
       .container {

--- a/index.html
+++ b/index.html
@@ -15,6 +15,11 @@
   <style>
     :root {
       --hero-gap: 1.5em;
+      --glass-background: rgba(255, 255, 255, 0.16);
+      --glass-background-hover: rgba(255, 255, 255, 0.28);
+      --glass-border: rgba(255, 255, 255, 0.5);
+      --glass-border-strong: rgba(255, 255, 255, 0.65);
+      --glass-shadow: 0 14px 38px rgba(16, 2, 37, 0.32);
     }
 
     html, body {
@@ -29,6 +34,50 @@
     body {
       position: relative;
       min-height: 100vh;
+    }
+
+    button,
+    .link-button,
+    .side-button {
+      position: relative;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.35em;
+      padding: 0.65em 1.4em;
+      font-weight: 600;
+      line-height: 1.2;
+      color: #fdf9ff;
+      text-decoration: none;
+      background: linear-gradient(135deg, var(--glass-background), rgba(255, 255, 255, 0.08));
+      border: 1.5px solid var(--glass-border);
+      border-radius: 18px;
+      box-shadow: var(--glass-shadow);
+      backdrop-filter: blur(14px) saturate(170%);
+      -webkit-backdrop-filter: blur(14px) saturate(170%);
+      text-shadow: 0 1px 3px rgba(16, 2, 37, 0.45);
+      transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease,
+        background 0.25s ease;
+      cursor: pointer;
+    }
+
+    button:hover,
+    .link-button:hover,
+    .side-button:hover,
+    button:focus-visible,
+    .link-button:focus-visible,
+    .side-button:focus-visible {
+      background: linear-gradient(135deg, var(--glass-background-hover), rgba(255, 255, 255, 0.18));
+      border-color: var(--glass-border-strong);
+      box-shadow: 0 18px 44px rgba(16, 2, 37, 0.4);
+      transform: translateY(-2px);
+    }
+
+    button:focus-visible,
+    .link-button:focus-visible,
+    .side-button:focus-visible {
+      outline: 3px solid rgba(230, 210, 255, 0.55);
+      outline-offset: 3px;
     }
 
     .container {
@@ -53,27 +102,11 @@
     }
 
     .next-background-button {
-      cursor: pointer;
-      padding: 0.6em 1.4em;
-      background: rgba(255, 255, 255, 0.85);
-      color: #5a1a9c;
+      padding: 0.55em 1.8em;
       font-weight: 700;
-      border: 2px solid #f3e5ff;
       border-radius: 999px;
       text-transform: uppercase;
-      letter-spacing: 0.05em;
-      transition: background 0.3s ease, transform 0.3s ease;
-    }
-
-    .next-background-button:hover,
-    .next-background-button:focus-visible {
-      background: #f3e5ff;
-      transform: translateY(-2px);
-    }
-
-    .next-background-button:focus-visible {
-      outline: 3px solid rgba(158, 94, 222, 0.55);
-      outline-offset: 2px;
+      letter-spacing: 0.12em;
     }
 
     .hero-layer {
@@ -179,36 +212,26 @@
 
     .link-button,
     #bark-test {
-      cursor: pointer;
-      display: inline-block;
       margin: 0.5em;
-      padding: 0.7em 1.4em;
-      background-color: white;
-      color: #6a0dad;
-      font-weight: bold;
-      border: 2px solid white;
-      border-radius: 25px;
-      text-decoration: none;
+      padding: 0.55em 1.6em;
+      border-radius: 999px;
+      font-weight: 700;
+      letter-spacing: 0.08em;
     }
 
     .side-button {
-      background: white;
-      color: #6a0dad;
-      min-height: 120px;
-      width: 48px;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      font-weight: bold;
-      font-size: 0.8em;
-      border: 2px solid white;
-      text-decoration: none;
-      padding: 0.55em 0.35em;
-      border-radius: 15px;
+      flex-direction: column;
+      min-height: 118px;
+      width: 30px;
+      padding: 0.45em 0.28em;
+      font-size: 0.75em;
+      letter-spacing: 0.18em;
+      border-radius: 18px;
+      box-shadow: 0 14px 40px rgba(16, 2, 37, 0.38);
     }
 
     .side-button--right {
-      border-radius: 15px 0 0 15px;
+      border-radius: 18px 0 0 18px;
     }
 
     #right-side-buttons {
@@ -227,7 +250,7 @@
       top: 50%;
       left: 0;
       transform: translateY(-50%);
-      border-radius: 0 15px 15px 0;
+      border-radius: 0 18px 18px 0;
       z-index: 1000;
     }
     #paw-panel {
@@ -236,13 +259,16 @@
       left: 0;
       height: 100%;
       width: clamp(300px, 70vw, 500px);
-      background-color: #6a5acd;
       padding: 2em;
-      box-shadow: 4px 0 15px rgba(0, 0, 0, 0.6);
+      background: linear-gradient(135deg, rgba(52, 24, 94, 0.86), rgba(114, 64, 174, 0.65));
+      border: 1.5px solid rgba(255, 255, 255, 0.4);
+      box-shadow: 0 24px 60px rgba(16, 2, 37, 0.45);
       z-index: 999;
       overflow-y: auto;
       transition: transform 0.3s ease;
       transform: translateX(-100%);
+      backdrop-filter: blur(18px) saturate(165%);
+      -webkit-backdrop-filter: blur(18px) saturate(165%);
     }
 
     #paw-panel.open { transform: translateX(0); }
@@ -250,11 +276,21 @@
     #paw-name,
     #paw-input {
       width: 100%;
-      border-radius: 10px;
-      padding: 0.5em;
+      border-radius: 14px;
+      padding: 0.65em 0.8em;
       font-size: 1em;
       margin-bottom: 1em;
-      border: none;
+      border: 1.5px solid rgba(255, 255, 255, 0.45);
+      background: linear-gradient(135deg, rgba(255, 255, 255, 0.14), rgba(230, 210, 255, 0.05));
+      color: #fdf9ff;
+      box-shadow: 0 14px 32px rgba(16, 2, 37, 0.3);
+      backdrop-filter: blur(14px) saturate(170%);
+      -webkit-backdrop-filter: blur(14px) saturate(170%);
+    }
+
+    #paw-name::placeholder,
+    #paw-input::placeholder {
+      color: rgba(247, 239, 255, 0.7);
     }
 
     #paw-input {
@@ -263,13 +299,10 @@
     }
 
     #paw-submit {
-      background-color: #dabfff;
-      color: #4b0082;
-      font-weight: bold;
-      border: none;
-      border-radius: 10px;sheperd
-      padding: 0.5em 1em;
-      cursor: pointer;
+      border-radius: 14px;
+      padding: 0.6em 1.4em;
+      font-weight: 700;
+      letter-spacing: 0.05em;
     }
 
     #paw-feedback {
@@ -282,17 +315,19 @@
       bottom: 20px;
       left: 50%;
       transform: translateX(-50%);
-      background: white;
-      color: #6a0dad;
-      border: 2px solid #dabfff;
-      border-radius: 15px;
+      background: linear-gradient(135deg, rgba(255, 255, 255, 0.22), rgba(230, 210, 255, 0.08));
+      color: #fdf9ff;
+      border: 1.5px solid rgba(255, 255, 255, 0.45);
+      border-radius: 20px;
       padding: 1.4em 2.5em 1.2em;
       z-index: 9999;
       text-align: center;
-      box-shadow: 0 15px 40px rgba(0, 0, 0, 0.25);
+      box-shadow: 0 18px 42px rgba(16, 2, 37, 0.35);
       width: min(92vw, 360px);
       box-sizing: border-box;
       outline: none;
+      backdrop-filter: blur(18px) saturate(170%);
+      -webkit-backdrop-filter: blur(18px) saturate(170%);
     }
 
     #cookie-popup:focus-visible {
@@ -310,20 +345,16 @@
 
     #cookie-popup button {
       margin: 0.8em 0.6em 0 0.6em;
-      padding: 0.5em 1.2em;
-      font-weight: bold;
-      background-color: #dabfff;
-      color: #4b0082;
-      border: none;
-      border-radius: 10px;
-      cursor: pointer;
-      transition: transform 0.15s ease, box-shadow 0.15s ease;
+      padding: 0.55em 1.6em;
+      border-radius: 999px;
+      font-weight: 700;
+      letter-spacing: 0.05em;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
     }
 
     #cookie-popup button:hover,
     #cookie-popup button:focus-visible {
-      transform: translateY(-1px);
-      box-shadow: 0 6px 15px rgba(106, 13, 173, 0.25);
+      box-shadow: 0 14px 32px rgba(16, 2, 37, 0.38);
     }
 
     .cookie-popup__actions {
@@ -340,24 +371,16 @@
       right: -12px;
       width: 40px;
       height: 40px;
+      padding: 0;
       border-radius: 50%;
-      border: 2px solid #4b0082;
-      background: #dabfff;
-      color: #4b0082;
       font-weight: 900;
       font-size: 1.2em;
-      cursor: pointer;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;sheperd
-      box-shadow: 0 8px 18px rgba(0, 0, 0, 0.2);
-      transition: transform 0.2s ease, box-shadow 0.2s ease;
+      box-shadow: 0 12px 28px rgba(16, 2, 37, 0.35);
     }
 
     .cookie-info-button:hover,
     .cookie-info-button:focus-visible {
       transform: translateY(-2px) rotate(-6deg);
-      box-shadow: 0 12px 22px rgba(106, 13, 173, 0.35);
     }
 
     @media (max-width: 480px) {
@@ -397,14 +420,16 @@
     }
 
     .cookie-info-card {
-      background: white;
-      color: #4b0082;
-      border-radius: 18px;
-      border: 2px solid #dabfff;
+      background: linear-gradient(135deg, rgba(45, 7, 80, 0.78), rgba(110, 40, 170, 0.55));
+      color: #fdf9ff;
+      border-radius: 22px;
+      border: 1.5px solid rgba(255, 255, 255, 0.4);
       padding: 1.5em;
       max-width: min(480px, 90vw);
-      box-shadow: 0 20px 45px rgba(0, 0, 0, 0.35);
+      box-shadow: 0 24px 50px rgba(16, 2, 37, 0.4);
       text-align: left;
+      backdrop-filter: blur(18px) saturate(160%);
+      -webkit-backdrop-filter: blur(18px) saturate(160%);
     }
 
     .cookie-info-card h2 {
@@ -427,25 +452,13 @@
     }
 
     .cookie-info-close {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      border: none;
-      background: #dabfff;
-      color: #4b0082;
-      font-weight: bold;
-      border-radius: 999px;
-      padding: 0.5em 1.5em;
-      cursor: pointer;
-      margin: 0 auto;sheperd
       display: block;
-      transition: transform 0.15s ease, box-shadow 0.15s ease;
-    }
-
-    .cookie-info-close:hover,
-    .cookie-info-close:focus-visible {
-      transform: translateY(-1px);
-      box-shadow: 0 8px 20px rgba(106, 13, 173, 0.35);
+      margin: 0 auto;
+      padding: 0.55em 2em;
+      border-radius: 999px;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
     }
 
     #volume-wrapper { margin-top: 1em; }

--- a/story.html
+++ b/story.html
@@ -6,12 +6,59 @@
   <title>Puppy pillow fortress – Story</title>
   <link rel="icon" type="image/x-icon" href="/favicon.ico">
   <style>
+    :root {
+      --glass-background: rgba(255, 255, 255, 0.16);
+      --glass-background-hover: rgba(255, 255, 255, 0.28);
+      --glass-border: rgba(255, 255, 255, 0.5);
+      --glass-border-strong: rgba(255, 255, 255, 0.65);
+      --glass-shadow: 0 14px 38px rgba(16, 2, 37, 0.32);
+    }
+
     html, body {
       margin: 0;
       padding: 0;
       font-family: comic sans, sans-serif;
       background-color: #8a2be2;
       color: white;
+    }
+
+    .link-button,
+    .side-button {
+      position: relative;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.3em;
+      padding: 0.55em 1.6em;
+      font-weight: 700;
+      line-height: 1.2;
+      color: #fdf9ff;
+      text-decoration: none;
+      background: linear-gradient(135deg, var(--glass-background), rgba(255, 255, 255, 0.08));
+      border: 1.5px solid var(--glass-border);
+      border-radius: 18px;
+      box-shadow: var(--glass-shadow);
+      backdrop-filter: blur(14px) saturate(170%);
+      -webkit-backdrop-filter: blur(14px) saturate(170%);
+      text-shadow: 0 1px 3px rgba(16, 2, 37, 0.45);
+      transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease,
+        background 0.25s ease;
+    }
+
+    .link-button:hover,
+    .side-button:hover,
+    .link-button:focus-visible,
+    .side-button:focus-visible {
+      background: linear-gradient(135deg, var(--glass-background-hover), rgba(255, 255, 255, 0.18));
+      border-color: var(--glass-border-strong);
+      box-shadow: 0 18px 44px rgba(16, 2, 37, 0.4);
+      transform: translateY(-2px);
+    }
+
+    .link-button:focus-visible,
+    .side-button:focus-visible {
+      outline: 3px solid rgba(230, 210, 255, 0.55);
+      outline-offset: 3px;
     }
 
     .container {
@@ -66,31 +113,20 @@
     }
 
     .link-button {
-      display: inline-block;
       margin: 0.5em;
-      padding: 0.7em 1.4em;
-      background-color: white;
-      color: #6a0dad;
-      font-weight: bold;
-      border: 2px solid white;
-      border-radius: 25px;
-      text-decoration: none;
+      border-radius: 999px;
+      letter-spacing: 0.08em;
     }
 
     .side-button {
-      background: white;
-      color: #6a0dad;
-      min-height: 140px;
-      width: 60px;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      font-weight: bold;
-      font-size: 0.85em;
-      border: 2px solid white;
-      text-decoration: none;
-      padding: 0.7em 0.5em;
-      border-radius: 15px;
+      flex-direction: column;
+      min-height: 120px;
+      width: 30px;
+      padding: 0.45em 0.28em;
+      font-size: 0.75em;
+      letter-spacing: 0.18em;
+      border-radius: 18px;
+      box-shadow: 0 14px 40px rgba(16, 2, 37, 0.38);
     }
 
     .side-button--left {
@@ -98,7 +134,7 @@
       top: 50%;
       left: 0;
       transform: translateY(-50%);
-      border-radius: 0 15px 15px 0;
+      border-radius: 0 18px 18px 0;
       z-index: 1000;
     }
 
@@ -143,6 +179,10 @@
       margin-bottom: 0.5em;
     }
     a { color: #dabfff; }
+
+    a.link-button {
+      color: #fdf9ff;
+    }
 
     @media (max-width: 600px) {
       .container {


### PR DESCRIPTION
## Summary
- restyle every button with a shared glassmorphism treatment, including hover and focus states
- slim down the side navigation buttons and extend the glass look across the cookie dialog and paw panel
- align the blog and story pages with the new glass variables so buttons match the home page

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cb9e7fa9e08324916dc5d8aa749295