### PR TITLE
Adjust paw print button hover translation

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -293,6 +293,11 @@ img {
   border-radius: 0 18px 18px 0;
   z-index: 1000;
 }
+
+.side-button--left:hover,
+.side-button--left:focus-visible {
+  transform: translateY(-50%) translateX(10px);
+}
 #paw-panel {
   position: fixed;
   top: 0;


### PR DESCRIPTION
## Summary
- keep the paw-print side button horizontally aligned while hovered
- translate the button slightly to the right on hover/focus instead of jumping down

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d38172ea5c83248081dcd016574ec3