### PR TITLE
Remove embedded Google Docs iframe and show backup link on failure

### DIFF
--- a/scripts/story.js
+++ b/scripts/story.js
@@ -4,10 +4,18 @@
  * document when automatic fetching fails.
  */
 const storyContent = document.getElementById('story-content');
+const backupLinks = document.getElementById('story-links');
+
+const setBackupVisibility = (visible) => {
+  if (!backupLinks) {
+    return;
+  }
+
+  backupLinks.hidden = !visible;
+};
 
 if (storyContent) {
   const googleDocId = '13_zTWp_cWnmwHUGpvco56Cj-GCbmQKmFdurH-WKjAs8';
-  const fallbackUrl = `https://docs.google.com/document/d/${googleDocId}/view`;
   const docTextUrl = `https://docs.google.com/document/d/${googleDocId}/export?format=txt`;
 
   // Replace the content area with a series of <p> elements, skipping empties.
@@ -30,10 +38,13 @@ if (storyContent) {
     if (!appended) {
       storyContent.innerHTML = '<p>The story is currently empty.</p>';
     }
+
+    setBackupVisibility(false);
   };
 
   const showError = (extraMessage = '') => {
-    storyContent.innerHTML = `<p>We couldn't load the plain-text story automatically. <a href="${fallbackUrl}" target="_blank" rel="noopener">Open the story on Google Docs</a>.${extraMessage}</p>`;
+    storyContent.innerHTML = `<p>We couldn't load the plain-text story automatically. Use the backup button below to open it on Google Docs.${extraMessage}</p>`;
+    setBackupVisibility(true);
   };
 
   const fetchStory = async () => {
@@ -88,5 +99,6 @@ if (storyContent) {
   };
 
   storyContent.innerHTML = '<p>Gathering the story magic…</p>';
+  setBackupVisibility(false);
   fetchStory();
 }

--- a/story.html
+++ b/story.html
@@ -19,16 +19,7 @@
       <h1>Story Time</h1>
       <p>Grab a blanket, get comfy, and enjoy the latest adventure from the Puppy Pillow Fortress!</p>
       <div class="story-sections">
-        <section class="story-embed" aria-label="Story embedded from Google Docs">
-          <iframe
-            class="story-embed__frame"
-            src="https://docs.google.com/document/d/13_zTWp_cWnmwHUGpvco56Cj-GCbmQKmFdurH-WKjAs8/preview?embedded=true"
-            title="Embedded story from Google Docs"
-            loading="lazy"
-            allowfullscreen
-          ></iframe>
-        </section>
-        <div class="story-links">
+        <div id="story-links" class="story-links" hidden>
           <a
             class="link-button"
             href="https://docs.google.com/document/d/13_zTWp_cWnmwHUGpvco56Cj-GCbmQKmFdurH-WKjAs8/view"
@@ -42,6 +33,18 @@
           <p>Gathering the story magic…</p>
         </section>
       </div>
+      <noscript>
+        <div class="story-links">
+          <a
+            class="link-button"
+            href="https://docs.google.com/document/d/13_zTWp_cWnmwHUGpvco56Cj-GCbmQKmFdurH-WKjAs8/view"
+            target="_blank"
+            rel="noopener"
+          >
+            Open the story in Google Docs
+          </a>
+        </div>
+      </noscript>
     </div>
   </main>
   <footer>

--- a/styles/story.css
+++ b/styles/story.css
@@ -179,21 +179,6 @@ h1 {
   gap: 1.75em;
 }
 
-.story-embed {
-  border-radius: 22px;
-  overflow: hidden;
-  background: rgba(18, 2, 45, 0.42);
-  border: 1px solid rgba(244, 232, 255, 0.28);
-  box-shadow: 0 20px 50px rgba(10, 0, 35, 0.5);
-}
-
-.story-embed__frame {
-  width: 100%;
-  height: clamp(420px, 68vh, 820px);
-  border: 0;
-  background-color: white;
-}
-
 .story-links {
   display: flex;
   flex-wrap: wrap;
@@ -232,12 +217,6 @@ footer {
   color: rgba(245, 232, 255, 0.6);
   font-size: 0.95rem;
   z-index: 1;
-}
-
-@media (max-width: 900px) {
-  .story-embed__frame {
-    height: clamp(380px, 62vh, 720px);
-  }
 }
 
 @media (max-width: 720px) {


### PR DESCRIPTION
## Summary
- remove the embedded Google Docs iframe from the story page and hide the backup link by default
- reveal the backup button only when the plain-text fetch fails and add a noscript fallback
- clean up styles that only supported the removed iframe

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d434f93a888324abb97cf082172592