### PR TITLE
Add Train-AI system with training UI, worker inference and training lifecycle

### DIFF
--- a/games/turboracing-exp/index.html
+++ b/games/turboracing-exp/index.html
@@ -16,7 +16,7 @@
   <div class="menuActions">
     <button id="introStartBtn" class="btn btn-p">START GAME</button>
   </div>
-  <div class="menuVersion" aria-label="Game version">v0.93-exp</div>
+  <div class="menuVersion" aria-label="Game version">v0.102-exp</div>
 </div>
 <div id="hud" role="status" aria-live="polite">
   <div id="raceTop">
@@ -131,6 +131,64 @@
   </div>
 </div>
 
+
+<div id="trainAiModal">
+  <div class="trainAiPanel" role="dialog" aria-modal="true" aria-labelledby="trainAiTitle">
+    <h2 id="trainAiTitle">Train-AI Lab</h2>
+    <form id="trainAiForm">
+      <div class="trainAiGrid">
+        <section class="trainAiSection">
+          <h3>Rotation</h3>
+          <div id="trainTrackList" class="trainAiList"></div>
+          <h3>Autos</h3>
+          <div id="trainCarList" class="trainAiList"></div>
+          <label class="toggleRow" for="trainAiVisible">
+            <span class="toggleLbl">SIMULATION SICHTBAR</span>
+            <input type="checkbox" id="trainAiVisible" checked>
+          </label>
+        </section>
+        <section class="trainAiSection">
+          <h3>Simulation</h3>
+          <div class="trainAiFields">
+            <label><span>KI-Autos</span><input name="populationSize" type="number" min="1" max="200" value="24"></label>
+            <label><span>Max Sim Seconds</span><input name="maxSimulationTime" type="number" min="5" max="600" value="45"></label>
+            <label><span>Node Lookahead</span><input name="nodeLookahead" type="number" min="1" max="8" value="3"></label>
+            <label><span>Hidden Layers</span><input name="hiddenLayers" type="number" min="1" max="6" value="2"></label>
+            <label><span>Neurons / Layer</span><input name="neuronsPerLayer" type="number" min="2" max="64" value="12"></label>
+            <label><span>Elite Count</span><input name="eliteCount" type="number" min="1" max="50" value="4"></label>
+            <label><span>Mutation Rate</span><input name="mutationRate" type="number" min="0.01" max="1" step="0.01" value="0.14"></label>
+            <label><span>Mutation Strength</span><input name="mutationStrength" type="number" min="0.01" max="3" step="0.01" value="0.22"></label>
+            <label><span>Tickrate / Speed</span><input name="tickRate" type="number" min="0.25" max="12" step="0.25" value="1"></label>
+            <label><span>Joker Sims</span><input name="jokerCarrySimulations" type="number" min="0" max="20" step="1" value="3"></label>
+          </div>
+          <h3>Rewards</h3>
+          <div class="trainAiFields">
+            <label><span>Progress</span><input name="rewardProgress" type="number" step="0.1" value="18"></label>
+            <label><span>Speed</span><input name="rewardSpeed" type="number" step="0.01" value="0.06"></label>
+            <label><span>Finish</span><input name="rewardFinish" type="number" step="1" value="140"></label>
+            <label><span>Survival</span><input name="rewardSurvival" type="number" step="0.1" value="0.7"></label>
+            <label><span>Gravel Penalty</span><input name="rewardGravelPenalty" type="number" step="0.1" value="1.2"></label>
+            <label><span>Wall Penalty</span><input name="rewardWallPenalty" type="number" step="0.1" value="3.4"></label>
+            <label><span>Steering Penalty</span><input name="rewardSteeringPenalty" type="number" step="0.01" value="0.05"></label>
+          </div>
+        </section>
+      </div>
+      <section class="trainAiSection">
+        <h3>JSON Import / Export</h3>
+        <textarea id="trainAiJson" class="trainAiJson" spellcheck="false" placeholder="Hier erscheint das exportierte KI-JSON."></textarea>
+        <div class="trainAiMeta">Generation: <strong id="trainAiGeneration">0</strong> · Episode: <strong id="trainAiEpisode">0</strong></div>
+        <div id="trainAiStatus" class="trainAiStatus">Train-AI bereit.</div>
+      </section>
+      <div class="menuActions menuActions-inline">
+        <button type="button" id="trainAiImportBtn" class="btn btn-s">JSON LADEN</button>
+        <button type="button" id="trainAiExportBtn" class="btn btn-s">JSON SPEICHERN</button>
+        <button type="button" id="trainAiCloseBtn" class="btn btn-s">SCHLIESSEN</button>
+        <button type="button" id="trainAiStartBtn" class="btn btn-p">TRAINING STARTEN</button>
+      </div>
+    </form>
+  </div>
+</div>
+
 <!-- MAIN MENU -->
 <div class="screen" id="sMain">
   <h1>F³ Racing Experimental</h1>
@@ -138,10 +196,11 @@
   <div class="menuActions">
     <button id="gameStartBtn" class="btn btn-p">START RACE</button>
     <button id="trackEditorBtn" class="btn btn-s">TRACK EDITOR</button>
+    <button id="trainAiBtn" class="btn btn-s">TRAIN-AI</button>
 <button id="mainSettingsBtn" class="btn btn-s">SETTINGS</button>
     <button id="backToSelectionBtn" class="btn btn-s">BACK TO GAME SELECTION</button>
   </div>
-  <div class="menuVersion" aria-label="Game version">v0.93-exp</div>
+  <div class="menuVersion" aria-label="Game version">v0.102-exp</div>
 
 </div>
 

--- a/games/turboracing-exp/scripts/ai-script.js
+++ b/games/turboracing-exp/scripts/ai-script.js
@@ -1,120 +1,46 @@
-export class AI {
-  constructor(car,la,context){
-    this.car=car;
-    this.la=la||.055;
-    this.slowTimer=0;
-    this.prevPos=null;
-    this.stuckCount=0;
-    this.context=context;
+import { TrainableAIController, mergeConfig } from './train-ai.js';
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function createFallbackGenome(inputSize) {
+  const cfg = mergeConfig({ hiddenLayers: 1, neuronsPerLayer: 8 });
+  const layers = [];
+  let width = inputSize;
+  for (let layer = 0; layer < cfg.hiddenLayers; layer += 1) {
+    layers.push({
+      weights: Array.from({ length: cfg.neuronsPerLayer }, () => Array.from({ length: width }, () => 0)),
+      biases: Array.from({ length: cfg.neuronsPerLayer }, () => 0),
+    });
+    width = cfg.neuronsPerLayer;
+  }
+  layers.push({
+    weights: [
+      Array.from({ length: width }, (_, i) => (i === 3 ? 0.85 : i === 4 ? -0.25 : 0)),
+      Array.from({ length: width }, (_, i) => (i === 5 ? 0.9 : i === 4 ? 0.18 : 0)),
+      Array.from({ length: width }, (_, i) => (i === 3 ? 0.5 : i === 4 ? -0.7 : i === 6 ? 0.3 : 0)),
+    ],
+    biases: [0.2, -0.55, 0],
+  });
+  return { layers, meta: { createdAt: new Date().toISOString(), inputSize, outputSize: 3, preset: 'fallback' } };
+}
+
+export class AI extends TrainableAIController {
+  constructor(car, _la, context, options = {}) {
+    const config = mergeConfig(options.config || {});
+    const probe = context();
+    const inputSize = 3 + config.nodeLookahead * 3 + 2 + 2 + 1 + 1 + 1;
+    const genome = options.genome || createFallbackGenome(inputSize);
+    super(car, genome, context, config);
+    this.aggression = clamp(options.aggression ?? car.aiAgg ?? 1, 0.4, 1.6);
   }
 
-  update(dt){
-    const { trackPoints, trackCurvature, cityAiPoints, cityCorridors, trackData, playerCar }=this.context();
-    if(!trackPoints.length||this.car.finished)return;
-    const c=this.car;
-
-    if(!this.prevPos) this.prevPos={x:c.pos.x,z:c.pos.z};
-    const moved=Math.sqrt((c.pos.x-this.prevPos.x)**2+(c.pos.z-this.prevPos.z)**2);
-    this.prevPos.x=c.pos.x; this.prevPos.z=c.pos.z;
-    if(moved<0.015*dt*60) this.slowTimer+=dt;
-    else { this.slowTimer=Math.max(0,this.slowTimer-dt*3); this.stuckCount=0; }
-
-    if(c.stuckTimer>1.5 || this.slowTimer>2.5){
-      c.stuckTimer=0; this.slowTimer=0; this.stuckCount++;
-      const navP=cityAiPoints?cityAiPoints.pts:trackPoints;
-      let md2=Infinity,ri2=0;
-      for(let i=0;i<navP.length;i++){const d=(c.pos.x-navP[i].x)**2+(c.pos.z-navP[i].z)**2;if(d<md2){md2=d;ri2=i;}}
-      const ahead=5+this.stuckCount*5;
-      const tp=navP[(ri2+ahead)%navP.length];
-      const nxt=navP[(ri2+ahead+3)%navP.length];
-      c.pos.x=tp.x; c.pos.z=tp.z;
-      c.hdg=Math.atan2(nxt.x-tp.x,nxt.z-tp.z);
-      c.spd=3; c.isReversing=false; c.revSpd=0;
-      return;
+  update(dt) {
+    const preSpeed = this.car.spd;
+    super.update(dt);
+    if (this.car.spd < preSpeed * 0.35 && !this.car.onGravel) {
+      this.car.spd = Math.max(this.car.spd, preSpeed * 0.45);
     }
-
-    const useCity=!!cityAiPoints;
-    const navPts=useCity?cityAiPoints.pts:trackPoints;
-    const navCurv=useCity?cityAiPoints.curv:trackCurvature;
-    let md=Infinity,ci=0;
-    for(let i=0;i<navPts.length;i++){const d=(c.pos.x-navPts[i].x)**2+(c.pos.z-navPts[i].z)**2;if(d<md){md=d;ci=i;}}
-    const n=navPts.length;
-
-    const speedFrac=c.spd/c.data.maxSpd;
-    let ti;
-    if(useCity){
-      const look=Math.round(4+speedFrac*12);
-      ti=(ci+look)%n;
-    } else {
-      const maxLook=Math.round(3+speedFrac*25);
-      ti=ci;
-      for(let step=1;step<=maxLook;step++){
-        const si=(ci+step)%n;
-        if(navCurv[si]>0.25){ ti=si; break; }
-        ti=si;
-      }
-    }
-
-    let tgtX=navPts[ti].x, tgtZ=navPts[ti].z;
-
-    if(cityCorridors&&cityCorridors.length){
-      const px=c.pos.x,pz=c.pos.z;
-      for(const cr of cityCorridors){
-        if(px>cr.x-cr.hw&&px<cr.x+cr.hw&&pz>cr.z-cr.hd&&pz<cr.z+cr.hd){
-          const dL=px-(cr.x-cr.hw), dR=(cr.x+cr.hw)-px;
-          const dB=pz-(cr.z-cr.hd), dT=(cr.z+cr.hd)-pz;
-          const wallMin=Math.min(dL,dR,dB,dT);
-          const margin=4.0;
-          if(wallMin<margin){
-            const blend=Math.pow(1-wallMin/margin,2)*0.5;
-            tgtX=tgtX*(1-blend)+cr.x*blend;
-            tgtZ=tgtZ*(1-blend)+cr.z*blend;
-          }
-          break;
-        }
-      }
-    }
-
-    const dx=tgtX-c.pos.x,dz=tgtZ-c.pos.z;
-    const dh=Math.atan2(dx,dz);
-    let he=((dh-c.hdg+Math.PI*3)%(Math.PI*2))-Math.PI;
-    let str=Math.max(-1,Math.min(1,he*2.5));
-    const ts=Math.abs(he);
-
-    const scanDist=Math.round(20+speedFrac*80);
-    let worstCurv=0, worstDist=Infinity;
-    for(let k=1;k<scanDist;k++){
-      const ki=(ci+k)%n;
-      if(navCurv[ki]>worstCurv){worstCurv=navCurv[ki]; worstDist=k;}
-    }
-    const cornerSpeed=c.data.maxSpd*(0.25+0.75*(1-worstCurv));
-    const speedOverTarget=c.spd-cornerSpeed;
-    const ptSpacing=2;
-    const distToCorner=worstDist*ptSpacing;
-    let reqBrake=0;
-    if(speedOverTarget>0&&distToCorner>0){
-      const reqDecel=(c.spd*c.spd-cornerSpeed*cornerSpeed)/(2*distToCorner);
-      reqBrake=Math.min(1,reqDecel/c.data.brake);
-    }
-
-    let thr=ts<.30?1:Math.max(.45,1-ts*0.8);
-    let brk=Math.max(ts>.70?(ts-.70)*1.5:0, reqBrake);
-    if(brk>0.2) thr=Math.min(thr,1-brk);
-
-    if(!cityCorridors&&trackData){
-      const edgeDist=Math.sqrt(md);
-      const wallDist=trackData.rw*0.5;
-      if(edgeDist>wallDist*0.5){
-        const np=trackPoints[ci];
-        const pullAngle=Math.atan2(np.x-c.pos.x,np.z-c.pos.z);
-        let pullErr=((pullAngle-c.hdg+Math.PI*3)%(Math.PI*2))-Math.PI;
-        const pushFactor=Math.min(1,(edgeDist-wallDist*0.5)/(wallDist*0.5));
-        str=Math.max(-1,Math.min(1,str+pullErr*pushFactor*1.5));
-      }
-    }
-
-    thr*=c.data.aiSpd*c.aiAgg;
-    if(playerCar){const lead=c.totalProg-playerCar.totalProg;if(lead>8)thr*=.93;else if(lead<-8)thr=Math.min(1,thr*1.05);}
-    c.update({thr,brk:Math.min(1,brk),str},dt);
   }
 }

--- a/games/turboracing-exp/scripts/camera.js
+++ b/games/turboracing-exp/scripts/camera.js
@@ -14,6 +14,32 @@ import {
 
 'use strict';
 
+
+function getTrackBoundsFromPoints(points){
+  let minX=Infinity,maxX=-Infinity,minZ=Infinity,maxZ=-Infinity;
+  for(const point of points||[]){
+    if(point.x<minX)minX=point.x;
+    if(point.x>maxX)maxX=point.x;
+    if(point.z<minZ)minZ=point.z;
+    if(point.z>maxZ)maxZ=point.z;
+  }
+  if(!isFinite(minX)) return {minX:-150,maxX:150,minZ:-150,maxZ:150};
+  return {minX,maxX,minZ,maxZ};
+}
+
+export function resetFreeCameraToTrack(points){
+  const b=getTrackBoundsFromPoints(points);
+  editorCam.target.set((b.minX+b.maxX)/2,0,(b.minZ+b.maxZ)/2);
+  const span=Math.max(180,Math.max(b.maxX-b.minX,b.maxZ-b.minZ));
+  editorCam.distance=Math.max(180,span*1.15);
+  editorCam.pitch=1.16;
+  editorCam.yaw=0;
+}
+
+export function updateTrainingFreeCamera(dt){
+  updateEditorPreviewCamera(dt);
+}
+
 export function updateCamera(){
   if(!state.pCar)return;
   const now=performance.now();

--- a/games/turboracing-exp/scripts/car.js
+++ b/games/turboracing-exp/scripts/car.js
@@ -18,7 +18,7 @@ class Car {
     this.shiftWarnRpm = Math.round(this.redlineRpm * 0.78);
     this.rpm = this.gearbox.idleRpm;
     this.lap = 0; this.lastCP = 0; this.cpPassed = 0;
-    this.totalProg = 0; this.finished = false; this.finTime = 0; this.lapStart = 0;
+    this.totalProg = 0; this.progressMeters = 0; this.progressCm = 0; this.finished = false; this.finTime = 0; this.lapStart = 0;
     this.lapTimes = [];
     this.tl = []; this.wh = [];
     this.prevGear = 1; this.rpmDrop = 0; // for gear-shift RPM dip
@@ -264,48 +264,73 @@ class Car {
         }
       }
     }
+    if (state.trkPts && state.trkPts.length && state.trkDist && state.trkDist.length === state.trkPts.length) {
+      let bestIndex = 0;
+      let bestDistance = Infinity;
+      for (let index = 0; index < state.trkPts.length; index += 1) {
+        const point = state.trkPts[index];
+        const d = (this.pos.x - point.x) ** 2 + (this.pos.z - point.z) ** 2;
+        if (d < bestDistance) {
+          bestDistance = d;
+          bestIndex = index;
+        }
+      }
+      const lapDistance = state.trkDist[bestIndex] || 0;
+      this.progressMeters = this.lap * (state.trkLen || 0) + lapDistance;
+      this.progressCm = Math.max(0, Math.round(this.progressMeters * 100));
+      this.totalProg = this.progressMeters;
+      return;
+    }
     const ni = (this.lastCP + 1 + n) % n, nw = state.trkData.wp[ni];
     const dd = Math.sqrt((this.pos.x - nw[0]) ** 2 + (this.pos.z - nw[2]) ** 2);
     this.totalProg = this.lap * n + this.cpPassed + Math.max(0, 1 - dd / 35);
+    this.progressMeters = this.totalProg;
+    this.progressCm = Math.round(this.totalProg * 100);
   }
 }
 
-function buildRaceGrid(trackPoints){
+function buildRaceGrid(trackPoints, totalCars=5, stackedStart=false){
   const n=trackPoints.length;
-  if(!n)return Array(5).fill({pos:new THREE.Vector3(0,0,0),hdg:0});
+  if(!n)return Array.from({length:totalCars},()=>({pos:new THREE.Vector3(0,0,0),hdg:0}));
   const grid=[];
-  const rows=[1,1,2,2,3];
-  const cols=[-1,1,-1,1,0];
+  const carsPerRow=Math.max(2, Math.ceil(Math.sqrt(totalCars)));
   const rowStep=16;
-  const sideOff=2.6;
-  for(let slot=0;slot<5;slot++){
-    const idx=((n - rows[slot]*rowStep) % n + n) % n;
+  const sideOff=stackedStart?0.08:2.6;
+  for(let slot=0;slot<totalCars;slot++){
+    const row=stackedStart?1:(1+Math.floor(slot/carsPerRow));
+    const lane=stackedStart?0:(slot%carsPerRow);
+    const centered=stackedStart?((slot-totalCars/2)*0.04):(lane-(carsPerRow-1)/2);
+    const idx=((n - row*rowStep) % n + n) % n;
     const pt=trackPoints[idx];
     const ptF=trackPoints[(idx+5)%n];
     const hdg=Math.atan2(ptF.x-pt.x, ptF.z-pt.z);
     const right=new THREE.Vector3(Math.cos(hdg),0,-Math.sin(hdg));
-    const pos=pt.clone().addScaledVector(right,cols[slot]*sideOff);
+    const pos=pt.clone().addScaledVector(right,centered*sideOff);
     grid.push({pos,hdg});
   }
   return grid;
 }
 
-export function instantiateRaceCars({ trackPoints, cars, selectedCarIndex, scene, createAIController, aiCount=4 }){
-  const grid=buildRaceGrid(trackPoints);
-  const playerCar=new Car(cars[selectedCarIndex],grid[0].pos,grid[0].hdg,true,scene);
+export function instantiateRaceCars({ trackPoints, cars, selectedCarIndex, scene, createAIController, aiCount=4, playerControlled=true, stackedStart=false }){
+  const totalCars=(playerControlled?1:0)+Math.max(0,Math.floor(aiCount)||0);
+  const grid=buildRaceGrid(trackPoints, Math.max(1,totalCars), stackedStart);
+  const playerTemplate=cars[selectedCarIndex]||cars[0];
+  const playerCar=playerControlled?new Car(playerTemplate,grid[0].pos,grid[0].hdg,true,scene):null;
 
   const aiCars=[];
   const aiControllers=[];
-  const count=Math.max(0,Math.min(4,Math.floor(aiCount)||0));
+  const count=Math.max(0,Math.floor(aiCount)||0);
   const aiIndexes=cars.map((_, index) => index).filter((index) => index !== selectedCarIndex);
   for(let i=0;i<count;i++){
-    const aiCar=new Car(cars[aiIndexes[i % aiIndexes.length]],grid[i+1].pos,grid[i+1].hdg,false,scene);
+    const gridIndex=playerControlled?i+1:i;
+    const aiSourceIndex=aiIndexes.length?aiIndexes[i % aiIndexes.length]:selectedCarIndex;
+    const aiCar=new Car(cars[aiSourceIndex],grid[gridIndex].pos,grid[gridIndex].hdg,false,scene);
     aiCar.aiAgg=.86+i*.04;
     aiCars.push(aiCar);
     aiControllers.push(createAIController(aiCar,i));
   }
 
-  return { playerCar, aiCars, aiControllers, allCars:[playerCar,...aiCars] };
+  return { playerCar, aiCars, aiControllers, allCars:playerCar?[playerCar,...aiCars]:aiCars.slice() };
 }
 
 export { Car };

--- a/games/turboracing-exp/scripts/game-loop.js
+++ b/games/turboracing-exp/scripts/game-loop.js
@@ -6,10 +6,10 @@ import {
   getTouchSliderSteer,
 } from './touch-controls.js';
 import { updateAudio, aiSounds } from './audio.js';
-import { updateCamera, updateEditorPreviewCamera } from './camera.js';
+import { updateCamera, updateEditorPreviewCamera, updateTrainingFreeCamera } from './camera.js';
 import { updateHUD, drawDash, drawMinimap } from './hud.js';
 import { ghostVisuals, sampleGhostFrame, updateGhostReplay, shouldRenderGhostsForState } from './ghost.js';
-import { updateResultsUI } from './race.js';
+import { updateResultsUI, endRace } from './race.js';
 import { editorRebuildScene } from './editor.js';
 
 function isTouchDevice() {
@@ -96,6 +96,37 @@ function updateRacingState(dt) {
   updateGhostState();
 }
 
+
+function updateTrainingState(dt) {
+  const tickRate = Math.max(0.25, state.training.config?.tickRate || 1);
+  const totalDt = dt * tickRate;
+  const steps = Math.max(1, Math.ceil(tickRate));
+  const stepDt = totalDt / steps;
+  for (let step = 0; step < steps; step += 1) {
+    state.raceTime += stepDt;
+    updateAiControllers(stepDt);
+    if (state.raceTime >= (state.training.config?.maxSimulationTime || 45)) break;
+  }
+  state.training.workerPool?.schedule(state.aiControllers);
+  if (state.training.visible && state.pCar) {
+    updateTrainingFreeCamera(dt);
+    updateHUD();
+    drawMinimap();
+  }
+  const leadCar = state.aiCars.reduce((best, car) => (!best || (car.progressCm || 0) > (best.progressCm || 0) ? car : best), null);
+  state.training.progressCm = leadCar?.progressCm || 0;
+  const statusEl = document.getElementById('trainAiStatus');
+  if (statusEl) statusEl.textContent = `Generation ${state.training.generation || 1} · Episode ${state.training.episode + 1} · ${(state.training.progressCm || 0).toLocaleString('de-DE')} cm`;
+  const maxSimulationTime = state.training.config?.maxSimulationTime || 45;
+  if (state.raceTime >= maxSimulationTime) {
+    state.raceTime = maxSimulationTime;
+    endRace();
+    return;
+  }
+  const unfinished = state.aiCars.some((car) => !car.finished);
+  if (!unfinished) endRace();
+}
+
 function updateCooldownState(dt) {
   state.raceTime += dt;
   state.pCar.update({ thr: 0, brk: 0.3, str: 0 }, dt);
@@ -140,6 +171,9 @@ export function updateGameFrame(dt) {
       break;
     case 'cooldown':
       updateCooldownState(dt);
+      break;
+    case 'training':
+      updateTrainingState(dt);
       break;
     case 'editorPreview':
     case 'editor':

--- a/games/turboracing-exp/scripts/game.js
+++ b/games/turboracing-exp/scripts/game.js
@@ -13,7 +13,11 @@ import { toggleCam } from './camera.js';
 import { setupLights } from './lighting.js';
 import { resizeDC } from './hud.js';
 import { setOnlineGhostToggle, setOnlineGhostCount, readOnlineGhostToggle, readOnlineGhostCount } from './ghost.js';
-import { pauseRace, resumeRace, startRace, restartRace } from './race.js';
+import {
+  pauseRace, resumeRace, startRace, restartRace,
+  openTrainingModal, closeTrainingModal, startTrainingFromUi,
+  importTrainingJsonFromUi, exportTrainingJsonToUi, updateTrainingSelectionUi, stopTraining
+} from './race.js';
 import {
   setEditorNodeCount, setEditorBrushAsset, setEditorBrushEnabled, setEditorBrushSize, setEditorBrushSpacing,
   onEditorMetaChanged, onEditorStreetGridChanged, onEditorNodeChanged,
@@ -56,7 +60,9 @@ function bindKeyboardInput() {
         return;
       }
 
-      if (state.gState === 'racing' || state.gState === 'cooldown') {
+      if (state.gState === 'training') {
+        stopTraining();
+      } else if (state.gState === 'racing' || state.gState === 'cooldown') {
         pauseRace();
       } else if (state.gState === 'paused') {
         resumeRace();
@@ -84,6 +90,11 @@ function bindSettingsControls() {
   document.getElementById('settingsCloseBtn').addEventListener('click', closeSettings);
   document.getElementById('showSettingsBtn').addEventListener('click', showSettings);
   document.getElementById('mainSettingsBtn').addEventListener('click', () => { tryStartMenuMusic(); showSettings(); });
+  document.getElementById('trainAiBtn').addEventListener('click', () => { tryStartMenuMusic(); openTrainingModal(); });
+  document.getElementById('trainAiCloseBtn').addEventListener('click', closeTrainingModal);
+  document.getElementById('trainAiStartBtn').addEventListener('click', startTrainingFromUi);
+  document.getElementById('trainAiImportBtn').addEventListener('click', importTrainingJsonFromUi);
+  document.getElementById('trainAiExportBtn').addEventListener('click', exportTrainingJsonToUi);
 }
 
 function bindMenuButtons() {
@@ -170,6 +181,7 @@ function bindUi() {
 function applyStoredSettings() {
   setOnlineGhostToggle(readOnlineGhostToggle());
   setOnlineGhostCount(readOnlineGhostCount());
+  updateTrainingSelectionUi();
 }
 
 function updateVersionLabels() {

--- a/games/turboracing-exp/scripts/hud.js
+++ b/games/turboracing-exp/scripts/hud.js
@@ -51,7 +51,7 @@ function updateHudPosition() {
 }
 
 export function updateHUD() {
-  if (!state.pCar || !state.trkData || (state.gState !== 'racing' && state.gState !== 'finished')) {
+  if (!state.pCar || !state.trkData || !['racing','finished','training'].includes(state.gState)) {
     return;
   }
 

--- a/games/turboracing-exp/scripts/menu.js
+++ b/games/turboracing-exp/scripts/menu.js
@@ -24,6 +24,7 @@ export function showSettings(){
 
 export function closeSettings(){
   document.getElementById('settingsModal').style.display='none';
+  const trainModal=document.getElementById('trainAiModal'); if(trainModal) trainModal.style.display='none';
 }
 
 // ═══════════════════════════════════════════════════════
@@ -40,6 +41,7 @@ export function showIntro(){
   releaseAllTouchControls();
   document.getElementById('pauseMenu').style.display='none';
   document.getElementById('settingsModal').style.display='none';
+  const trainModal=document.getElementById('trainAiModal'); if(trainModal) trainModal.style.display='none';
   clearGhostVisual();
   dc.style.display='none';
 }
@@ -54,6 +56,7 @@ export function showMain(){
   releaseAllTouchControls();
   document.getElementById('pauseMenu').style.display='none';
   document.getElementById('settingsModal').style.display='none';
+  const trainModal=document.getElementById('trainAiModal'); if(trainModal) trainModal.style.display='none';
   dc.style.display='none';
   const epb=document.getElementById('editorPreviewBanner'); if(epb)epb.style.display='none';
   const epbtn=document.getElementById('editorPreviewBtn'); if(epbtn)epbtn.textContent='3D PREVIEW';
@@ -62,7 +65,7 @@ export function showMain(){
   clearGhostVisual();
   if(audioReady)startMusic();
   for(const c of state.allCars)scene.remove(c.mesh);
-  state.allCars=[]; state.aiCars=[]; state.pCar=null;
+  state.allCars=[]; state.aiCars=[]; state.pCar=null; state.training.running=false; state.raceMode='race'; if(state.training.workerPool){ state.training.workerPool.dispose(); state.training.workerPool=null; }
 }
 
 // ═══════════════════════════════════════════════════════

--- a/games/turboracing-exp/scripts/race.js
+++ b/games/turboracing-exp/scripts/race.js
@@ -5,6 +5,7 @@ import { buildTrack } from './track-gen.js';
 import { instantiateRaceCars } from './car.js';
 import { AI } from './ai-script.js';
 import { setupLights } from './lighting.js';
+import { resetFreeCameraToTrack } from './camera.js';
 import {
   initAudio, initAiSounds, clearAiSounds,
   stopAudio, stopMusic, playBeep,
@@ -23,166 +24,431 @@ import {
   setupGhostReplayFromTrack, startGhostRecording,
   finalizeGhostRecording
 } from './ghost.js';
-import { getTrackById } from './editor.js';
+import { getTrackById, getAllTracks, loadTracksFromFolder, loadEditorTracks } from './editor.js';
+import { createTrainingManager, createTrainingWorkerPool, mergeConfig, parseTrainingJson } from './train-ai.js';
 
-// ═══════════════════════════════════════════════════════
-//  RACE LOGIC
-// ═══════════════════════════════════════════════════════
-export async function initRace(){
-  for(const c of state.allCars)scene.remove(c.mesh);
-  state.allCars=[]; state.aiCars=[]; state.aiControllers=[]; state.pCar=null;
+
+function formatProgressCm(progressCm = 0) {
+  const meters = (progressCm / 100).toFixed(2);
+  return `${progressCm.toLocaleString('de-DE')} cm (${meters} m)`;
+}
+
+function trainingContext() {
+  return {
+    trackPoints: state.trkPts,
+    trackCurvature: state.trkCurv,
+    cityAiPoints: state.cityAiPts,
+    corridors: state.cityCorridors,
+    cityCorridors: state.cityCorridors,
+    trackData: state.trkData,
+    playerCar: state.pCar,
+  };
+}
+
+function getTrainingUiElements() {
+  return {
+    modal: document.getElementById('trainAiModal'),
+    status: document.getElementById('trainAiStatus'),
+    exportArea: document.getElementById('trainAiJson'),
+    generation: document.getElementById('trainAiGeneration'),
+    episode: document.getElementById('trainAiEpisode'),
+  };
+}
+
+function updateTrainingStatus(message = '') {
+  const ui = getTrainingUiElements();
+  if (ui.status) ui.status.textContent = message;
+  if (ui.generation) ui.generation.textContent = String(state.training.generation || 0);
+  if (ui.episode) ui.episode.textContent = String(state.training.episode || 0);
+  state.training.status = message;
+}
+
+function readCheckedValues(name) {
+  return [...document.querySelectorAll(`input[name="${name}"]:checked`)].map((input) => input.value);
+}
+
+function normaliseTrainingConfig(raw = {}) {
+  return mergeConfig({
+    nodeLookahead: +raw.nodeLookahead,
+    populationSize: +raw.populationSize,
+    maxSimulationTime: +raw.maxSimulationTime,
+    hiddenLayers: +raw.hiddenLayers,
+    neuronsPerLayer: +raw.neuronsPerLayer,
+    mutationRate: +raw.mutationRate,
+    mutationStrength: +raw.mutationStrength,
+    eliteCount: +raw.eliteCount,
+    tickRate: +raw.tickRate,
+    jokerCarrySimulations: +raw.jokerCarrySimulations,
+    rewards: {
+      progress: +raw.rewardProgress,
+      speed: +raw.rewardSpeed,
+      finish: +raw.rewardFinish,
+      survival: +raw.rewardSurvival,
+      gravelPenalty: +raw.rewardGravelPenalty,
+      wallPenalty: +raw.rewardWallPenalty,
+      steeringPenalty: +raw.rewardSteeringPenalty,
+    },
+  });
+}
+
+function getTrainingSelection() {
+  const visible = !!document.getElementById('trainAiVisible')?.checked;
+  const selectedTrackIds = readCheckedValues('train-track');
+  const selectedCarIds = readCheckedValues('train-car').map((value) => Number(value));
+  const config = normaliseTrainingConfig(Object.fromEntries(new FormData(document.getElementById('trainAiForm')).entries()));
+  return { visible, selectedTrackIds, selectedCarIds, config };
+}
+
+function ensureTrainingManager(config) {
+  if (!state.training.controller) state.training.controller = createTrainingManager(config);
+  state.training.controller.config = mergeConfig(config);
+  state.training.config = mergeConfig(config);
+  return state.training.controller;
+}
+
+function chooseTrainingTrack() {
+  const selected = state.training.selectedTrackIds.length ? state.training.selectedTrackIds : getAllTracks().map((track) => String(track.id));
+  if (!selected.length) return getTrackById(state.selTrk);
+  const nextIndex = state.training.episode % selected.length;
+  return getTrackById(selected[nextIndex]);
+}
+
+function chooseTrainingCarIndex() {
+  const selected = state.training.selectedCarIds.length ? state.training.selectedCarIds : CARS.map((car) => car.id);
+  if (!selected.length) return 0;
+  return selected[state.training.episode % selected.length];
+}
+
+export async function openTrainingModal() {
+  loadEditorTracks();
+  await loadTracksFromFolder().catch(() => {});
+  const ui = getTrainingUiElements();
+  if (!ui.modal) return;
+  ui.modal.style.display = 'flex';
+  updateTrainingSelectionUi();
+  updateTrainingStatus(state.training.status || 'Train-AI bereit.');
+}
+
+export function closeTrainingModal() {
+  const ui = getTrainingUiElements();
+  if (ui.modal) ui.modal.style.display = 'none';
+}
+
+export function updateTrainingSelectionUi() {
+  const trackWrap = document.getElementById('trainTrackList');
+  const carWrap = document.getElementById('trainCarList');
+  if (trackWrap) {
+    const tracks = getAllTracks();
+    trackWrap.innerHTML = tracks.map((track, index) => `<label class="trainAiPick"><input type="checkbox" name="train-track" value="${track.id}" ${index < Math.min(3, tracks.length) ? 'checked' : ''}> <span>${track.name}</span></label>`).join('');
+  }
+  if (carWrap) {
+    carWrap.innerHTML = CARS.map((car) => `<label class="trainAiPick"><input type="checkbox" name="train-car" value="${car.id}" ${car.id < 2 ? 'checked' : ''}> <span>${car.name}</span></label>`).join('');
+  }
+  if (state.training.controller) {
+    const ui = getTrainingUiElements();
+    if (ui.exportArea && !ui.exportArea.value.trim()) ui.exportArea.value = state.training.controller.exportJSON();
+  }
+}
+
+function applyTrainingCars(selection) {
+  state.raceMode = 'training';
+  state.training.running = true;
+  state.training.visible = selection.visible;
+  state.training.selectedTrackIds = selection.selectedTrackIds;
+  state.training.selectedCarIds = selection.selectedCarIds;
+  const manager = ensureTrainingManager(selection.config);
+  const track = chooseTrainingTrack();
+  state.selTrk = track?.id ?? state.selTrk;
+  state.selCar = chooseTrainingCarIndex();
+  if (selection.visible) {
+    startRace({ mode: 'training', skipCountdown: true });
+  } else {
+    void initRace({ mode: 'training', skipCountdown: true });
+  }
+  const ui = getTrainingUiElements();
+  if (ui.exportArea) ui.exportArea.value = manager.exportJSON();
+}
+
+export function startTrainingFromUi() {
+  const selection = getTrainingSelection();
+  closeTrainingModal();
+  applyTrainingCars(selection);
+}
+
+export function importTrainingJsonFromUi() {
+  const ui = getTrainingUiElements();
+  if (!ui.exportArea) return;
+  const manager = ensureTrainingManager(normaliseTrainingConfig({}));
+  try {
+    manager.importJSON(parseTrainingJson(ui.exportArea.value));
+    manager.saveToStorage();
+    updateTrainingStatus('Train-AI JSON importiert.');
+  } catch (error) {
+    updateTrainingStatus(`Import fehlgeschlagen: ${error.message}`);
+  }
+}
+
+export function exportTrainingJsonToUi() {
+  const ui = getTrainingUiElements();
+  const manager = ensureTrainingManager(normaliseTrainingConfig({}));
+  if (ui.exportArea) ui.exportArea.value = manager.exportJSON();
+  manager.saveToStorage();
+  updateTrainingStatus('Train-AI JSON exportiert.');
+}
+
+export async function initRace(options = {}) {
+  const mode = options.mode || state.raceMode || 'race';
+  const skipCountdown = !!options.skipCountdown;
+  const trainingMode = mode === 'training';
+  state.raceMode = mode;
+
+  for (const c of state.allCars) scene.remove(c.mesh);
+  state.allCars = []; state.aiCars = []; state.aiControllers = []; state.pCar = null;
   clearAiSounds();
   clearGhostVisual();
+  if (trainingMode) { stopAudio(); stopMusic(); }
 
-  state.trkData=getTrackById(state.selTrk);
-  try{ buildTrack(state.trkData); }catch(e){ console.error('buildTrack error:',e); }
+  if (trainingMode) {
+    const track = chooseTrainingTrack();
+    state.trkData = track;
+    state.selTrk = track?.id ?? state.selTrk;
+  } else {
+    state.trkData = getTrackById(state.selTrk);
+  }
+  try { buildTrack(state.trkData); } catch (e) { console.error('buildTrack error:', e); }
   setupLights();
 
-  let corridors=state.cityCorridors;
+  const corridors = state.cityCorridors;
+  const ghostModeEnabled = !trainingMode && onlineGhostEnabled;
+  const trainingConfig = state.training.config || mergeConfig({});
+  const aiCount = trainingMode ? trainingConfig.populationSize : 4;
+  const playerControlled = !trainingMode;
+  const manager = trainingMode ? ensureTrainingManager(trainingConfig) : null;
+  if (trainingMode && !state.training.workerPool) state.training.workerPool = createTrainingWorkerPool();
 
-  const ghostModeEnabled=onlineGhostEnabled;
-  const raceCars=instantiateRaceCars({
+  const raceCars = instantiateRaceCars({
     trackPoints: state.trkPts,
     cars: CARS,
-    selectedCarIndex: state.selCar,
-    aiCount: ghostModeEnabled?0:4,
-    scene: scene,
-    createAIController: (aiCar,i)=>new AI(aiCar,.044+i*.010,()=>({
-      trackPoints: state.trkPts,
-      trackCurvature: state.trkCurv,
-      cityAiPoints: state.cityAiPts,
-      corridors,
-      trackData: state.trkData,
-      playerCar: state.pCar
-    }))
+    selectedCarIndex: trainingMode ? chooseTrainingCarIndex() : state.selCar,
+    aiCount: ghostModeEnabled ? 0 : aiCount,
+    playerControlled,
+    stackedStart: trainingMode,
+    scene,
+    createAIController: (aiCar, i) => {
+      if (trainingMode) {
+        const inputSize = 3 + trainingConfig.nodeLookahead * 3 + 2 + 2 + 1 + 1 + 1;
+        return new AI(aiCar, .044 + i * .010, trainingContext, {
+          config: trainingConfig,
+          genome: manager.getGenomeAt(i, inputSize),
+          aggression: 1,
+        });
+      }
+      return new AI(aiCar, .044 + i * .010, trainingContext, { aggression: .86 + i * .04 });
+    }
   });
-  state.pCar=raceCars.playerCar;
-  state.aiCars=raceCars.aiCars;
-  state.aiControllers=raceCars.aiControllers;
-  state.allCars=raceCars.allCars;
-  await setupGhostReplayFromTrack(state.trkData&&state.trkData.id);
+  state.pCar = playerControlled ? raceCars.playerCar : raceCars.aiCars[0] || null;
+  state.aiCars = trainingMode ? raceCars.aiCars : raceCars.aiCars;
+  state.aiControllers = raceCars.aiControllers;
+  if (trainingMode && state.training.workerPool) state.training.workerPool.register(state.aiControllers);
+  state.allCars = playerControlled ? raceCars.allCars : raceCars.aiCars;
+  if (!trainingMode) await setupGhostReplayFromTrack(state.trkData && state.trkData.id);
 
-  state.raceTime=0; state.gState='countdown';
+  state.raceTime = 0; state.gState = 'countdown';
   resetCurrentRaceSubmitted();
-  document.getElementById('hud').style.display='block';
-  document.getElementById('hint').style.display=isTouchControlsEnabled()?'none':'block';
+  document.getElementById('hud').style.display = trainingMode && !state.training.visible ? 'none' : 'block';
+  document.getElementById('hint').style.display = isTouchControlsEnabled() && !trainingMode ? 'none' : 'block';
   updateTouchControlsVisibility(state.gState);
-  document.getElementById('camLabel').textContent='[ C ] COCKPIT VIEW';
-  state.camMode='chase'; dc.style.display='none';
-  document.getElementById('speedBox').style.display='block';
-  document.getElementById('gearBox').style.display='block';
-  startGhostRecording();
-  if(ghostModeEnabled&&ghostVisuals.length===0)notify('Ghost mode enabled: no matching ghost data for this track yet.');
-  doCountdown();
+  document.getElementById('camLabel').textContent = trainingMode ? '[ WASD ] TRAIN FREECAM' : '[ C ] COCKPIT VIEW';
+  state.camMode = trainingMode ? 'free' : 'chase'; dc.style.display = 'none';
+  document.getElementById('speedBox').style.display = trainingMode ? 'none' : 'block';
+  document.getElementById('gearBox').style.display = trainingMode ? 'none' : 'block';
+  if (trainingMode && state.training.visible) resetFreeCameraToTrack(state.trkPts);
+  if (!trainingMode) startGhostRecording();
+  if (ghostModeEnabled && ghostVisuals.length === 0) notify('Ghost mode enabled: no matching ghost data for this track yet.');
+  if (skipCountdown || trainingMode) {
+    document.getElementById('cd').style.display = 'none';
+    state.gState = trainingMode ? 'training' : 'racing';
+    if (trainingMode) updateTrainingStatus(`Generation ${state.training.generation || 1} · Episode ${state.training.episode + 1} · ${state.trkData?.name || 'Track'} · 0 cm`);
+    updateTouchControlsVisibility(state.gState);
+    startMusic();
+  } else {
+    doCountdown();
+  }
 }
 
-export function doCountdown(){
+export function doCountdown() {
   stopMusic();
   initAudio();
-  if(audioReady){
+  if (audioReady) {
     initAiSounds(state.aiCars.length);
   }
-  const el=document.getElementById('cd');
-  el.style.display='block';
-  let c=3; el.textContent=c;
+  const el = document.getElementById('cd');
+  el.style.display = 'block';
+  let c = 3; el.textContent = c;
   announce('3');
-  playBeep(440,.18,.25,'square');
-  const iv=setInterval(()=>{
+  playBeep(440, .18, .25, 'square');
+  const iv = setInterval(() => {
     c--;
-    if(c>0){
-      el.textContent=c; playBeep(440,.18,.25,'square'); announce(String(c));
-    }else{
-      el.textContent='GO!'; playBeep(880,.45,.4,'square'); announce('Go go go!');
+    if (c > 0) {
+      el.textContent = c; playBeep(440, .18, .25, 'square'); announce(String(c));
+    } else {
+      el.textContent = 'GO!'; playBeep(880, .45, .4, 'square'); announce('Go go go!');
       clearInterval(iv);
-      setTimeout(()=>{el.style.display='none'; state.gState='racing'; updateTouchControlsVisibility(state.gState); startMusic();},700);
+      setTimeout(() => {
+        el.style.display = 'none';
+        state.gState = state.raceMode === 'training' ? 'training' : 'racing';
+        updateTouchControlsVisibility(state.gState);
+        startMusic();
+      }, 700);
     }
-  },1000);
+  }, 1000);
 }
 
-let _prePauseState='racing';
-export function pauseRace(){
-  _prePauseState=state.gState;
-  state.gState='paused'; stopAudio(); stopMusic();
-  document.getElementById('pauseMenu').style.display='flex';
+let _prePauseState = 'racing';
+export function pauseRace() {
+  _prePauseState = state.gState;
+  state.gState = 'paused'; stopAudio(); stopMusic();
+  document.getElementById('pauseMenu').style.display = 'flex';
   updateTouchControlsVisibility(state.gState);
   releaseAllTouchControls();
 }
 
-export function resumeRace(){
-  state.gState=_prePauseState==='cooldown'?'cooldown':'racing';
-  document.getElementById('pauseMenu').style.display='none';
-  document.getElementById('settingsModal').style.display='none';
+export function resumeRace() {
+  state.gState = _prePauseState === 'cooldown' ? 'cooldown' : (state.raceMode === 'training' ? 'training' : 'racing');
+  document.getElementById('pauseMenu').style.display = 'none';
+  document.getElementById('settingsModal').style.display = 'none';
   updateTouchControlsVisibility(state.gState);
   initAudio(); startMusic();
 }
 
-export async function endRace(){
-  const all=[state.pCar,...state.aiCars].sort((a,b)=>{
-    if(a.finished&&b.finished)return a.finTime-b.finTime;
-    if(a.finished)return-1; if(b.finished)return 1; return b.totalProg-a.totalProg;
+function finishTrainingGeneration() {
+  const manager = ensureTrainingManager(state.training.config || mergeConfig({}));
+  const winner = manager.evaluate(state.aiControllers);
+  state.training.generation = manager.generation;
+  state.training.episode += 1;
+  state.training.bestGenome = winner;
+  manager.saveToStorage();
+  const ui = getTrainingUiElements();
+  if (ui.exportArea) ui.exportArea.value = manager.exportJSON();
+  const bestCm = winner?.telemetry?.progressCm || 0;
+  updateTrainingStatus(`Gen ${state.training.generation} fertig · ${formatProgressCm(bestCm)} · Fitness ${winner ? winner.fitness.toFixed(2) : '0.00'} · ${state.trkData?.name || 'Track'}`);
+  if (state.training.running) {
+    void initRace({ mode: 'training', skipCountdown: true });
+  }
+}
+
+export async function endRace() {
+  if (state.raceMode === 'training') {
+    finishTrainingGeneration();
+    return;
+  }
+  const all = [state.pCar, ...state.aiCars].sort((a, b) => {
+    if (a.finished && b.finished) return a.finTime - b.finTime;
+    if (a.finished) return -1; if (b.finished) return 1; return b.totalProg - a.totalProg;
   });
-  const pos=all.indexOf(state.pCar)+1;
-  state.gState='cooldown';
-  if(pos===1){
+  const pos = all.indexOf(state.pCar) + 1;
+  state.gState = 'cooldown';
+  if (pos === 1) {
     playVictoryJingle();
     announce('Checkered flag! You win!');
-  }else{
+  } else {
     playLossSound();
-    announce('Race finished! P'+pos+'!');
+    announce(`Race finished! P${pos}!`);
   }
-  const ghostPayload=await finalizeGhostRecording();
-  setTimeout(()=>showResults(ghostPayload),1200);
+  const ghostPayload = await finalizeGhostRecording();
+  setTimeout(() => showResults(ghostPayload), 1200);
 }
-globalThis.endRace=endRace;
+globalThis.endRace = endRace;
 
-export function showResults(ghostPayload){
+export function showResults(ghostPayload) {
   updateResultsUI();
-  handlePostRaceLeaderboard(notify,ghostPayload);
-  document.getElementById('results').style.display='flex';
-  document.getElementById('hud').style.display='none';
-  document.getElementById('touchControls').style.display='none';
-  for(const visual of ghostVisuals){
-    if(visual.tagEl)visual.tagEl.style.display='none';
+  handlePostRaceLeaderboard(notify, ghostPayload);
+  document.getElementById('results').style.display = 'flex';
+  document.getElementById('hud').style.display = 'none';
+  document.getElementById('touchControls').style.display = 'none';
+  for (const visual of ghostVisuals) {
+    if (visual.tagEl) visual.tagEl.style.display = 'none';
   }
   releaseAllTouchControls();
-  dc.style.display='none';
+  dc.style.display = 'none';
 }
 
-export function updateResultsUI(){
-  const all=[state.pCar,...state.aiCars].sort((a,b)=>{
-    if(a.finished&&b.finished)return a.finTime-b.finTime;
-    if(a.finished)return-1; if(b.finished)return 1; return b.totalProg-a.totalProg;
+export function updateResultsUI() {
+  const pool = state.raceMode === 'training' ? state.aiCars : [state.pCar, ...state.aiCars];
+  const player = state.pCar || state.aiCars[0];
+  const all = pool.slice().sort((a, b) => {
+    if (a.finished && b.finished) return a.finTime - b.finTime;
+    if (a.finished) return -1; if (b.finished) return 1; return b.totalProg - a.totalProg;
   });
-  const win=all[0]===state.pCar;
-  document.getElementById('rTitle').textContent=win?'🏆 VICTORY!':'RACE OVER';
-  document.getElementById('rTitle').style.color=win?'#ffd700':'#ff5500';
-  const pods=document.getElementById('podium'); pods.innerHTML='';
-  const medals=['🥇','🥈','🥉','4th','5th'];
-  for(let i=0;i<Math.min(5,all.length);i++){
-    const car=all[i],ip=car===state.pCar;
-    const d=document.createElement('div'); d.className='pi';
-    d.innerHTML=`<div class="pm">${medals[i]}</div>
-      <div class="pn" style="color:${ip?'#ffd700':'#aaa'}">${ip?'⭐ YOU':car.data.name}</div>
-      <div class="pt">${car.finished?fmtT(car.finTime):'racing...'}</div>`;
+  const win = all[0] === player;
+  document.getElementById('rTitle').textContent = win ? '🏆 VICTORY!' : 'RACE OVER';
+  document.getElementById('rTitle').style.color = win ? '#ffd700' : '#ff5500';
+  const pods = document.getElementById('podium'); pods.innerHTML = '';
+  const medals = ['🥇', '🥈', '🥉', '4th', '5th'];
+  for (let i = 0; i < Math.min(5, all.length); i++) {
+    const car = all[i], ip = car === player;
+    const d = document.createElement('div'); d.className = 'pi';
+    d.innerHTML = `<div class="pm">${medals[i]}</div>
+      <div class="pn" style="color:${ip ? '#ffd700' : '#aaa'}">${ip ? '⭐ YOU' : car.data.name}</div>
+      <div class="pt">${car.finished ? fmtT(car.finTime) : 'racing...'}</div>`;
     pods.appendChild(d);
   }
-  const pp=all.indexOf(state.pCar)+1;
-  document.getElementById('ptime').textContent=`Your time: ${fmtT(state.pCar.finTime||state.raceTime)}  ·  P${pp}`;
-  const carName=(state.pCar&&state.pCar.data&&state.pCar.data.name)?state.pCar.data.name:'Unknown';
-  document.getElementById('runCar').textContent=`Run car: ${carName}`;
+  const pp = all.indexOf(player) + 1;
+  document.getElementById('ptime').textContent = `Your time: ${fmtT(player.finTime || state.raceTime)}  ·  P${pp}`;
+  const carName = (player && player.data && player.data.name) ? player.data.name : 'Unknown';
+  document.getElementById('runCar').textContent = `Run car: ${carName}`;
   const cached = getCurrentTrackLeaderboard();
   renderResultsLeaderboard(cached.entries);
 }
 
-export function startRace(){
-  document.querySelectorAll('.screen,#results').forEach(s=>s.style.display='none');
-  void initRace();
+export function startRace(options = {}) {
+  document.querySelectorAll('.screen,#results').forEach(s => s.style.display = 'none');
+  void initRace(options);
 }
 
-export function restartRace(){
-  document.getElementById('pauseMenu').style.display='none';
-  document.getElementById('settingsModal').style.display='none';
+export function restartRace() {
+  document.getElementById('pauseMenu').style.display = 'none';
+  document.getElementById('settingsModal').style.display = 'none';
   releaseAllTouchControls();
-  document.getElementById('results').style.display='none';
-  void initRace();
+  document.getElementById('results').style.display = 'none';
+  void initRace({ mode: state.raceMode, skipCountdown: true });
+}
+
+export function stopTraining({ saveBest = true, exitToMenu = true } = {}) {
+  const manager = state.training.controller;
+  if (saveBest && manager) {
+    if (state.aiControllers?.length) {
+      const liveBest = state.aiControllers
+        .map((controller, index) => ({
+          genome: controller.exportData().genome,
+          telemetry: controller.exportData().telemetry,
+          fitness: (controller.car.progressCm || 0) + controller.telemetry.maxSpeed,
+          carIndex: index,
+        }))
+        .sort((a, b) => (b.telemetry.progressCm || 0) - (a.telemetry.progressCm || 0))[0];
+      if (liveBest && (!manager.bestEntry || (liveBest.telemetry.progressCm || 0) >= (manager.bestEntry.telemetry?.progressCm || 0))) {
+        manager.bestEntry = liveBest;
+      }
+    }
+    manager.saveToStorage();
+    const ui = getTrainingUiElements();
+    if (ui.exportArea) ui.exportArea.value = manager.exportJSON();
+  }
+  state.training.running = false;
+  if (state.training.workerPool) { state.training.workerPool.dispose(); state.training.workerPool = null; }
+  state.gState = 'menu';
+  state.raceMode = 'race';
+  updateTrainingStatus('Training per ESC beendet. Beste KI wurde behalten.');
+  if (exitToMenu) {
+    const pauseMenu = document.getElementById('pauseMenu');
+    if (pauseMenu) pauseMenu.style.display = 'none';
+    document.querySelectorAll('.screen,#results').forEach((screen) => { screen.style.display = 'none'; });
+    const main = document.getElementById('sMain');
+    if (main) main.style.display = 'flex';
+    document.getElementById('hud').style.display = 'none';
+    document.getElementById('hint').style.display = 'none';
+    const modal = document.getElementById('trainAiModal');
+    if (modal) modal.style.display = 'flex';
+    updateTrainingSelectionUi();
+  }
 }

--- a/games/turboracing-exp/scripts/state.js
+++ b/games/turboracing-exp/scripts/state.js
@@ -49,6 +49,8 @@ export const state = {
     trkCurve: null,
     trkPts: [],
     trkCurv: [],
+    trkDist: [],
+    trkLen: 0,
     trkWallLeft: [],
     trkWallRight: [],
     sceneryExclusionZones: [],
@@ -56,5 +58,21 @@ export const state = {
     cityCorridors: null, // For city tracks: array of {x,z,hw,hd} axis-aligned driveable rectangles
     cityAiPts: null,    // For city tracks: dense waypoints following grid roads exactly
     gravelProfile: null, // Runoff profile used for gravel physics detection
-    renderer: null
+    renderer: null,
+    raceMode: 'race',
+    training: {
+      visible: true,
+      running: false,
+      generation: 0,
+      episode: 0,
+      progressCm: 0,
+      agentIndex: 0,
+      selectedTrackIds: [],
+      selectedCarIds: [],
+      config: null,
+      controller: null,
+      workerPool: null,
+      bestGenome: null,
+      status: ''
+    }
 };

--- a/games/turboracing-exp/scripts/track-gen.js
+++ b/games/turboracing-exp/scripts/track-gen.js
@@ -115,6 +115,16 @@ export function buildTrack(data){
       : data.wp.map(w=>new THREE.Vector3(w[0],w[1],w[2]));
   const curve=new THREE.CatmullRomCurve3(raw,true,'centripetal',.5);
   state.trkCurve=curve; state.trkPts=curve.getSpacedPoints(500);
+  state.trkDist=[0];
+  let trkLen=0;
+  for(let i=1;i<state.trkPts.length;i++){
+    trkLen+=state.trkPts[i].distanceTo(state.trkPts[i-1]);
+    state.trkDist.push(trkLen);
+  }
+  if(state.trkPts.length>1){
+    trkLen+=state.trkPts[0].distanceTo(state.trkPts[state.trkPts.length-1]);
+  }
+  state.trkLen=trkLen;
   state.trkWallLeft=[];
   state.trkWallRight=[];
   // Precompute per-point curvature (0=straight, 1=very tight) for AI adaptive lookahead

--- a/games/turboracing-exp/scripts/train-ai.js
+++ b/games/turboracing-exp/scripts/train-ai.js
@@ -1,0 +1,492 @@
+const TRAINING_STORAGE_KEY = 'turboracing_exp_train_ai_genome';
+let nextWorkerControllerId = 1;
+const DEFAULT_CONFIG = {
+  nodeLookahead: 3,
+  populationSize: 24,
+  maxSimulationTime: 45,
+  hiddenLayers: 2,
+  neuronsPerLayer: 12,
+  mutationRate: 0.14,
+  mutationStrength: 0.22,
+  eliteCount: 4,
+  tickRate: 1,
+  jokerCarrySimulations: 3,
+  rewards: {
+    progress: 18,
+    speed: 0.06,
+    finish: 140,
+    survival: 0.7,
+    gravelPenalty: 1.2,
+    wallPenalty: 3.4,
+    steeringPenalty: 0.05,
+  },
+};
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function randRange(amount) {
+  return (Math.random() * 2 - 1) * amount;
+}
+
+function sigmoid(value) {
+  return Math.tanh(value);
+}
+
+function deepClone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function mergeConfig(config = {}) {
+  const merged = deepClone(DEFAULT_CONFIG);
+  Object.assign(merged, config || {});
+  merged.rewards = { ...DEFAULT_CONFIG.rewards, ...(config.rewards || {}) };
+  merged.nodeLookahead = clamp(Math.round(merged.nodeLookahead || 3), 1, 8);
+  merged.populationSize = clamp(Math.round(merged.populationSize || 24), 1, 200);
+  merged.maxSimulationTime = clamp(+merged.maxSimulationTime || 45, 5, 600);
+  merged.hiddenLayers = clamp(Math.round(merged.hiddenLayers || 2), 1, 6);
+  merged.neuronsPerLayer = clamp(Math.round(merged.neuronsPerLayer || 12), 2, 64);
+  merged.mutationRate = clamp(+merged.mutationRate || 0.14, 0.001, 1);
+  merged.mutationStrength = clamp(+merged.mutationStrength || 0.22, 0.001, 3);
+  merged.eliteCount = clamp(Math.round(merged.eliteCount || 4), 1, merged.populationSize);
+  merged.tickRate = clamp(+merged.tickRate || 1, 0.25, 12);
+  merged.jokerCarrySimulations = clamp(Math.round(merged.jokerCarrySimulations ?? 3), 0, 20);
+  return merged;
+}
+
+function randomWeight() {
+  return randRange(1);
+}
+
+function createLayer(inputSize, outputSize) {
+  return {
+    weights: Array.from({ length: outputSize }, () => Array.from({ length: inputSize }, randomWeight)),
+    biases: Array.from({ length: outputSize }, randomWeight),
+  };
+}
+
+function createGenome(config, inputSize, outputSize = 3) {
+  const layers = [];
+  let currentInput = inputSize;
+  for (let index = 0; index < config.hiddenLayers; index += 1) {
+    layers.push(createLayer(currentInput, config.neuronsPerLayer));
+    currentInput = config.neuronsPerLayer;
+  }
+  layers.push(createLayer(currentInput, outputSize));
+  return { layers, meta: { createdAt: new Date().toISOString(), inputSize, outputSize } };
+}
+
+function cloneGenome(genome) {
+  return deepClone(genome);
+}
+
+function mutateGenome(genome, config) {
+  const next = cloneGenome(genome);
+  next.layers.forEach((layer) => {
+    layer.weights.forEach((row) => {
+      for (let index = 0; index < row.length; index += 1) {
+        if (Math.random() < config.mutationRate) row[index] += randRange(config.mutationStrength);
+      }
+    });
+    for (let index = 0; index < layer.biases.length; index += 1) {
+      if (Math.random() < config.mutationRate) layer.biases[index] += randRange(config.mutationStrength);
+    }
+  });
+  next.meta.updatedAt = new Date().toISOString();
+  return next;
+}
+
+function crossoverGenome(a, b) {
+  const out = cloneGenome(a);
+  out.layers.forEach((layer, layerIndex) => {
+    const otherLayer = b.layers[layerIndex];
+    layer.weights.forEach((row, rowIndex) => {
+      row.forEach((_, weightIndex) => {
+        if (Math.random() < 0.5) row[weightIndex] = otherLayer.weights[rowIndex][weightIndex];
+      });
+    });
+    layer.biases.forEach((_, biasIndex) => {
+      if (Math.random() < 0.5) layer.biases[biasIndex] = otherLayer.biases[biasIndex];
+    });
+  });
+  out.meta.updatedAt = new Date().toISOString();
+  return out;
+}
+
+function forwardPass(genome, inputs) {
+  let activations = inputs;
+  genome.layers.forEach((layer) => {
+    activations = layer.weights.map((row, outputIndex) => {
+      let sum = layer.biases[outputIndex];
+      for (let inputIndex = 0; inputIndex < row.length; inputIndex += 1) sum += row[inputIndex] * activations[inputIndex];
+      return sigmoid(sum);
+    });
+  });
+  return activations;
+}
+
+function rotateRelative(dx, dz, heading) {
+  const sin = Math.sin(-heading);
+  const cos = Math.cos(-heading);
+  return {
+    x: dx * cos - dz * sin,
+    z: dx * sin + dz * cos,
+  };
+}
+
+function computeClearance(car, trackData, cityCorridors) {
+  if (cityCorridors?.length) {
+    for (const corridor of cityCorridors) {
+      if (car.pos.x > corridor.x - corridor.hw && car.pos.x < corridor.x + corridor.hw && car.pos.z > corridor.z - corridor.hd && car.pos.z < corridor.z + corridor.hd) {
+        return {
+          left: corridor.x + corridor.hw - car.pos.x,
+          right: car.pos.x - (corridor.x - corridor.hw),
+        };
+      }
+    }
+  }
+  const width = trackData?.rw || 12;
+  return { left: width * 0.5, right: width * 0.5 };
+}
+
+function wrapAngle(angle) {
+  return ((angle + Math.PI) % (Math.PI * 2) + Math.PI * 2) % (Math.PI * 2) - Math.PI;
+}
+
+function getNodeBundle(car, context, lookahead) {
+  const navPts = context.cityAiPoints ? context.cityAiPoints.pts : context.trackPoints;
+  const curv = context.cityAiPoints ? context.cityAiPoints.curv : context.trackCurvature;
+  if (!navPts?.length) return [];
+  let closestIndex = 0;
+  let minDistance = Infinity;
+  for (let index = 0; index < navPts.length; index += 1) {
+    const point = navPts[index];
+    const d = (car.pos.x - point.x) ** 2 + (car.pos.z - point.z) ** 2;
+    if (d < minDistance) {
+      minDistance = d;
+      closestIndex = index;
+    }
+  }
+  const points = [];
+  let reference = { x: car.pos.x, z: car.pos.z };
+  for (let step = 1; step <= lookahead; step += 1) {
+    const point = navPts[(closestIndex + step) % navPts.length];
+    const rel = rotateRelative(point.x - reference.x, point.z - reference.z, car.hdg);
+    points.push({ x: rel.x, z: rel.z, steepness: curv[(closestIndex + step) % navPts.length] || 0 });
+    reference = point;
+  }
+  return points;
+}
+
+export function createTrainingSnapshot(car, context, config = DEFAULT_CONFIG) {
+  const nodes = getNodeBundle(car, context, config.nodeLookahead);
+  const navPts = context.cityAiPoints ? context.cityAiPoints.pts : context.trackPoints;
+  let headingRelative = 0;
+  if (navPts?.length) {
+    let closestIndex = 0;
+    let minDistance = Infinity;
+    for (let index = 0; index < navPts.length; index += 1) {
+      const point = navPts[index];
+      const d = (car.pos.x - point.x) ** 2 + (car.pos.z - point.z) ** 2;
+      if (d < minDistance) {
+        minDistance = d;
+        closestIndex = index;
+      }
+    }
+    const current = navPts[closestIndex];
+    const next = navPts[(closestIndex + 1) % navPts.length] || current;
+    const trackHeading = Math.atan2(next.x - current.x, next.z - current.z);
+    headingRelative = wrapAngle(car.hdg - trackHeading) / Math.PI;
+  }
+  const clearance = computeClearance(car, context.trackData, context.cityCorridors || context.corridors);
+  const speedRatio = car.data.maxSpd > 0 ? car.spd / car.data.maxSpd : 0;
+  const primary = [car.data.hdl || 0, car.data.brake || 0, car.data.maxSpd || 0];
+  const nodeInputs = [];
+  nodes.forEach((node) => {
+    nodeInputs.push(node.x / 120, node.z / 120, node.steepness);
+  });
+  while (nodeInputs.length < config.nodeLookahead * 3) nodeInputs.push(0, 0, 0);
+  return {
+    primaryStats: { grip: primary[0], brake: primary[1], speed: primary[2] },
+    nodes,
+    ownPosition: { x: car.pos.x, z: car.pos.z },
+    clearance,
+    speed: car.spd,
+    speedRatio,
+    onGravel: !!car.onGravel,
+    headingRelative,
+    inputs: [
+      primary[0] / 1.2,
+      primary[1] / 24,
+      primary[2] / 90,
+      ...nodeInputs,
+      car.pos.x / 500,
+      car.pos.z / 500,
+      clamp(clearance.left / 20, 0, 2),
+      clamp(clearance.right / 20, 0, 2),
+      speedRatio,
+      headingRelative,
+      car.onGravel ? 1 : -1,
+    ],
+  };
+}
+
+function scoreCar(car, telemetry, config) {
+  const rewards = config.rewards;
+  const progressMeters = Number.isFinite(car.progressMeters) ? car.progressMeters : car.totalProg;
+  const progressCm = Number.isFinite(car.progressCm) ? car.progressCm : Math.round(progressMeters * 100);
+  return progressCm * rewards.progress * 0.01 + telemetry.maxSpeed * rewards.speed + telemetry.aliveTime * rewards.survival + (car.finished ? rewards.finish : 0) - telemetry.gravelTime * rewards.gravelPenalty - telemetry.wallContacts * rewards.wallPenalty - telemetry.steerEffort * rewards.steeringPenalty;
+}
+
+export class TrainableAIController {
+  constructor(car, genome, getContext, config) {
+    this.car = car;
+    this.genome = cloneGenome(genome);
+    this.getContext = getContext;
+    this.config = mergeConfig(config);
+    this.telemetry = { aliveTime: 0, gravelTime: 0, wallContacts: 0, maxSpeed: 0, steerEffort: 0, progressCm: 0, snapshots: [] };
+    this.lastStuckTimer = 0;
+    this.bootstrapTimer = 0;
+    this.explorationSeed = Math.random() * Math.PI * 2;
+    this.workerId = nextWorkerControllerId++;
+    this.workerSnapshot = null;
+    this.pendingWorkerAction = null;
+  }
+
+  exportData() {
+    return {
+      genome: cloneGenome(this.genome),
+      config: deepClone(this.config),
+      telemetry: deepClone(this.telemetry),
+      snapshot: this.lastSnapshot || null,
+    };
+  }
+
+  importData(payload) {
+    if (payload?.genome) this.genome = cloneGenome(payload.genome);
+    if (payload?.config) this.config = mergeConfig(payload.config);
+  }
+
+  update(dt) {
+    const context = this.getContext();
+    if (!context.trackPoints?.length || this.car.finished) return;
+    const snapshot = createTrainingSnapshot(this.car, context, this.config);
+    this.lastSnapshot = snapshot;
+    const outputs = this.pendingWorkerAction || forwardPass(this.genome, snapshot.inputs);
+    this.pendingWorkerAction = null;
+    this.workerSnapshot = snapshot;
+    const bootstrapNode = snapshot.nodes[0] || { x: 0, z: 1, steepness: 0 };
+    const targetSteer = clamp(bootstrapNode.x / Math.max(8, Math.abs(bootstrapNode.z) + 4), -1, 1);
+    const isStartingFromRest = this.telemetry.aliveTime < 2.2 && this.car.spd < Math.max(4.5, this.car.data.maxSpd * 0.16);
+    const isStuck = this.car.spd < 0.35 && this.telemetry.aliveTime > 1.2;
+    let thr = clamp((outputs[0] + 1) * 0.5, 0, 1);
+    let brk = clamp((outputs[1] + 1) * 0.5, 0, 1);
+    let str = clamp(outputs[2], -1, 1);
+    if (isStartingFromRest || isStuck) {
+      this.bootstrapTimer += dt;
+      thr = Math.max(thr, 0.72);
+      brk = Math.min(brk, 0.12);
+      str = clamp(targetSteer + Math.sin(this.explorationSeed + this.telemetry.aliveTime * 4.5) * 0.18, -1, 1);
+    } else {
+      this.bootstrapTimer = Math.max(0, this.bootstrapTimer - dt * 2);
+    }
+    this.car.update({ thr, brk, str }, dt);
+    this.telemetry.aliveTime += dt;
+    this.telemetry.maxSpeed = Math.max(this.telemetry.maxSpeed, this.car.spd);
+    this.telemetry.steerEffort += Math.abs(str);
+    this.telemetry.progressCm = Math.max(this.telemetry.progressCm, this.car.progressCm || 0);
+    if (this.car.onGravel) this.telemetry.gravelTime += dt;
+    if (this.car.stuckTimer > this.lastStuckTimer && this.car.stuckTimer > 0.15) this.telemetry.wallContacts += 1;
+    this.lastStuckTimer = this.car.stuckTimer;
+    if (this.telemetry.snapshots.length < 12) this.telemetry.snapshots.push(snapshot);
+  }
+}
+
+export class TrainingManager {
+  constructor(config) {
+    this.config = mergeConfig(config);
+    this.population = [];
+    this.generation = 0;
+    this.bestEntry = null;
+    this.inputSize = null;
+    this.jokerGenome = null;
+    this.jokerRemaining = 0;
+  }
+
+  initPopulation(inputSize) {
+    this.inputSize = inputSize;
+    this.population = Array.from({ length: this.config.populationSize }, () => ({ genome: createGenome(this.config, inputSize), fitness: 0, source: 'random' }));
+    this.generation = 1;
+  }
+
+  ensurePopulation(inputSize) {
+    if (!this.population.length || this.inputSize !== inputSize) this.initPopulation(inputSize);
+  }
+
+  buildControllers(cars, getContext) {
+    if (!cars.length) return [];
+    const seedSnapshot = createTrainingSnapshot(cars[0], getContext(), this.config);
+    this.ensurePopulation(seedSnapshot.inputs.length);
+    return cars.map((car, index) => new TrainableAIController(car, this.population[index % this.population.length].genome, getContext, this.config));
+  }
+
+  getGenomeAt(index, inputSize) {
+    this.ensurePopulation(inputSize);
+    return this.population[index % this.population.length].genome;
+  }
+
+  evaluate(controllers) {
+    if (!controllers.length) return null;
+    const scored = controllers.map((controller, index) => ({
+      genome: cloneGenome(controller.genome),
+      fitness: scoreCar(controller.car, controller.telemetry, this.config),
+      telemetry: controller.exportData().telemetry,
+      carIndex: index,
+    })).sort((a, b) => b.fitness - a.fitness);
+    this.population = scored.slice(0, this.config.populationSize);
+    this.bestEntry = scored[0] || this.bestEntry;
+    if (scored[0] && this.config.jokerCarrySimulations > 0) {
+      this.jokerGenome = cloneGenome(scored[0].genome);
+      this.jokerRemaining = this.config.jokerCarrySimulations;
+      this.bestEntry.jokerRemaining = this.jokerRemaining;
+    }
+    const elites = this.population.slice(0, this.config.eliteCount).map((entry) => entry.genome);
+    const next = [];
+    if (this.jokerGenome && this.jokerRemaining > 0) {
+      next.push({ genome: cloneGenome(this.jokerGenome), fitness: 0, source: 'joker', jokerRemaining: this.jokerRemaining });
+      this.jokerRemaining -= 1;
+    }
+    for (const entry of this.population.slice(0, this.config.eliteCount)) {
+      if (next.length >= this.config.populationSize) break;
+      next.push({ genome: cloneGenome(entry.genome), fitness: 0, source: entry.source || 'elite' });
+    }
+    while (next.length < this.config.populationSize) {
+      const a = elites[Math.floor(Math.random() * elites.length)];
+      const b = elites[Math.floor(Math.random() * elites.length)];
+      next.push({ genome: mutateGenome(crossoverGenome(a, b), this.config), fitness: 0, source: 'bred' });
+    }
+    this.population = next;
+    this.generation += 1;
+    return scored[0] || null;
+  }
+
+  exportJSON() {
+    return JSON.stringify({
+      version: 1,
+      exportedAt: new Date().toISOString(),
+      config: this.config,
+      generation: this.generation,
+      bestEntry: this.bestEntry,
+      population: this.population,
+      jokerGenome: this.jokerGenome,
+      jokerRemaining: this.jokerRemaining,
+    }, null, 2);
+  }
+
+  importJSON(jsonString) {
+    const parsed = typeof jsonString === 'string' ? JSON.parse(jsonString) : jsonString;
+    this.config = mergeConfig(parsed.config || {});
+    this.population = Array.isArray(parsed.population) ? parsed.population.map((entry) => ({ genome: cloneGenome(entry.genome), fitness: +entry.fitness || 0, source: entry.source || 'imported' })) : [];
+    this.generation = Math.max(1, Math.round(parsed.generation || 1));
+    this.bestEntry = parsed.bestEntry || null;
+    this.jokerGenome = parsed.jokerGenome ? cloneGenome(parsed.jokerGenome) : null;
+    this.jokerRemaining = Math.max(0, Math.round(parsed.jokerRemaining || 0));
+    const firstGenome = this.population[0]?.genome;
+    this.inputSize = firstGenome?.meta?.inputSize || null;
+    return parsed;
+  }
+
+  saveToStorage() {
+    localStorage.setItem(TRAINING_STORAGE_KEY, this.exportJSON());
+  }
+
+  loadFromStorage() {
+    const raw = localStorage.getItem(TRAINING_STORAGE_KEY);
+    if (!raw) return null;
+    return this.importJSON(raw);
+  }
+}
+
+export function createTrainingManager(config) {
+  const manager = new TrainingManager(config);
+  try {
+    manager.loadFromStorage();
+  } catch {
+    // ignore corrupted data
+  }
+  return manager;
+}
+
+export function parseTrainingJson(jsonString) {
+  const parsed = JSON.parse(jsonString);
+  return parsed;
+}
+
+export { DEFAULT_CONFIG, TRAINING_STORAGE_KEY, mergeConfig };
+
+
+export class TrainingWorkerPool {
+  constructor() {
+    const concurrency = Math.max(2, Math.min(8, (navigator.hardwareConcurrency || 4) - 1 || 2));
+    this.controllers = new Map();
+    this.workers = Array.from({ length: concurrency }, () => {
+      const worker = new Worker(new URL('./training-worker.js', import.meta.url), { type: 'module' });
+      const entry = { worker };
+      worker.onmessage = (event) => this.handleMessage(event.data);
+      return entry;
+    });
+    this.inFlightToken = 0;
+    this.pendingResponses = 0;
+  }
+
+  register(controllers) {
+    controllers.forEach((controller) => {
+      this.controllers.set(controller.workerId, controller);
+    });
+  }
+
+  schedule(controllers) {
+    if (!this.workers.length || this.pendingResponses > 0) return;
+    const batch = (controllers || []).filter((controller) => controller && controller.workerSnapshot && !controller.car.finished);
+    if (!batch.length) return;
+    this.register(batch);
+    this.inFlightToken += 1;
+    const token = this.inFlightToken;
+    const workerCount = Math.min(this.workers.length, batch.length);
+    this.pendingResponses = workerCount;
+    for (let workerIndex = 0; workerIndex < workerCount; workerIndex += 1) {
+      const slice = batch.filter((_, index) => index % workerCount === workerIndex).map((controller) => ({
+        id: controller.workerId,
+        genome: controller.genome,
+        inputs: controller.workerSnapshot.inputs,
+      }));
+      this.workers[workerIndex].worker.postMessage({ type: 'infer', token, batch: slice });
+    }
+  }
+
+  handleMessage(message) {
+    if (message?.type !== 'infer-result' || message.token !== this.inFlightToken) return;
+    (message.results || []).forEach((result) => {
+      const controller = this.controllers.get(result.id);
+      if (controller) controller.pendingWorkerAction = result.outputs;
+    });
+    this.pendingResponses = Math.max(0, this.pendingResponses - 1);
+  }
+
+  dispose() {
+    this.workers.forEach(({ worker }) => worker.terminate());
+    this.workers = [];
+    this.pendingResponses = 0;
+    this.controllers.clear();
+  }
+}
+
+export function createTrainingWorkerPool() {
+  try {
+    if (typeof Worker === 'undefined') return null;
+    return new TrainingWorkerPool();
+  } catch {
+    return null;
+  }
+}

--- a/games/turboracing-exp/scripts/training-worker.js
+++ b/games/turboracing-exp/scripts/training-worker.js
@@ -1,0 +1,27 @@
+function sigmoid(value) {
+  return Math.tanh(value);
+}
+
+function forwardPass(genome, inputs) {
+  let activations = inputs;
+  genome.layers.forEach((layer) => {
+    activations = layer.weights.map((row, outputIndex) => {
+      let sum = layer.biases[outputIndex];
+      for (let inputIndex = 0; inputIndex < row.length; inputIndex += 1) {
+        sum += row[inputIndex] * activations[inputIndex];
+      }
+      return sigmoid(sum);
+    });
+  });
+  return activations;
+}
+
+self.onmessage = (event) => {
+  const { type, token, batch } = event.data || {};
+  if (type !== 'infer' || !Array.isArray(batch)) return;
+  const results = batch.map((entry) => ({
+    id: entry.id,
+    outputs: forwardPass(entry.genome, entry.inputs),
+  }));
+  self.postMessage({ type: 'infer-result', token, results });
+};

--- a/games/turboracing-exp/scripts/version.js
+++ b/games/turboracing-exp/scripts/version.js
@@ -1,1 +1,1 @@
-export const TURBORACING_EXP_VERSION = 'v0.96-exp';
+export const TURBORACING_EXP_VERSION = 'v0.102-exp';

--- a/games/turboracing-exp/styles/game.css
+++ b/games/turboracing-exp/styles/game.css
@@ -210,3 +210,21 @@ body{background:#000;overflow:hidden;font-family:'Rajdhani',sans-serif;color:#ff
   .ctrl-grid{grid-template-columns:1fr;font-size:11px;gap:4px;padding:14px;}
   .ctrl-grid span:nth-child(odd){margin-top:6px;}
 }
+
+#trainAiModal{position:fixed;inset:0;display:none;align-items:center;justify-content:center;background:rgba(0,0,0,.82);z-index:420;padding:16px;}
+.trainAiPanel{width:min(1100px,100%);max-height:calc(100vh - 24px);overflow:auto;background:#0a0f1c;border:1px solid #223041;border-radius:14px;padding:24px;box-shadow:0 16px 50px rgba(0,0,0,.4);}
+.trainAiPanel h2,.trainAiPanel h3{font-family:'Orbitron',monospace;letter-spacing:3px;text-transform:uppercase;}
+.trainAiPanel h2{margin-bottom:16px;color:#d3dcff;text-align:center;}
+.trainAiPanel h3{font-size:13px;color:#8fa5d3;margin:14px 0 10px;}
+.trainAiGrid{display:grid;grid-template-columns:1fr 1.3fr;gap:16px;}
+.trainAiSection{padding:14px;border:1px solid rgba(255,255,255,.06);border-radius:10px;background:rgba(255,255,255,.025);}
+.trainAiList{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:8px;}
+.trainAiPick{display:flex;align-items:center;gap:8px;padding:8px 10px;border-radius:8px;background:#0d1320;border:1px solid #1f2b3c;color:#d8e3ff;font-size:13px;}
+.trainAiPick input{accent-color:#ff5500;}
+.trainAiFields{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:10px;}
+.trainAiFields label{display:flex;flex-direction:column;gap:6px;font-size:12px;color:#a9b6d0;}
+.trainAiFields input{background:#0d1320;color:#eef3ff;border:1px solid #243246;border-radius:8px;padding:9px 10px;font:inherit;}
+.trainAiJson{width:100%;min-height:180px;background:#08101c;color:#d8f1ff;border:1px solid #223041;border-radius:10px;padding:12px;font:12px/1.45 monospace;resize:vertical;}
+.trainAiMeta,.trainAiStatus{margin-top:10px;font-size:12px;color:#95a6d0;}
+.trainAiStatus{color:#ffd28f;}
+@media (max-width: 900px){.trainAiGrid{grid-template-columns:1fr;}}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nele-pet",
-  "version": "1.0.0",
+  "version": "1.0.6",
   "private": true,
   "devDependencies": {
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
### Motivation

- Add an integrated Train-AI workflow so AIs can be evolved/trained in-situ with configurable parameters and JSON import/export. 
- Integrate training mode into the existing race lifecycle to run headless or visible simulations with configurable tick rates and population sizes. 
- Provide UI and worker-based inference to offload neural-network forward passes and allow saving/loading of generations.

### Description

- Added a new Train-AI UI and styles (`index.html` changes and new CSS rules) exposing track/car selection, simulation parameters, reward weights and JSON import/export. 
- Implemented the whole training stack in `scripts/train-ai.js` providing `TrainingManager`, `TrainableAIController`, population/genome management, mutation/crossover, scoring, and `TrainingWorkerPool` for multi-threaded inference; added a web worker `scripts/training-worker.js` to run forward passes off the main thread. 
- Reworked the AI integration: replaced the old heuristic-only `AI` behavior with a trainable `AI` that extends `TrainableAIController` (`scripts/ai-script.js`), added a fallback genome builder, and connected controller genomes to the training manager. 
- Integrated training mode across the codebase: game lifecycle (`scripts/race.js`) now supports `training` mode (track/car selection, stacked starts, hidden/visible simulation), training start/stop/import/export UI hooks in `scripts/game.js` and `scripts/menu.js`, a training-aware game loop (`scripts/game-loop.js`) and camera helpers for training freecam (`scripts/camera.js`). 
- Expanded car tracking and progress measurement in `scripts/car.js` to maintain meter and centimeter progress, improved race grid generation and flexible instantiation for variable/silent (non-player) races. 
- Added persistent training state to `scripts/state.js`, new version constant (`scripts/version.js`), and bumped package version in `package.json`.

### Testing

- No automated tests were included or executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69baa01aae348324a96c97445c905ab0)