### PR TITLE
Refactor city scenery to use corridorW instead of roadW

### DIFF
--- a/games/turborace/scripts/track-gen.js
+++ b/games/turborace/scripts/track-gen.js
@@ -848,12 +848,12 @@ function addCityScenery(curve,data){
     const p=state.trkPts[i];
     const nearX=Math.round(p.x/gs)*gs, nearZ=Math.round(p.z/gs)*gs;
     // On a vertical road? (X near gridline, Z in mid-segment)
-    if(Math.abs(p.x-nearX)<roadW*0.7){
+    if(Math.abs(p.x-nearX)<corridorW/2){
       const segZ=Math.floor(p.z/gs)*gs;
       if(p.z>segZ+intZone && p.z<segZ+gs-intZone) trackV.add(nearX+','+segZ);
     }
     // On a horizontal road?
-    if(Math.abs(p.z-nearZ)<roadW*0.7){
+    if(Math.abs(p.z-nearZ)<corridorW/2){
       const segX=Math.floor(p.x/gs)*gs;
       if(p.x>segX+intZone && p.x<segX+gs-intZone) trackH.add(segX+','+nearZ);
     }
@@ -964,7 +964,7 @@ function addCityScenery(curve,data){
   });
   const ban=new THREE.Mesh(new THREE.BoxGeometry(corridorW+2,.4,.18),gR);
   ban.position.copy(sp); ban.position.y=5.6; ban.rotation.y=ang; ban.userData.trk=true; scene.add(ban);
-  const sfLine=new THREE.Mesh(new THREE.BoxGeometry(roadW,.07,1.3),mat(0xffffff));
+  const sfLine=new THREE.Mesh(new THREE.BoxGeometry(corridorW,.07,1.3),mat(0xffffff));
   sfLine.position.copy(sp); sfLine.position.y=.07; sfLine.rotation.y=ang; sfLine.userData.trk=true; scene.add(sfLine);
 
   // ── 4. BUILDINGS ──
@@ -1038,7 +1038,6 @@ function addCityScenery(curve,data){
     const w=wps[i];
     // Skip if near start/finish
     if(Math.hypot(w[0]-sfPt.x,w[2]-sfPt.z)<sfExclude)continue;
-    if(pointInNoAutoZone(data,w[0],w[2],6))continue;
     const prev=wps[(i-1+nwp)%nwp],next=wps[(i+1)%nwp];
     const tx=next[0]-prev[0],tz=next[2]-prev[2];
     const tl=Math.sqrt(tx*tx+tz*tz)||1;


### PR DESCRIPTION
## Summary
This PR refactors the city scenery generation in the track generator to use a consistent `corridorW` variable instead of the hardcoded `roadW` calculation, and removes an unnecessary collision check.

## Key Changes
- **Replaced roadW calculations with corridorW**: Updated two road detection conditions (lines 851 and 858) from `roadW*0.7` to `corridorW/2` for consistency and clarity
- **Updated surface line geometry**: Changed the surface line (sfLine) BoxGeometry width from `roadW` to `corridorW` to match the corridor width
- **Removed redundant collision check**: Deleted the `pointInNoAutoZone()` check in the waypoint placement logic, simplifying the waypoint filtering conditions

## Implementation Details
The changes consolidate the use of `corridorW` as the single source of truth for corridor/road width calculations throughout the city scenery generation, replacing ad-hoc calculations with `roadW*0.7`. This improves code maintainability and ensures consistent corridor sizing across all scenery elements.

https://claude.ai/code/session_01Mx1wifvU1obhhpDpNSoztX