### PR TITLE
Bomber: fix presence/joining, open rooms list, private rooms, layout cleanup

### DIFF
--- a/games/bomberman/index.html
+++ b/games/bomberman/index.html
@@ -12,27 +12,41 @@
     <h1>💣 Bomber</h1>
     <p class="subtitle">Online Multiplayer · 2–4 Players</p>
 
-    <!-- Shown when an arcade account is detected -->
-    <div id="account-row" class="hidden account-row">
-      <p class="account-label">Playing as</p>
-      <p class="account-name" id="account-display"></p>
+    <!-- Logged-in account display -->
+    <div id="account-display" class="account-display hidden">
+      Playing as <strong id="account-name"></strong>
     </div>
 
-    <!-- Shown when no arcade account is found -->
-    <div id="guest-row">
-      <input id="guest-name-input" type="text" placeholder="Your name" maxlength="16" autocomplete="off">
+    <!-- Shown when no arcade account detected -->
+    <div id="login-prompt" class="login-prompt hidden">
+      <p>Log in to the <a href="/games/">Arcade</a> to play.</p>
     </div>
 
+    <!-- Create / join -->
     <div class="room-actions">
-      <button id="create-btn" class="btn primary">Create Room</button>
-      <div class="divider">— or join an existing one —</div>
+      <div class="create-row">
+        <button id="create-btn" class="btn primary" disabled>Create Room</button>
+        <label class="private-label">
+          <input type="checkbox" id="private-toggle">
+          <span>Private</span>
+        </label>
+      </div>
+      <div class="divider">— or join with a code —</div>
       <div class="join-row">
         <input id="room-code-input" type="text" placeholder="XXXX" maxlength="4" autocomplete="off">
-        <button id="join-btn" class="btn">Join</button>
+        <button id="join-btn" class="btn" disabled>Join</button>
       </div>
     </div>
 
     <p id="status-msg"></p>
+
+    <!-- Open rooms list -->
+    <div class="rooms-section">
+      <h3 class="rooms-title">Open Rooms</h3>
+      <div id="room-list" class="room-list">
+        <p class="rooms-empty">Loading…</p>
+      </div>
+    </div>
 
     <p class="subtitle">WASD / ↑↓←→ to move &nbsp;·&nbsp; Space or F to place bomb</p>
     <a href="/games/" class="btn">← Back to Arcade</a>

--- a/games/bomberman/lobby.html
+++ b/games/bomberman/lobby.html
@@ -17,6 +17,7 @@
         <div class="room-code-block">
           <span class="room-label">Room</span>
           <span id="room-code-display" class="room-code" title="Click to copy"></span>
+          <span id="private-badge" class="private-badge hidden">Private</span>
         </div>
         <button id="copy-link-btn" class="btn small">🔗 Copy link</button>
       </div>
@@ -33,8 +34,9 @@
 
     <div class="lobby-actions">
       <button id="back-btn" class="btn">← Back</button>
-      <button id="start-btn" class="btn primary hidden">▶ Start Game</button>
+      <button id="start-btn" class="btn primary" disabled>▶ Start Game</button>
     </div>
+
   </div>
 
   <!-- ── Game ───────────────────────────────────────────────────────────────── -->

--- a/games/bomberman/scripts/home.js
+++ b/games/bomberman/scripts/home.js
@@ -1,14 +1,12 @@
 import { supabase } from './supabase.js';
 
-// ─── Arcade account lookup (same pattern as turborace/user.js) ───────────────
-async function getArcadePlayerName() {
-  // 1. Check localStorage cache (set by arcade.js on login)
+// ─── Arcade account lookup ────────────────────────────────────────────────────
+async function getArcadeUser() {
   try {
     const cached = JSON.parse(localStorage.getItem('arcade_user') || 'null');
-    if (cached?.name) return cached.name;
+    if (cached?.name) return cached;
   } catch { /* ignore */ }
 
-  // 2. Fall back to live Supabase session
   const { data } = await supabase.auth.getSession();
   const user = data?.session?.user;
   if (!user) return null;
@@ -16,18 +14,14 @@ async function getArcadePlayerName() {
   const name = user.user_metadata?.username
     || user.email?.split('@')[0]
     || 'Player';
-
-  // Cache it for future page loads
-  localStorage.setItem('arcade_user', JSON.stringify({
-    user_id: user.id,
-    name,
-    email: user.email,
-  }));
-  return name;
+  const arcadeUser = { user_id: user.id, name, email: user.email };
+  localStorage.setItem('arcade_user', JSON.stringify(arcadeUser));
+  return arcadeUser;
 }
 
 // ─── DOM ──────────────────────────────────────────────────────────────────────
 const $ = id => document.getElementById(id);
+let currentPlayerName = null;
 
 function setStatus(msg, err = false) {
   const el = $('status-msg');
@@ -35,49 +29,111 @@ function setStatus(msg, err = false) {
   el.style.color = err ? '#ff4444' : '#aaa8cc';
 }
 
-function getPlayerName() {
-  // Prefer logged-in account name
-  try {
-    const cached = JSON.parse(localStorage.getItem('arcade_user') || 'null');
-    if (cached?.name) return cached.name;
-  } catch { /* ignore */ }
-  return $('guest-name-input').value.trim() || null;
+function goToLobby(roomCode, playerName, host = false, isPrivate = false) {
+  const p = new URLSearchParams({ room: roomCode, name: playerName });
+  if (host)      p.set('host', '1');
+  if (isPrivate) p.set('private', '1');
+  location.href = `lobby.html?${p}`;
 }
 
-function goToLobby(roomCode, playerName, host = false) {
-  const params = new URLSearchParams({ room: roomCode, name: playerName });
-  if (host) params.set('host', '1');
-  location.href = `lobby.html?${params}`;
+// ─── Public rooms list ────────────────────────────────────────────────────────
+async function loadRooms() {
+  const { data, error } = await supabase
+    .from('bomberman_rooms')
+    .select('*')
+    .eq('status', 'waiting')
+    .gte('created_at', new Date(Date.now() - 30 * 60 * 1000).toISOString()) // max 30 min old
+    .order('created_at', { ascending: false })
+    .limit(6);
+
+  if (error) {
+    console.warn('Could not load rooms:', error.message);
+    renderRoomList([]);
+    return;
+  }
+  renderRoomList(data ?? []);
 }
 
-// ─── Init: detect arcade account ─────────────────────────────────────────────
+function renderRoomList(rooms) {
+  const list = $('room-list');
+  list.innerHTML = '';
+
+  if (rooms.length === 0) {
+    list.innerHTML = '<p class="rooms-empty">No open rooms right now — create one!</p>';
+    return;
+  }
+
+  for (const room of rooms) {
+    const row = document.createElement('div');
+    row.className = 'room-row';
+    row.innerHTML = `
+      <span class="room-row-host">${escHtml(room.host_name)}</span>
+      <span class="room-row-count">${room.player_count}/4 players</span>
+      <span class="room-row-code">${room.code}</span>
+    `;
+    const btn = document.createElement('button');
+    btn.className = 'btn small';
+    btn.textContent = 'Join';
+    btn.addEventListener('click', () => {
+      if (!currentPlayerName) { setStatus('Log in to the Arcade first!', true); return; }
+      goToLobby(room.code, currentPlayerName, false, false);
+    });
+    row.appendChild(btn);
+    list.appendChild(row);
+  }
+}
+
+function escHtml(str) {
+  return str.replace(/[&<>"']/g, c => ({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;' }[c]));
+}
+
+function subscribeRooms() {
+  supabase
+    .channel('bomberman_rooms_watch')
+    .on('postgres_changes', { event: '*', schema: 'public', table: 'bomberman_rooms' }, loadRooms)
+    .subscribe();
+}
+
+// ─── Init ─────────────────────────────────────────────────────────────────────
 (async () => {
-  const name = await getArcadePlayerName();
-  if (name) {
-    $('account-display').textContent = name;
-    $('account-row').classList.remove('hidden');
-    $('guest-row').classList.add('hidden');
+  // Detect arcade account
+  const user = await getArcadeUser();
+  if (user?.name) {
+    currentPlayerName = user.name;
+    $('account-name').textContent = user.name;
+    $('account-display').classList.remove('hidden');
+    $('login-prompt').classList.add('hidden');
+    $('create-btn').disabled = false;
+    $('join-btn').disabled   = false;
+  } else {
+    $('account-display').classList.add('hidden');
+    $('login-prompt').classList.remove('hidden');
+    $('create-btn').disabled = true;
+    $('join-btn').disabled   = true;
   }
 
   // Pre-fill room code from invite link (?room=CODE)
   const inviteRoom = new URLSearchParams(location.search).get('room');
   if (inviteRoom) $('room-code-input').value = inviteRoom.slice(0, 4).toUpperCase();
+
+  // Load public rooms
+  await loadRooms();
+  subscribeRooms();
 })();
 
 // ─── Buttons ──────────────────────────────────────────────────────────────────
 $('create-btn').addEventListener('click', () => {
-  const name = getPlayerName();
-  if (!name) { setStatus('Enter your name first!', true); return; }
+  if (!currentPlayerName) { setStatus('Log in to the Arcade first!', true); return; }
+  const isPrivate = $('private-toggle').checked;
   const code = Math.random().toString(36).slice(2, 6).toUpperCase();
-  goToLobby(code, name, true);
+  goToLobby(code, currentPlayerName, true, isPrivate);
 });
 
 $('join-btn').addEventListener('click', () => {
-  const name = getPlayerName();
+  if (!currentPlayerName) { setStatus('Log in to the Arcade first!', true); return; }
   const code = $('room-code-input').value.trim().toUpperCase();
-  if (!name) { setStatus('Enter your name first!', true); return; }
   if (code.length !== 4) { setStatus('Enter a valid 4-letter room code!', true); return; }
-  goToLobby(code, name, false);
+  goToLobby(code, currentPlayerName, false, false);
 });
 
 $('room-code-input').addEventListener('keydown', e => {

--- a/games/bomberman/scripts/lobby.js
+++ b/games/bomberman/scripts/lobby.js
@@ -1,15 +1,16 @@
 import { GameState, createMap, BOMB_FUSE, PLAYER_COLORS } from './game.js';
-import { Renderer } from './renderer.js';
-import { Network }  from './network.js';
+import { Renderer }  from './renderer.js';
+import { Network }   from './network.js';
 import { AIPlayer, BOT_NAMES } from './ai.js';
+import { supabase }  from './supabase.js';
 
 // ─── URL params ───────────────────────────────────────────────────────────────
 const params     = new URLSearchParams(location.search);
 const roomCode   = params.get('room')?.slice(0, 4).toUpperCase();
 const playerName = decodeURIComponent(params.get('name') || '').trim();
 const isHost     = params.has('host');
+const isPrivate  = params.has('private');
 
-// Redirect back if params are missing
 if (!roomCode || !playerName) location.replace('index.html');
 
 // ─── Core objects ─────────────────────────────────────────────────────────────
@@ -19,12 +20,10 @@ let renderer    = null;
 let myPlayer    = null;
 let gameRunning = false;
 
-// Lobby state
-let lobbyRealPlayers = []; // from Supabase presence
-let lobbyAIPlayers   = []; // { id, name, isAI: true } — managed by host
-let aiInstances      = []; // AIPlayer[]  — only on host
+let lobbyRealPlayers = [];
+let lobbyAIPlayers   = [];
+let aiInstances      = [];
 
-// Input
 const keys = {};
 let lastMoveTime = 0;
 const MOVE_COOLDOWN = 130;
@@ -35,12 +34,43 @@ const $ = id => document.getElementById(id);
 
 function showSection(name) {
   ['lobby', 'game', 'result'].forEach(s => {
-    $(`${s}-section`).classList.toggle('hidden',   s !== name);
-    $(`${s}-section`).classList.toggle('active',   s === name);
+    $(`${s}-section`).classList.toggle('hidden', s !== name);
+    $(`${s}-section`).classList.toggle('active', s === name);
   });
 }
 
+// ─── Room database helpers (public rooms only) ────────────────────────────────
+async function dbRegisterRoom() {
+  if (!isHost || isPrivate) return;
+  await supabase.from('bomberman_rooms').upsert(
+    { code: roomCode, host_name: playerName, player_count: 1, status: 'waiting' },
+    { onConflict: 'code' }
+  );
+}
+
+async function dbUpdatePlayerCount(n) {
+  if (!isHost || isPrivate) return;
+  await supabase.from('bomberman_rooms').update({ player_count: n }).eq('code', roomCode);
+}
+
+async function dbMarkStarted() {
+  if (!isHost || isPrivate) return;
+  await supabase.from('bomberman_rooms').update({ status: 'started' }).eq('code', roomCode);
+}
+
+async function dbDeleteRoom() {
+  if (!isHost || isPrivate) return;
+  await supabase.from('bomberman_rooms').delete().eq('code', roomCode);
+}
+
 // ─── Lobby UI ─────────────────────────────────────────────────────────────────
+function el(tag, cls, text = '') {
+  const e = document.createElement(tag);
+  if (cls) e.className = cls;
+  if (text) e.textContent = text;
+  return e;
+}
+
 function renderSlots() {
   const all = [...lobbyRealPlayers, ...lobbyAIPlayers];
 
@@ -55,7 +85,7 @@ function renderSlots() {
       slot.classList.add('slot-filled');
       slot.style.setProperty('--color', PLAYER_COLORS[i]);
 
-      const dot  = el('span', 'slot-dot');
+      const dot   = el('span', 'slot-dot');
       const label = el('span', 'slot-name',
         (p.isAI ? '🤖 ' : '') + p.name + (!p.isAI && p.isHost ? ' 👑' : ''));
       slot.append(dot, label);
@@ -79,21 +109,21 @@ function renderSlots() {
 
   const total    = all.length;
   const canStart = isHost && total >= 2;
-  $('start-btn').classList.toggle('hidden', !canStart);
+
+  // Start button: always visible, disabled when not ready
+  const startBtn = $('start-btn');
+  startBtn.disabled = !canStart;
+
   $('lobby-msg').textContent = isHost
     ? (total >= 2 ? `${total} players ready!` : 'Add 1 more player or bot to start.')
     : 'Waiting for host to start the game…';
 }
 
-function el(tag, cls, text = '') {
-  const e = document.createElement(tag);
-  if (cls) e.className = cls;
-  if (text) e.textContent = text;
-  return e;
-}
-
 function updateRoomDisplay() {
   $('room-code-display').textContent = roomCode;
+  // Show private badge if applicable
+  const badge = $('private-badge');
+  if (badge) badge.classList.toggle('hidden', !isPrivate);
 }
 
 // ─── AI management ────────────────────────────────────────────────────────────
@@ -124,6 +154,7 @@ async function startGame() {
   const map         = createMap(Date.now());
   const playerOrder = all.map(p => ({ id: p.id, name: p.name, isAI: !!p.isAI }));
 
+  await dbMarkStarted();
   beginGame(map, playerOrder);
   await net.sendGameStart(map, playerOrder);
 }
@@ -146,7 +177,6 @@ function beginGame(map, playerOrder) {
 
 // ─── In-game network events ───────────────────────────────────────────────────
 function handlePlayerMove({ id, tileX, tileY }) {
-  // Apply moves for any player that isn't me (includes remote AI from host)
   const p = state.players.get(id);
   if (p && id !== net.myId) p.startMove(tileX, tileY, Date.now());
 }
@@ -171,7 +201,7 @@ function handlePowerupCollected({ playerId, tileX, tileY }) {
 function handleGameEnd({ winnerId }) {
   gameRunning = false;
   const winner = winnerId ? state.players.get(winnerId) : null;
-  $('result-title').textContent = winner ? `${winner.name} wins! 🎉` : "It's a draw! 💥";
+  $('result-title').textContent    = winner ? `${winner.name} wins! 🎉` : "It's a draw! 💥";
   $('result-subtitle').textContent = winner
     ? `${winner.name} was the last one standing.`
     : 'Everyone eliminated at the same time.';
@@ -197,12 +227,8 @@ function triggerExplosion(bombId) {
 
   updateHUD();
 
-  // Each human self-reports only their own death
-  if (myPlayer && wasMyPlayerAlive && !myPlayer.alive) {
-    net.sendPlayerDead(net.myId);
-  }
+  if (myPlayer && wasMyPlayerAlive && !myPlayer.alive) net.sendPlayerDead(net.myId);
 
-  // Host also reports AI deaths
   if (isHost) {
     for (const id of justKilled) {
       if (id.startsWith('ai-')) net.sendAnyPlayerDead(id);
@@ -276,7 +302,6 @@ function gameLoop() {
   if (!gameRunning) return;
   const now = Date.now();
 
-  // AI updates (host only)
   if (isHost) {
     for (const ai of aiInstances) {
       ai.update(state, now, net, (bombId, delay) => {
@@ -294,8 +319,8 @@ function gameLoop() {
 
 // ─── HUD ──────────────────────────────────────────────────────────────────────
 function updateHUD() {
-  const el = $('player-stats');
-  el.innerHTML = '';
+  const hudEl = $('player-stats');
+  hudEl.innerHTML = '';
   let i = 0;
   for (const [, p] of state.players) {
     const chip = document.createElement('div');
@@ -306,7 +331,7 @@ function updateHUD() {
       <span class="chip-name">${p.name}</span>
       <span class="chip-info">🔥${p.bombRange} 💣${p.maxBombs}</span>
     `;
-    el.appendChild(chip);
+    hudEl.appendChild(chip);
   }
 }
 
@@ -314,11 +339,13 @@ function updateHUD() {
 async function init() {
   updateRoomDisplay();
   showSection('lobby');
+  renderSlots(); // initial render (empty, but shows structure)
 
-  // Wire callbacks before joining
   net.onPresenceUpdate = players => {
     lobbyRealPlayers = players;
     renderSlots();
+    // Host keeps room player count in sync
+    if (isHost && !isPrivate) dbUpdatePlayerCount(players.length);
   };
   net.onAIUpdate = ({ aiPlayers }) => {
     lobbyAIPlayers = aiPlayers ?? [];
@@ -331,11 +358,25 @@ async function init() {
   net.onPowerupCollected  = handlePowerupCollected;
   net.onGameEnd           = handleGameEnd;
 
-  await net.joinRoom(roomCode, playerName, isHost);
+  try {
+    await net.joinRoom(roomCode, playerName, isHost);
+  } catch (e) {
+    $('lobby-msg').textContent = `Connection failed: ${e.message}. Try refreshing.`;
+    return;
+  }
 
-  // Force-refresh lobby list (presence sync may have fired during async join)
+  // Register public room in database
+  if (isHost) await dbRegisterRoom();
+
+  // Immediate presence refresh (sync may have already fired during join)
   lobbyRealPlayers = net.getPresencePlayers();
   renderSlots();
+
+  // Delayed fallback: presence state sometimes lags one round-trip behind track()
+  setTimeout(() => {
+    lobbyRealPlayers = net.getPresencePlayers();
+    renderSlots();
+  }, 800);
 }
 
 // ─── Button wiring ────────────────────────────────────────────────────────────
@@ -343,30 +384,30 @@ $('start-btn').addEventListener('click', startGame);
 
 $('back-btn').addEventListener('click', async e => {
   e.preventDefault();
+  await dbDeleteRoom();
   await net.leave();
   location.href = 'index.html';
 });
 
 $('play-again-btn').addEventListener('click', () => {
-  // Reset game state and go back to lobby view in-page (same channel)
   gameRunning = false;
   showSection('lobby');
   renderSlots();
-  // Re-send AI list to sync (host may want to add/remove bots)
-  if (isHost) net.sendAIUpdate(lobbyAIPlayers);
+  if (isHost) {
+    net.sendAIUpdate(lobbyAIPlayers);
+    // Re-open room in database if public
+    if (!isPrivate) dbRegisterRoom();
+  }
 });
 
-// Copy room code
 $('room-code-display').addEventListener('click', async () => {
-  const code = roomCode;
   try {
-    await navigator.clipboard.writeText(code);
+    await navigator.clipboard.writeText(roomCode);
     $('room-code-display').textContent = 'Copied!';
-    setTimeout(() => { $('room-code-display').textContent = code; }, 1200);
+    setTimeout(() => { $('room-code-display').textContent = roomCode; }, 1200);
   } catch { /* ignore */ }
 });
 
-// Copy invite link
 $('copy-link-btn').addEventListener('click', async () => {
   const url = `${location.origin}/games/bomberman/?room=${roomCode}`;
   const btn = $('copy-link-btn');
@@ -375,6 +416,14 @@ $('copy-link-btn').addEventListener('click', async () => {
     btn.textContent = '✓ Copied!';
     setTimeout(() => { btn.textContent = '🔗 Copy link'; }, 1800);
   } catch { /* ignore */ }
+});
+
+// Clean up room if tab/window closes
+window.addEventListener('beforeunload', () => {
+  if (isHost && !isPrivate) {
+    // Best-effort delete on page unload (may not always fire)
+    navigator.sendBeacon && supabase.from('bomberman_rooms').delete().eq('code', roomCode);
+  }
 });
 
 init();

--- a/games/bomberman/scripts/network.js
+++ b/games/bomberman/scripts/network.js
@@ -8,7 +8,7 @@ export class Network {
 
     // Callbacks — set before joinRoom()
     this.onPresenceUpdate    = null;
-    this.onAIUpdate          = null;   // { aiPlayers }
+    this.onAIUpdate          = null;
     this.onGameStart         = null;
     this.onPlayerMove        = null;
     this.onBombPlaced        = null;
@@ -27,15 +27,17 @@ export class Network {
       },
     });
 
-    // Presence — lobby player list
-    this.channel.on('presence', { event: 'sync' }, () => {
-      if (this.onPresenceUpdate) {
-        const players = Object.values(this.channel.presenceState()).flat();
-        this.onPresenceUpdate(players);
-      }
-    });
+    // ── Presence — fire on sync, join, AND leave for reliability ──────────
+    const refreshPresence = () => {
+      if (!this.onPresenceUpdate) return;
+      const players = Object.values(this.channel.presenceState()).flat();
+      this.onPresenceUpdate(players);
+    };
+    this.channel.on('presence', { event: 'sync'  }, refreshPresence);
+    this.channel.on('presence', { event: 'join'  }, refreshPresence);
+    this.channel.on('presence', { event: 'leave' }, refreshPresence);
 
-    // Broadcast events
+    // ── Broadcast events ───────────────────────────────────────────────────
     const on = (event, cb) =>
       this.channel.on('broadcast', { event }, ({ payload }) => cb?.(payload));
 
@@ -47,12 +49,18 @@ export class Network {
     on('powerup_collected', p => this.onPowerupCollected?.(p));
     on('game_end',          p => this.onGameEnd?.(p));
 
-    // Subscribe and announce presence
-    await new Promise(resolve => {
+    // ── Subscribe then track presence ──────────────────────────────────────
+    await new Promise((resolve, reject) => {
       this.channel.subscribe(async status => {
         if (status === 'SUBSCRIBED') {
-          await this.channel.track({ id: this.myId, name: playerName, isHost });
+          try {
+            await this.channel.track({ id: this.myId, name: playerName, isHost });
+          } catch (e) {
+            console.warn('presence track failed:', e);
+          }
           resolve();
+        } else if (status === 'CHANNEL_ERROR' || status === 'TIMED_OUT') {
+          reject(new Error(`Channel ${status}`));
         }
       });
     });
@@ -64,7 +72,6 @@ export class Network {
   }
 
   // ── Lobby ──────────────────────────────────────────────────────────────────
-  /** Host broadcasts current AI player list to sync all lobby UIs */
   sendAIUpdate(aiPlayers) {
     return this.#send('ai_update', { aiPlayers });
   }
@@ -95,17 +102,14 @@ export class Network {
   }
 
   // ── Game — AI / any player (host only) ────────────────────────────────────
-  /** Broadcast a move on behalf of any player id (used for AI) */
   sendAnyMove(id, tileX, tileY) {
     return this.#send('player_move', { id, tileX, tileY });
   }
 
-  /** Broadcast a bomb placement on behalf of any player id (used for AI) */
   sendAnyBomb(bombId, placedBy, tileX, tileY, explodesAt, range) {
     return this.#send('bomb_placed', { bombId, placedBy, tileX, tileY, explodesAt, range });
   }
 
-  /** Broadcast death on behalf of any player id (used for AI) */
   sendAnyPlayerDead(id) {
     return this.#send('player_dead', { id });
   }

--- a/games/bomberman/styles/bomberman.css
+++ b/games/bomberman/styles/bomberman.css
@@ -13,13 +13,14 @@ body {
 }
 
 /* ─── Screens ──────────────────────────────────────────────────────────────── */
-.screen { display: none; width: 100%; }
-.screen.active { display: flex; flex-direction: column; align-items: center; gap: 1.1rem; }
-.screen.hidden { display: none !important; }
+.screen         { display: none; width: 100%; }
+.screen.active  { display: flex; flex-direction: column; align-items: center; gap: 1rem; }
+.screen.hidden  { display: none !important; }
+.hidden         { display: none !important; }
 
-/* ─── Shared elements ──────────────────────────────────────────────────────── */
+/* ─── Typography ───────────────────────────────────────────────────────────── */
 h1 {
-  font-size: 2.6rem;
+  font-size: 2.4rem;
   letter-spacing: 0.04em;
   background: linear-gradient(135deg, #a78bfa, #60a5fa, #34d399);
   -webkit-background-clip: text;
@@ -30,28 +31,28 @@ h1 {
 
 .subtitle {
   color: #7c78a8;
-  font-size: 0.85rem;
+  font-size: 0.82rem;
   text-align: center;
   letter-spacing: 0.05em;
 }
 
-/* Inputs */
+/* ─── Inputs ───────────────────────────────────────────────────────────────── */
 input[type="text"] {
   width: 100%;
   background: rgba(255,255,255,0.06);
   border: 1px solid rgba(167,139,250,0.3);
   border-radius: 8px;
-  padding: 0.6rem 1rem;
+  padding: 0.55rem 1rem;
   color: #e2dff8;
   font-family: inherit;
   font-size: 1rem;
   outline: none;
   transition: border-color 0.2s;
 }
-input[type="text"]:focus { border-color: #a78bfa; }
+input[type="text"]:focus   { border-color: #a78bfa; }
 input[type="text"]::placeholder { color: #4e4a72; }
 
-/* Buttons */
+/* ─── Buttons ──────────────────────────────────────────────────────────────── */
 .btn {
   display: inline-flex;
   align-items: center;
@@ -62,83 +63,133 @@ input[type="text"]::placeholder { color: #4e4a72; }
   background: rgba(255,255,255,0.05);
   color: #c8c4e8;
   font-family: inherit;
-  font-size: 0.95rem;
+  font-size: 0.92rem;
   cursor: pointer;
   text-decoration: none;
   transition: background 0.15s, border-color 0.15s, box-shadow 0.15s;
   white-space: nowrap;
 }
-.btn:hover { background: rgba(167,139,250,0.12); border-color: #a78bfa; }
+.btn:hover:not(:disabled) { background: rgba(167,139,250,0.12); border-color: #a78bfa; }
 .btn.primary {
   background: linear-gradient(135deg, #7c3aed, #3b82f6);
   border: none;
   color: #fff;
   font-weight: 700;
 }
-.btn.primary:hover { box-shadow: 0 0 18px rgba(124,58,237,0.5); }
-.btn.small { padding: 0.35rem 0.9rem; font-size: 0.82rem; }
-.btn.hidden { display: none !important; }
+.btn.primary:hover:not(:disabled) { box-shadow: 0 0 18px rgba(124,58,237,0.5); }
+.btn.small   { padding: 0.32rem 0.85rem; font-size: 0.8rem; }
+.btn:disabled {
+  opacity: 0.38;
+  cursor: not-allowed;
+  filter: grayscale(0.4);
+}
 
 /* ─── Home screen ──────────────────────────────────────────────────────────── */
 #home-section {
-  max-width: 420px;
-  padding: 2.5rem 2rem;
+  max-width: 440px;
+  width: 100%;
+  padding: 2rem 1.5rem;
 }
 
-/* Arcade account display */
-.account-row { text-align: center; }
-.account-label { font-size: 0.78rem; color: #7c78a8; letter-spacing: 0.05em; }
-.account-name {
-  font-size: 1.1rem;
-  font-weight: 700;
-  color: #a78bfa;
-  margin-top: 0.15rem;
-}
-
-.hidden { display: none !important; }
-
-/* Room actions */
-.room-actions { width: 100%; display: flex; flex-direction: column; gap: 0.75rem; }
-
-.divider {
+.account-display {
+  font-size: 0.85rem;
+  color: #7c78a8;
   text-align: center;
-  color: #4e4a72;
-  font-size: 0.8rem;
-  letter-spacing: 0.05em;
 }
+.account-display strong { color: #a78bfa; font-size: 1rem; }
+
+.login-prompt {
+  font-size: 0.85rem;
+  color: #7c78a8;
+  text-align: center;
+  padding: 0.6rem 1rem;
+  border: 1px solid rgba(255,100,100,0.25);
+  border-radius: 8px;
+  background: rgba(255,70,70,0.05);
+}
+.login-prompt a { color: #a78bfa; text-decoration: underline; }
+
+/* Create/join area */
+.room-actions { width: 100%; display: flex; flex-direction: column; gap: 0.65rem; }
+
+.create-row { display: flex; align-items: center; gap: 0.75rem; }
+.create-row .btn { flex: 1; }
+
+.private-label {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.82rem;
+  color: #7c78a8;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.private-label input { accent-color: #a78bfa; cursor: pointer; }
+
+.divider { text-align: center; color: #4e4a72; font-size: 0.78rem; letter-spacing: 0.05em; }
 
 .join-row { display: flex; gap: 0.5rem; }
 .join-row input { flex: 1; text-transform: uppercase; letter-spacing: 0.15em; }
 
-#status-msg { min-height: 1.2em; font-size: 0.85rem; text-align: center; color: #aaa8cc; }
+#status-msg { min-height: 1.1em; font-size: 0.82rem; text-align: center; color: #aaa8cc; }
+
+/* Open rooms list */
+.rooms-section { width: 100%; }
+
+.rooms-title {
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #5e5a82;
+  margin-bottom: 0.5rem;
+  text-align: center;
+}
+
+.room-list { display: flex; flex-direction: column; gap: 0.4rem; min-height: 2.5rem; }
+
+.rooms-empty { text-align: center; font-size: 0.82rem; color: #4e4a72; padding: 0.5rem; }
+
+.room-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: rgba(255,255,255,0.04);
+  border: 1px solid rgba(167,139,250,0.15);
+  border-radius: 8px;
+  padding: 0.45rem 0.75rem;
+  font-size: 0.82rem;
+}
+.room-row-host  { flex: 1; font-weight: 600; color: #c8c4e8; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.room-row-count { color: #7c78a8; white-space: nowrap; }
+.room-row-code  { font-weight: 700; letter-spacing: 0.12em; color: #a78bfa; width: 3em; text-align: center; }
 
 /* ─── Lobby screen ─────────────────────────────────────────────────────────── */
 #lobby-section {
   max-width: 500px;
+  width: 100%;
   padding: 2rem 1.5rem;
 }
 
-.lobby-top { width: 100%; display: flex; flex-direction: column; align-items: center; gap: 0.8rem; }
+.lobby-top { width: 100%; display: flex; flex-direction: column; align-items: center; gap: 0.75rem; }
 
-/* Room header */
 .room-header {
   display: flex;
   align-items: center;
-  gap: 0.8rem;
+  gap: 0.75rem;
   background: rgba(255,255,255,0.04);
   border: 1px solid rgba(167,139,250,0.2);
   border-radius: 12px;
-  padding: 0.6rem 1rem;
+  padding: 0.55rem 1rem;
   width: 100%;
 }
 
-.room-code-block { display: flex; align-items: baseline; gap: 0.5rem; flex: 1; }
-.room-label { font-size: 0.75rem; color: #7c78a8; letter-spacing: 0.08em; text-transform: uppercase; }
+.room-code-block { display: flex; align-items: center; gap: 0.5rem; flex: 1; min-width: 0; }
+.room-label { font-size: 0.72rem; color: #7c78a8; letter-spacing: 0.08em; text-transform: uppercase; flex-shrink: 0; }
 
 .room-code {
-  font-size: 1.6rem;
+  font-size: 1.5rem;
   font-weight: 700;
-  letter-spacing: 0.18em;
+  letter-spacing: 0.2em;
   color: #a78bfa;
   cursor: pointer;
   border-radius: 4px;
@@ -146,6 +197,16 @@ input[type="text"]::placeholder { color: #4e4a72; }
   transition: background 0.15s;
 }
 .room-code:hover { background: rgba(167,139,250,0.12); }
+
+.private-badge {
+  font-size: 0.68rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #ff9f7f;
+  border: 1px solid rgba(255,159,127,0.4);
+  border-radius: 4px;
+  padding: 0.1em 0.4em;
+}
 
 /* Player slots */
 .player-slots {
@@ -156,13 +217,12 @@ input[type="text"]::placeholder { color: #4e4a72; }
 }
 
 .slot {
-  height: 62px;
+  height: 60px;
   border-radius: 12px;
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0 0.9rem;
-  transition: background 0.15s, border-color 0.15s;
+  padding: 0 0.85rem;
   position: relative;
   overflow: hidden;
 }
@@ -170,33 +230,33 @@ input[type="text"]::placeholder { color: #4e4a72; }
 .slot-filled {
   background: rgba(255,255,255,0.05);
   border: 1.5px solid var(--color, #a78bfa);
-  box-shadow: 0 0 12px -4px var(--color, #a78bfa);
+  box-shadow: 0 0 10px -4px var(--color, #a78bfa);
 }
 
 .slot-empty {
-  border: 2px dashed rgba(167,139,250,0.35);
+  border: 2px dashed rgba(167,139,250,0.3);
   background: rgba(167,139,250,0.03);
   justify-content: center;
   cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
 }
 .slot-empty:hover { background: rgba(167,139,250,0.08); border-color: #a78bfa; }
 
 .slot-passive {
-  border: 2px dashed rgba(255,255,255,0.08);
+  border: 2px dashed rgba(255,255,255,0.07);
   justify-content: center;
 }
 
 .slot-dot {
-  width: 11px;
-  height: 11px;
+  width: 10px; height: 10px;
   border-radius: 50%;
   background: var(--color, #888);
-  box-shadow: 0 0 6px var(--color, #888);
+  box-shadow: 0 0 5px var(--color, #888);
   flex-shrink: 0;
 }
 
 .slot-name {
-  font-size: 0.9rem;
+  font-size: 0.88rem;
   font-weight: 600;
   color: #e2dff8;
   flex: 1;
@@ -206,12 +266,12 @@ input[type="text"]::placeholder { color: #4e4a72; }
 }
 
 .slot-remove {
-  background: rgba(255,70,70,0.15);
+  background: rgba(255,70,70,0.14);
   border: 1px solid rgba(255,70,70,0.3);
   color: #ff7070;
   border-radius: 6px;
-  padding: 0.2rem 0.45rem;
-  font-size: 0.75rem;
+  padding: 0.18rem 0.42rem;
+  font-size: 0.72rem;
   cursor: pointer;
   flex-shrink: 0;
   transition: background 0.15s;
@@ -223,22 +283,20 @@ input[type="text"]::placeholder { color: #4e4a72; }
   border: none;
   color: #7c78a8;
   font-family: inherit;
-  font-size: 0.88rem;
-  cursor: pointer;
+  font-size: 0.86rem;
+  cursor: inherit;
   letter-spacing: 0.03em;
   transition: color 0.15s;
 }
 .slot-empty:hover .slot-add-btn { color: #a78bfa; }
 
-.slot-empty-label { color: #3a3860; font-size: 1rem; }
+.slot-empty-label { color: #2e2c4a; font-size: 1rem; }
 
-/* Lobby footer */
 .lobby-msg { font-size: 0.82rem; color: #5e5a82; text-align: center; min-height: 1.2em; }
 
 .lobby-actions {
   display: flex;
-  justify-content: space-between;
-  gap: 0.8rem;
+  gap: 0.75rem;
   width: 100%;
 }
 .lobby-actions .btn { flex: 1; }
@@ -253,43 +311,33 @@ input[type="text"]::placeholder { color: #4e4a72; }
 
 #game-header { display: flex; justify-content: center; width: 100%; }
 
-#player-stats {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.4rem;
-  justify-content: center;
-}
+#player-stats { display: flex; flex-wrap: wrap; gap: 0.4rem; justify-content: center; }
 
 .stat-chip {
   display: flex;
   align-items: center;
-  gap: 0.35rem;
-  padding: 0.25rem 0.6rem;
+  gap: 0.32rem;
+  padding: 0.22rem 0.55rem;
   border-radius: 20px;
   border: 1px solid var(--player-color, #888);
-  font-size: 0.78rem;
+  font-size: 0.76rem;
   background: rgba(255,255,255,0.04);
   transition: opacity 0.3s;
 }
-.stat-chip.dead { opacity: 0.3; text-decoration: line-through; filter: grayscale(0.8); }
-.chip-dot {
-  width: 8px; height: 8px;
-  border-radius: 50%;
-  background: var(--player-color, #888);
-  box-shadow: 0 0 5px var(--player-color, #888);
-}
-.chip-name { font-weight: 700; color: var(--player-color, #fff); }
-.chip-info { color: #7c78a8; font-size: 0.72rem; }
+.stat-chip.dead   { opacity: 0.28; text-decoration: line-through; filter: grayscale(0.8); }
+.chip-dot         { width: 7px; height: 7px; border-radius: 50%; background: var(--player-color,#888); box-shadow: 0 0 4px var(--player-color,#888); }
+.chip-name        { font-weight: 700; color: var(--player-color, #fff); }
+.chip-info        { color: #7c78a8; font-size: 0.7rem; }
 
 #game-canvas {
-  border: 2px solid rgba(167,139,250,0.25);
+  border: 2px solid rgba(167,139,250,0.22);
   border-radius: 8px;
-  box-shadow: 0 0 30px rgba(124,58,237,0.2);
+  box-shadow: 0 0 28px rgba(124,58,237,0.18);
   display: block;
   max-width: 100%;
 }
 
-.controls-hint { font-size: 0.72rem; color: #4e4a72; text-align: center; letter-spacing: 0.03em; }
+.controls-hint { font-size: 0.7rem; color: #4e4a72; text-align: center; letter-spacing: 0.03em; }
 
 /* ─── Result screen ────────────────────────────────────────────────────────── */
 #result-section {
@@ -306,5 +354,5 @@ input[type="text"]::placeholder { color: #4e4a72; }
   background-clip: text;
 }
 
-#result-subtitle { color: #7c78a8; font-size: 0.9rem; }
+#result-subtitle { color: #7c78a8; font-size: 0.88rem; }
 #result-section .btn { min-width: 160px; }

--- a/supabase/bomberman_rooms_setup.sql
+++ b/supabase/bomberman_rooms_setup.sql
@@ -1,0 +1,34 @@
+-- ─── Bomberman public room registry ─────────────────────────────────────────
+-- Run this in the Supabase SQL editor for the nele.pet project.
+--
+-- Creates a lightweight room listing table so players can see and join
+-- public rooms from the home screen without knowing the room code.
+-- Private rooms skip this table entirely.
+
+create table if not exists public.bomberman_rooms (
+  code         text        primary key,
+  host_name    text        not null,
+  player_count integer     not null default 1
+                           check (player_count between 1 and 4),
+  status       text        not null default 'waiting'
+                           check (status in ('waiting', 'started')),
+  created_at   timestamptz not null default now()
+);
+
+-- Row-level security (all operations are public — no auth required for this table)
+alter table public.bomberman_rooms enable row level security;
+
+create policy "bomberman rooms: public read"
+  on public.bomberman_rooms for select using (true);
+
+create policy "bomberman rooms: public insert"
+  on public.bomberman_rooms for insert with check (true);
+
+create policy "bomberman rooms: public update"
+  on public.bomberman_rooms for update using (true);
+
+create policy "bomberman rooms: public delete"
+  on public.bomberman_rooms for delete using (true);
+
+-- Enable Realtime so the home page room list updates live
+alter publication supabase_realtime add table public.bomberman_rooms;


### PR DESCRIPTION
## ⚠️ Backend step required first

Before this will fully work, run **`supabase/bomberman_rooms_setup.sql`** in the Supabase SQL editor for the nele.pet project. This creates the `bomberman_rooms` table (used for the public rooms list) and enables Realtime on it. The game itself works without it — only the room list feature breaks.

---

## What changed

### Presence / joining fix (root cause of bots and joining not working)

`network.js` previously only listened to the presence `sync` event. `sync` fires when the full state is received from the server, but its timing is unreliable — it can fire before the local `onPresenceUpdate` callback is wired up, or before `presenceState()` has been populated (there's one network round-trip lag between `track()` resolving and the state reflecting the new entry).

Fix:
- Now subscribes to `sync` + `join` + `leave` presence events (all three refresh the player list)
- Added `CHANNEL_ERROR` / `TIMED_OUT` rejection in the subscribe promise so connection failures surface as a friendly message instead of hanging
- `lobby.js` calls `getPresencePlayers()` immediately after `joinRoom()` resolves AND once more after 800 ms as a fallback

### Layout / "Your name" field removed

- Guest name input removed entirely — the name always comes from the arcade account (`arcade_user` localStorage cache → live Supabase session fallback, same pattern as turborace)
- If no account is detected: Create/Join buttons are **disabled** and a "Log in to the Arcade" prompt appears with a link back to `/games/`
- "Playing as NAME" is now a clean single-line display

### Start button

Always visible; **disabled and greyed out** (not hidden) when fewer than 2 players/bots are present.

### Open rooms list

Home page fetches public rooms from `bomberman_rooms` and subscribes to live Postgres changes so the list updates in real time. Each entry shows host name, player count, room code, and a **Join** button. Rooms older than 30 minutes are filtered out automatically.

### Private rooms

A **Private** checkbox on the home page. Private rooms skip the database entirely — their code never appears in the public list. A `PRIVATE` badge appears in the lobby header.

### Room lifecycle (public, host only)

| Event | Database action |
|---|---|
| Host opens lobby | `INSERT` room row |
| Player joins (presence update) | `UPDATE player_count` |
| Game starts | `UPDATE status = 'started'` |
| Host clicks Back | `DELETE` row |
| Tab/window closes | Best-effort `DELETE` via `beforeunload` |

---

https://claude.ai/code/session_01UKnfL753QvSEpxiBy8ZoLm

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKnfL753QvSEpxiBy8ZoLm)_