### PR TITLE
bomberman: fix lobby presence, slot 0 pin, and stale room cleanup

### DIFF
--- a/games/bomberman/scripts/lobby.js
+++ b/games/bomberman/scripts/lobby.js
@@ -2,7 +2,7 @@ import { GameState, createMap, BOMB_FUSE, PLAYER_COLORS } from './game.js';
 import { Renderer }  from './renderer.js';
 import { Network }   from './network.js';
 import { AIPlayer, BOT_NAMES } from './ai.js';
-import { supabase }  from './supabase.js';
+import { supabase, SUPABASE_URL, SUPABASE_ANON_KEY } from './supabase.js';
 
 // ─── URL params ───────────────────────────────────────────────────────────────
 const params     = new URLSearchParams(location.search);
@@ -20,6 +20,7 @@ let renderer    = null;
 let myPlayer    = null;
 let gameRunning = false;
 
+// lobbyRealPlayers = other real humans (self is always pinned separately)
 let lobbyRealPlayers = [];
 let lobbyAIPlayers   = [];
 let aiInstances      = [];
@@ -37,6 +38,18 @@ function showSection(name) {
     $(`${s}-section`).classList.toggle('hidden', s !== name);
     $(`${s}-section`).classList.toggle('active', s === name);
   });
+}
+
+// ─── Player list helpers ──────────────────────────────────────────────────────
+// Self is always slot 0 — built from URL params, not from presence.
+function selfEntry() {
+  return { id: net.myId, name: playerName, isHost, isAI: false };
+}
+
+// Full ordered list: [self, ...other humans, ...bots]
+function allPlayers() {
+  const others = lobbyRealPlayers.filter(p => p.id !== net.myId);
+  return [selfEntry(), ...others, ...lobbyAIPlayers];
 }
 
 // ─── Room database helpers (public rooms only) ────────────────────────────────
@@ -59,8 +72,26 @@ async function dbMarkStarted() {
 }
 
 async function dbDeleteRoom() {
-  if (!isHost || isPrivate) return;
+  if (isPrivate) return;
   await supabase.from('bomberman_rooms').delete().eq('code', roomCode);
+}
+
+// keepalive DELETE — fires reliably on page unload even if JS engine is tearing down
+function dbDeleteRoomBeacon() {
+  if (isPrivate) return;
+  try {
+    fetch(
+      `${SUPABASE_URL}/rest/v1/bomberman_rooms?code=eq.${roomCode}`,
+      {
+        method: 'DELETE',
+        headers: {
+          'apikey': SUPABASE_ANON_KEY,
+          'Authorization': `Bearer ${SUPABASE_ANON_KEY}`,
+        },
+        keepalive: true,
+      }
+    );
+  } catch { /* ignore */ }
 }
 
 // ─── Lobby UI ─────────────────────────────────────────────────────────────────
@@ -72,7 +103,7 @@ function el(tag, cls, text = '') {
 }
 
 function renderSlots() {
-  const all = [...lobbyRealPlayers, ...lobbyAIPlayers];
+  const all = allPlayers();
 
   for (let i = 0; i < 4; i++) {
     const slot = $(`slot-${i}`);
@@ -110,10 +141,7 @@ function renderSlots() {
   const total    = all.length;
   const canStart = isHost && total >= 2;
 
-  // Start button: always visible, disabled when not ready
-  const startBtn = $('start-btn');
-  startBtn.disabled = !canStart;
-
+  $('start-btn').disabled = !canStart;
   $('lobby-msg').textContent = isHost
     ? (total >= 2 ? `${total} players ready!` : 'Add 1 more player or bot to start.')
     : 'Waiting for host to start the game…';
@@ -121,15 +149,13 @@ function renderSlots() {
 
 function updateRoomDisplay() {
   $('room-code-display').textContent = roomCode;
-  // Show private badge if applicable
   const badge = $('private-badge');
   if (badge) badge.classList.toggle('hidden', !isPrivate);
 }
 
 // ─── AI management ────────────────────────────────────────────────────────────
 function addAI() {
-  const total = lobbyRealPlayers.length + lobbyAIPlayers.length;
-  if (total >= 4) return;
+  if (allPlayers().length >= 4) return;
   const idx  = aiInstances.length;
   const id   = `ai-${crypto.randomUUID()}`;
   const name = BOT_NAMES[idx % BOT_NAMES.length];
@@ -148,7 +174,7 @@ function removeAI(id) {
 
 // ─── Game start ───────────────────────────────────────────────────────────────
 async function startGame() {
-  const all = [...lobbyRealPlayers, ...lobbyAIPlayers];
+  const all = allPlayers();
   if (all.length < 2) return;
 
   const map         = createMap(Date.now());
@@ -288,7 +314,7 @@ function placeBomb() {
   for (const [, b] of state.bombs) {
     if (b.tileX === tileX && b.tileY === tileY) return;
   }
-  const bombId    = crypto.randomUUID();
+  const bombId     = crypto.randomUUID();
   const explodesAt = Date.now() + BOMB_FUSE;
   state.addBomb(bombId, net.myId, tileX, tileY, explodesAt, myPlayer.bombRange);
   net.sendBomb(bombId, tileX, tileY, explodesAt, myPlayer.bombRange);
@@ -339,18 +365,71 @@ function updateHUD() {
 async function init() {
   updateRoomDisplay();
   showSection('lobby');
-  renderSlots(); // initial render (empty, but shows structure)
+  renderSlots(); // self is always shown immediately
 
+  // ── Presence: full sync (e.g. after reconnect) ─────────────────────────────
   net.onPresenceUpdate = players => {
-    lobbyRealPlayers = players;
+    lobbyRealPlayers = players.filter(p => p.id !== net.myId);
     renderSlots();
-    // Host keeps room player count in sync
-    if (isHost && !isPrivate) dbUpdatePlayerCount(players.length);
+    if (isHost && !isPrivate) {
+      dbUpdatePlayerCount(allPlayers().filter(p => !p.isAI).length);
+    }
   };
-  net.onAIUpdate = ({ aiPlayers }) => {
-    lobbyAIPlayers = aiPlayers ?? [];
-    renderSlots();
+
+  // ── Presence: incremental join — newPresences is more reliable than presenceState() ──
+  net.onPresenceJoin = newPlayers => {
+    let changed = false;
+    for (const p of newPlayers) {
+      if (p.id !== net.myId && !lobbyRealPlayers.find(r => r.id === p.id)) {
+        lobbyRealPlayers.push(p);
+        changed = true;
+      }
+    }
+    if (changed) {
+      renderSlots();
+      if (isHost && !isPrivate) {
+        dbUpdatePlayerCount(allPlayers().filter(p => !p.isAI).length);
+      }
+    }
   };
+
+  // ── Presence: incremental leave ────────────────────────────────────────────
+  net.onPresenceLeave = leftPlayers => {
+    const leftIds = new Set(leftPlayers.map(p => p.id));
+    const before  = lobbyRealPlayers.length;
+    lobbyRealPlayers = lobbyRealPlayers.filter(p => !leftIds.has(p.id));
+
+    // If the host disconnected and we're still in lobby, clean up the room
+    const hostLeft = leftPlayers.some(p => p.isHost);
+    if (hostLeft && !isHost && !gameRunning) {
+      dbDeleteRoom();
+    }
+
+    if (lobbyRealPlayers.length !== before) {
+      renderSlots();
+      if (isHost && !isPrivate) {
+        dbUpdatePlayerCount(allPlayers().filter(p => !p.isAI).length);
+      }
+    }
+  };
+
+  // ── Broadcast hello: redundancy so joiners always appear even if presence lags ──
+  net.onPlayerHello = ({ id, name, isHost: pIsHost }) => {
+    if (id === net.myId) return; // self (broadcast: self=false so shouldn't fire, but guard anyway)
+    if (!lobbyRealPlayers.find(p => p.id === id)) {
+      lobbyRealPlayers.push({ id, name, isHost: pIsHost });
+      renderSlots();
+      if (isHost && !isPrivate) {
+        dbUpdatePlayerCount(allPlayers().filter(p => !p.isAI).length);
+      }
+    }
+    // Host: resend current AI list so the new joiner sees existing bots
+    if (isHost && lobbyAIPlayers.length > 0) {
+      net.sendAIUpdate(lobbyAIPlayers);
+    }
+  };
+
+  net.onAIUpdate          = ({ aiPlayers }) => { lobbyAIPlayers = aiPlayers ?? []; renderSlots(); };
   net.onGameStart         = handleGameStart;
   net.onPlayerMove        = handlePlayerMove;
   net.onBombPlaced        = handleBombPlaced;
@@ -368,13 +447,13 @@ async function init() {
   // Register public room in database
   if (isHost) await dbRegisterRoom();
 
-  // Immediate presence refresh (sync may have already fired during join)
-  lobbyRealPlayers = net.getPresencePlayers();
+  // Immediate presence refresh (filter out self — we pin ourselves)
+  lobbyRealPlayers = net.getPresencePlayers().filter(p => p.id !== net.myId);
   renderSlots();
 
   // Delayed fallback: presence state sometimes lags one round-trip behind track()
   setTimeout(() => {
-    lobbyRealPlayers = net.getPresencePlayers();
+    lobbyRealPlayers = net.getPresencePlayers().filter(p => p.id !== net.myId);
     renderSlots();
   }, 800);
 }
@@ -418,12 +497,11 @@ $('copy-link-btn').addEventListener('click', async () => {
   } catch { /* ignore */ }
 });
 
-// Clean up room if tab/window closes
+// Clean up room when the page closes — keepalive fetch fires even as JS tears down
 window.addEventListener('beforeunload', () => {
-  if (isHost && !isPrivate) {
-    // Best-effort delete on page unload (may not always fire)
-    navigator.sendBeacon && supabase.from('bomberman_rooms').delete().eq('code', roomCode);
-  }
+  // Any client closing while in the lobby should try to clean up the room
+  // (especially the host, but also non-host clients detect host departure above)
+  if (isHost) dbDeleteRoomBeacon();
 });
 
 init();

--- a/games/bomberman/scripts/network.js
+++ b/games/bomberman/scripts/network.js
@@ -7,7 +7,10 @@ export class Network {
     this.roomCode = null;
 
     // Callbacks — set before joinRoom()
-    this.onPresenceUpdate    = null;
+    this.onPresenceUpdate    = null;   // full-state refresh (sync event)
+    this.onPresenceJoin      = null;   // incremental: array of new presences
+    this.onPresenceLeave     = null;   // incremental: array of left presences
+    this.onPlayerHello       = null;   // broadcast-based hello (redundancy)
     this.onAIUpdate          = null;
     this.onGameStart         = null;
     this.onPlayerMove        = null;
@@ -27,20 +30,42 @@ export class Network {
       },
     });
 
-    // ── Presence — fire on sync, join, AND leave for reliability ──────────
-    const refreshPresence = () => {
+    // ── Presence ──────────────────────────────────────────────────────────────
+    // sync: full state snapshot (e.g. after reconnect)
+    this.channel.on('presence', { event: 'sync' }, () => {
       if (!this.onPresenceUpdate) return;
       const players = Object.values(this.channel.presenceState()).flat();
       this.onPresenceUpdate(players);
-    };
-    this.channel.on('presence', { event: 'sync'  }, refreshPresence);
-    this.channel.on('presence', { event: 'join'  }, refreshPresence);
-    this.channel.on('presence', { event: 'leave' }, refreshPresence);
+    });
 
-    // ── Broadcast events ───────────────────────────────────────────────────
+    // join: use newPresences directly — more reliable than re-reading presenceState()
+    // which may not yet include the new entry at callback time
+    this.channel.on('presence', { event: 'join' }, ({ key, newPresences }) => {
+      const joined = newPresences.flat();
+      if (this.onPresenceJoin) {
+        this.onPresenceJoin(joined);
+      } else if (this.onPresenceUpdate) {
+        const players = Object.values(this.channel.presenceState()).flat();
+        this.onPresenceUpdate(players);
+      }
+    });
+
+    // leave: use leftPresences directly
+    this.channel.on('presence', { event: 'leave' }, ({ key, leftPresences }) => {
+      const left = leftPresences.flat();
+      if (this.onPresenceLeave) {
+        this.onPresenceLeave(left);
+      } else if (this.onPresenceUpdate) {
+        const players = Object.values(this.channel.presenceState()).flat();
+        this.onPresenceUpdate(players);
+      }
+    });
+
+    // ── Broadcast events ───────────────────────────────────────────────────────
     const on = (event, cb) =>
       this.channel.on('broadcast', { event }, ({ payload }) => cb?.(payload));
 
+    on('player_hello',      p => this.onPlayerHello?.(p));
     on('ai_update',         p => this.onAIUpdate?.(p));
     on('game_start',        p => this.onGameStart?.(p));
     on('player_move',       p => this.onPlayerMove?.(p));
@@ -49,7 +74,7 @@ export class Network {
     on('powerup_collected', p => this.onPowerupCollected?.(p));
     on('game_end',          p => this.onGameEnd?.(p));
 
-    // ── Subscribe then track presence ──────────────────────────────────────
+    // ── Subscribe then track presence ──────────────────────────────────────────
     await new Promise((resolve, reject) => {
       this.channel.subscribe(async status => {
         if (status === 'SUBSCRIBED') {
@@ -58,6 +83,8 @@ export class Network {
           } catch (e) {
             console.warn('presence track failed:', e);
           }
+          // Also announce via broadcast — presence can lag, this is instant
+          this.#send('player_hello', { id: this.myId, name: playerName, isHost });
           resolve();
         } else if (status === 'CHANNEL_ERROR' || status === 'TIMED_OUT') {
           reject(new Error(`Channel ${status}`));
@@ -66,17 +93,17 @@ export class Network {
     });
   }
 
-  // ── Private send helper ────────────────────────────────────────────────────
+  // ── Private send helper ──────────────────────────────────────────────────────
   #send(event, payload) {
     return this.channel?.send({ type: 'broadcast', event, payload });
   }
 
-  // ── Lobby ──────────────────────────────────────────────────────────────────
+  // ── Lobby ────────────────────────────────────────────────────────────────────
   sendAIUpdate(aiPlayers) {
     return this.#send('ai_update', { aiPlayers });
   }
 
-  // ── Game — my own player ───────────────────────────────────────────────────
+  // ── Game — my own player ─────────────────────────────────────────────────────
   sendGameStart(map, playerOrder) {
     return this.#send('game_start', { map, playerOrder });
   }
@@ -101,7 +128,7 @@ export class Network {
     return this.#send('game_end', { winnerId });
   }
 
-  // ── Game — AI / any player (host only) ────────────────────────────────────
+  // ── Game — AI / any player (host only) ───────────────────────────────────────
   sendAnyMove(id, tileX, tileY) {
     return this.#send('player_move', { id, tileX, tileY });
   }
@@ -114,7 +141,7 @@ export class Network {
     return this.#send('player_dead', { id });
   }
 
-  // ── Helpers ────────────────────────────────────────────────────────────────
+  // ── Helpers ──────────────────────────────────────────────────────────────────
   getPresencePlayers() {
     if (!this.channel) return [];
     return Object.values(this.channel.presenceState()).flat();

--- a/games/bomberman/scripts/supabase.js
+++ b/games/bomberman/scripts/supabase.js
@@ -1,5 +1,5 @@
 import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.39.5/+esm';
 
-const SUPABASE_URL = 'https://lglcvsptwkqxykapepey.supabase.co';
-const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImxnbGN2c3B0d2txeHlrYXBlcGV5Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDcwNzQ1NDcsImV4cCI6MjA2MjY1MDU0N30.ci7v2g-5wixuPKnG6wUUO87AsbI1bQ8wzRnHHG9QzIQ';
+export const SUPABASE_URL      = 'https://lglcvsptwkqxykapepey.supabase.co';
+export const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImxnbGN2c3B0d2txeHlrYXBlcGV5Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDcwNzQ1NDcsImV4cCI6MjA2MjY1MDU0N30.ci7v2g-5wixuPKnG6wUUO87AsbI1bQ8wzRnHHG9QzIQ';
 export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);


### PR DESCRIPTION
## What's fixed

### 🧑 Room creator always in slot 1
`renderSlots()` now builds the player list as `[self, ...others, ...bots]` where self is constructed directly from URL params — no waiting on presence timing. You're always visible in slot 1 immediately on load, and only 3 slots remain available for others/bots.

### 👥 Joining players now visible to host
Two redundant mechanisms to make remote players appear reliably:

1. **Presence `join` event** — now uses `newPresences` directly from the callback argument instead of re-reading `presenceState()`, which can lag on Supabase's side at the moment the event fires.
2. **`player_hello` broadcast** — each client broadcasts their identity right after subscribing. The host adds them immediately on receipt, without waiting for presence at all. The host also re-sends the current AI list on `player_hello` so late-joining players see bots that were added before they arrived.

### 🗑️ Stale rooms cleaned up
- `beforeunload` now uses `fetch(..., { keepalive: true })` against the Supabase REST API directly — this fires reliably even as the JS engine tears down, unlike async SDK calls which were being abandoned mid-flight.
- Non-host clients also delete the room if they detect the host's presence disappeared while still in the lobby (belt-and-suspenders in case the host's keepalive didn't fire).

## Files changed
- `scripts/lobby.js` — self-pin, incremental presence handlers, `onPlayerHello`, keepalive DELETE
- `scripts/network.js` — `onPresenceJoin`/`onPresenceLeave`/`onPlayerHello` callbacks, `player_hello` broadcast on join
- `scripts/supabase.js` — export `SUPABASE_URL` and `SUPABASE_ANON_KEY` for use in keepalive fetch

https://claude.ai/code/session_01UKnfL753QvSEpxiBy8ZoLm

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKnfL753QvSEpxiBy8ZoLm)_