### PR TITLE
bomberman: bug fixes — bomb hitboxes, stale rooms, lobby presence

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,18 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "agent",
+            "if": "Bash(git push *)",
+            "prompt": "A git push just ran. Use Bash to get the current branch: `git rev-parse --abbrev-ref HEAD`. Then use mcp__github__list_pull_requests (owner: rcktgrl, repo: nele.pet, state: open, head: <branch>) to check whether an open PR already exists for that branch. If one exists, do nothing. If none exists, use mcp__github__create_pull_request to open a PR from that branch into main for owner rcktgrl, repo nele.pet. Use the output of `git log origin/main..HEAD --oneline` to write a concise title and a brief bullet-point body summarising the commits.",
+            "timeout": 60,
+            "statusMessage": "Creating PR…"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/games/bomberman/scripts/game.js
+++ b/games/bomberman/scripts/game.js
@@ -151,6 +151,7 @@ export class GameState {
     const bomb = this.bombs.get(bombId);
     if (!bomb || bomb.exploded) return null;
     bomb.exploded = true;
+    this.bombs.delete(bombId); // remove so it no longer blocks movement
 
     const center = { x: bomb.tileX, y: bomb.tileY };
     const tiles  = [center];

--- a/games/bomberman/scripts/home.js
+++ b/games/bomberman/scripts/home.js
@@ -1,4 +1,4 @@
-import { supabase } from './supabase.js';
+import { supabase, SUPABASE_URL, SUPABASE_ANON_KEY } from './supabase.js';
 
 // ─── Arcade account lookup ────────────────────────────────────────────────────
 async function getArcadeUser() {
@@ -36,13 +36,33 @@ function goToLobby(roomCode, playerName, host = false, isPrivate = false) {
   location.href = `lobby.html?${p}`;
 }
 
+// ─── Stale room cleanup ───────────────────────────────────────────────────────
+// Runs on every home-page load. Any room older than 10 min is considered
+// abandoned (host closed tab, connection dropped, etc.) and deleted.
+// Uses keepalive fetch so it fires even if the page is being torn down.
+function cleanupStaleRooms() {
+  const cutoff = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+  fetch(
+    `${SUPABASE_URL}/rest/v1/bomberman_rooms?created_at=lt.${encodeURIComponent(cutoff)}`,
+    {
+      method: 'DELETE',
+      headers: {
+        'apikey': SUPABASE_ANON_KEY,
+        'Authorization': `Bearer ${SUPABASE_ANON_KEY}`,
+        'Prefer': 'return=minimal',
+      },
+      keepalive: true,
+    }
+  ).catch(() => { /* best-effort */ });
+}
+
 // ─── Public rooms list ────────────────────────────────────────────────────────
 async function loadRooms() {
   const { data, error } = await supabase
     .from('bomberman_rooms')
     .select('*')
     .eq('status', 'waiting')
-    .gte('created_at', new Date(Date.now() - 30 * 60 * 1000).toISOString()) // max 30 min old
+    .gte('created_at', new Date(Date.now() - 10 * 60 * 1000).toISOString()) // max 10 min old
     .order('created_at', { ascending: false })
     .limit(6);
 
@@ -116,7 +136,8 @@ function subscribeRooms() {
   const inviteRoom = new URLSearchParams(location.search).get('room');
   if (inviteRoom) $('room-code-input').value = inviteRoom.slice(0, 4).toUpperCase();
 
-  // Load public rooms
+  // Sweep for abandoned rooms, then load the fresh list
+  cleanupStaleRooms();
   await loadRooms();
   subscribeRooms();
 })();

--- a/games/bomberman/scripts/lobby.js
+++ b/games/bomberman/scripts/lobby.js
@@ -463,7 +463,7 @@ $('start-btn').addEventListener('click', startGame);
 
 $('back-btn').addEventListener('click', async e => {
   e.preventDefault();
-  await dbDeleteRoom();
+  if (isHost) await dbDeleteRoom();
   await net.leave();
   location.href = 'index.html';
 });


### PR DESCRIPTION
## Bug fixes

### 💣 Bomb hitboxes now clear after explosion
Exploded bombs were never removed from `this.bombs`, so `canMoveTo()` kept treating the tile as blocked permanently. Fix: `this.bombs.delete(bombId)` immediately after marking a bomb exploded.

### 🗑️ Stale rooms cleaned up reliably
- `beforeunload` now uses `fetch(..., { keepalive: true })` against the Supabase REST API directly, so the DELETE fires even as the JS engine tears down (the old SDK Promise was being abandoned).
- `home.js` runs a stale-room sweep on every page load — any room older than 10 minutes is deleted. Tightened the room list filter from 30 min → 10 min to match.
- Non-host clients delete the room if they detect the host's presence disappeared mid-lobby.
- Back button now only calls `dbDeleteRoom()` when `isHost` (non-hosts were accidentally deleting the room for everyone).

### 👥 Lobby presence fixes
- Room creator always appears in slot 1 instantly, built from URL params — no waiting on presence timing.
- Joining players now visible to host via two redundant paths: `newPresences` from the presence `join` event directly, and a `player_hello` broadcast sent on subscribe.
- Host re-sends current AI list on `player_hello` so late joiners see bots added before they arrived.

### ⚙️ Auto-create PR hook
Added `.claude/settings.json` with a `PostToolUse` agent hook that automatically opens a PR after every `git push`, if one doesn't already exist.

https://claude.ai/code/session_01UKnfL753QvSEpxiBy8ZoLm

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKnfL753QvSEpxiBy8ZoLm)_