### PR TITLE
bomber: dark theme bars, bots pick up & use items

### DIFF
--- a/games/bomberman/index.html
+++ b/games/bomberman/index.html
@@ -2,7 +2,10 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <meta name="theme-color" content="#080b18">
+  <meta name="color-scheme" content="dark">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <title>Bomber — Arcade</title>
   <link rel="stylesheet" href="styles/bomberman.css">
 </head>

--- a/games/bomberman/lobby.html
+++ b/games/bomberman/lobby.html
@@ -2,7 +2,10 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <meta name="theme-color" content="#080b18">
+  <meta name="color-scheme" content="dark">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <title>Bomber — Arcade</title>
   <link rel="stylesheet" href="styles/bomberman.css">
 </head>

--- a/games/bomberman/scripts/ai.js
+++ b/games/bomberman/scripts/ai.js
@@ -132,12 +132,16 @@ export class AIPlayer {
     return false;
   }
 
-  #doMove(state, me, nx, ny, now, net, dir) {
+  #doMove(state, me, nx, ny, now, net) {
     me.startMove(nx, ny, now);
     net.sendAnyMove(this.id, nx, ny);
+    // Collect any power-up sitting on the destination tile
+    const pu = state.collectPowerup(this.id, nx, ny);
+    if (pu) net.sendAnyPowerupCollected(this.id, nx, ny);
   }
 
-  update(state, now, net, scheduleBombExplosion) {
+  // awardScore is an optional (playerId, pts) callback provided by the host
+  update(state, now, net, scheduleBombExplosion, awardScore = null) {
     const me = state.players.get(this.id);
     if (!me || !me.alive) return;
 
@@ -165,7 +169,7 @@ export class AIPlayer {
       }
     }
 
-    const inDanger  = dangerSet.has(`${me.tileX},${me.tileY}`);
+    const inDanger = dangerSet.has(`${me.tileX},${me.tileY}`);
 
     if (
       !inDanger &&
@@ -173,10 +177,18 @@ export class AIPlayer {
       now - this.lastBombTime > this.bombCooldown &&
       this.#hasAdjacentTarget(state, me)
     ) {
+      // Use special bomb if the bot has one, otherwise normal
+      let bombType = 'normal';
+      if (me.specialBomb) {
+        bombType = me.specialBomb === 'napalm' ? 'napalm' : 'box';
+        me.specialBomb = null; // consume the power-up
+        if (awardScore) awardScore(this.id, 10); // 10pts for using a special bomb
+      }
+
       const bombId     = crypto.randomUUID();
       const explodesAt = Date.now() + BOMB_FUSE;
-      state.addBomb(bombId, this.id, me.tileX, me.tileY, explodesAt, me.bombRange);
-      net.sendAnyBomb(bombId, this.id, me.tileX, me.tileY, explodesAt, me.bombRange);
+      state.addBomb(bombId, this.id, me.tileX, me.tileY, explodesAt, me.bombRange, bombType);
+      net.sendAnyBomb(bombId, this.id, me.tileX, me.tileY, explodesAt, me.bombRange, bombType);
       scheduleBombExplosion(bombId, BOMB_FUSE);
       this.lastBombTime = now;
       dangerSet.add(`${me.tileX},${me.tileY}`);

--- a/games/bomberman/scripts/lobby.js
+++ b/games/bomberman/scripts/lobby.js
@@ -373,6 +373,10 @@ function handleBombPlaced({ bombId, placedBy, tileX, tileY, explodesAt, range, t
   state.addBomb(bombId, placedBy, tileX, tileY, explodesAt, range, type ?? 'normal');
   const delay = Math.max(0, explodesAt - Date.now());
   setTimeout(() => triggerExplosion(bombId), delay);
+  // Award 10pts for other players' special bombs (local player handles it in placeSpecialBomb)
+  if (type && type !== BOMB_TYPE.NORMAL && placedBy !== net.myId) {
+    awardGameScore(placedBy, 10);
+  }
 }
 
 function handleBombKick({ bombId, newTileX, newTileY }) {
@@ -657,7 +661,7 @@ function gameLoop() {
     for (const ai of aiInstances) {
       ai.update(state, now, net, (bombId, delay) => {
         setTimeout(() => triggerExplosion(bombId), delay);
-      });
+      }, awardGameScore);
     }
   }
 

--- a/games/bomberman/scripts/network.js
+++ b/games/bomberman/scripts/network.js
@@ -147,6 +147,10 @@ export class Network {
     return this.#send('player_dead', { id });
   }
 
+  sendAnyPowerupCollected(playerId, tileX, tileY) {
+    return this.#send('powerup_collected', { playerId, tileX, tileY });
+  }
+
   // ── Helpers ──────────────────────────────────────────────────────────────────
   getPresencePlayers() {
     if (!this.channel) return [];

--- a/games/bomberman/styles/bomberman.css
+++ b/games/bomberman/styles/bomberman.css
@@ -1,15 +1,24 @@
 /* ─── Reset & Base ─────────────────────────────────────────────────────────── */
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
+/* Covers the areas behind the iOS status bar / Safari chrome */
+html { background-color: #080b18; }
+
 body {
   font-family: 'Courier New', monospace;
-  background: radial-gradient(ellipse at center, #1e2245 0%, #080b18 100%);
+  background: radial-gradient(ellipse at center, #1e2245 0%, #080b18 100%) #080b18;
   color: #c8c4e8;
   min-height: 100vh;
+  min-height: 100dvh; /* dynamic viewport — correct on iOS Safari */
   display: flex;
   align-items: center;
   justify-content: center;
   overflow-x: hidden;
+  /* extend content behind iOS notch / home indicator */
+  padding-top:    env(safe-area-inset-top,    0px);
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+  padding-left:   env(safe-area-inset-left,   0px);
+  padding-right:  env(safe-area-inset-right,  0px);
 }
 
 /* ─── Screens ──────────────────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary
- Dark theme meta tags and styling for iOS/Android browser chrome
- Dynamic viewport height (100dvh) and safe-area inset padding for notch compatibility
- Bot AI improvements: power-up collection, special bomb usage, score tracking

## Changes
- Add theme-color, color-scheme, and apple-mobile-web-app-status-bar-style meta tags
- Set dark background colors to prevent white areas behind notches/toolbars
- Bots now properly collect power-ups and broadcast pickups to sync all clients
- Bots use special bombs and award points when placing them
- Add sendAnyPowerupCollected network message
- Pass awardGameScore callback to AI for point tracking

---
_Generated by [Claude Code](https://claude.ai/code/session_017BEyF79gnEWKEUunVQ2Kfr)_