### PR TITLE
turborace: fix lobby slot grid empty on first render

### DIFF
--- a/games/turborace/scripts/menu.js
+++ b/games/turborace/scripts/menu.js
@@ -502,6 +502,8 @@ export async function vsCreateRoom(){
   catch(e){ _vsSetStatus('❌ Failed: '+e.message); return; }
 
   state.vsMyId=net.myId;
+  // Pre-seed our own slot so the grid isn't empty while we wait for the first presence sync
+  state.vsLobbyPlayers=[{id:net.myId, name, isHost:true}];
   _attachVsHandlers(net, true);
   _showVsRoomPanel(true);
 }
@@ -525,6 +527,8 @@ export async function vsJoinRoom(){
   catch(e){ _vsSetStatus('❌ Failed: '+e.message); return; }
 
   state.vsMyId=net.myId;
+  // Pre-seed our own slot so the grid isn't empty while we wait for the first presence sync
+  state.vsLobbyPlayers=[{id:net.myId, name, isHost:false}];
   _attachVsHandlers(net, false);
   _showVsRoomPanel(false);
 


### PR DESCRIPTION
## Summary

- Pre-seed vsLobbyPlayers with our own entry immediately after joinRoom resolves so the slot grid shows the local player before the first Supabase presence sync fires (which is async)
- The real presence event overwrites it with the authoritative list

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMM7a6moQQDPRFQCNftVx8)_