### PR TITLE
fix: stop spurious lobby disconnects in Bomber and Turbo Race

### DIFF
--- a/games/bomberman/scripts/lobby.js
+++ b/games/bomberman/scripts/lobby.js
@@ -768,29 +768,27 @@ async function init() {
   };
 
   net.onPresenceLeave = leftPlayers => {
-    const leftIds  = new Set(leftPlayers.map(p => p.id));
+    // Only handle the time-sensitive host-left case immediately.
+    // We deliberately do NOT prune real players here because Supabase fires
+    // spurious leave+join pairs during WebSocket reconnections — removing a
+    // player on every leave event causes false disappearances.
+    // Intentional leaves are signalled via the player_leave broadcast (handled
+    // by onPlayerLeave below), and the 30-second interval cleans up true
+    // disconnects reliably.
     const hostLeft = leftPlayers.some(p => p.isHost);
-    // Handle host-left immediately — this is time-sensitive
     if (hostLeft && !isHost && !gameRunning) dbDeleteRoom();
+  };
 
-    // Delay the actual removal to guard against spurious leave events that
-    // Supabase fires during WebSocket reconnections (a leave+join pair for the
-    // same player).  Re-check presence state before removing.
-    // Only prune while in the lobby — not during the game or result screen.
-    // (gameRunning is already false on the result screen, so checking only
-    // gameRunning would cause players to be pruned prematurely.)
-    setTimeout(() => {
-      if (activeSection !== 'lobby') return;
-      const stillPresent = new Set(net.getPresencePlayers().map(p => p.id));
-      const before = lobbyRealPlayers.length;
-      lobbyRealPlayers = lobbyRealPlayers.filter(
-        p => !leftIds.has(p.id) || stillPresent.has(p.id)
-      );
-      if (lobbyRealPlayers.length !== before) {
-        renderSlots();
-        if (isHost && !isPrivate) dbUpdatePlayerCount(allPlayers().filter(p => !p.isAI).length);
-      }
-    }, 2500);
+  // Intentional leave: player clicked "leave" / back button and broadcast before
+  // disconnecting.  Remove them immediately so the slot opens up right away.
+  net.onPlayerLeave = ({ id }) => {
+    if (id === net.myId) return;
+    const before = lobbyRealPlayers.length;
+    lobbyRealPlayers = lobbyRealPlayers.filter(p => p.id !== id);
+    if (lobbyRealPlayers.length !== before) {
+      renderSlots();
+      if (isHost && !isPrivate) dbUpdatePlayerCount(allPlayers().filter(p => !p.isAI).length);
+    }
   };
 
   net.onPlayerHello = ({ id, name, isHost: pIsHost }) => {
@@ -888,6 +886,9 @@ $('start-btn').addEventListener('click', startGame);
 
 $('back-btn').addEventListener('click', async e => {
   e.preventDefault();
+  // Broadcast intentional leave so other clients can remove us immediately
+  // (before net.leave() disconnects us from the channel).
+  net.sendPlayerLeave(net.myId);
   if (isHost) await dbDeleteRoom();
   await net.leave();
   location.href = 'index.html';

--- a/games/bomberman/scripts/network.js
+++ b/games/bomberman/scripts/network.js
@@ -11,6 +11,7 @@ export class Network {
     this.onPresenceJoin      = null;
     this.onPresenceLeave     = null;
     this.onPlayerHello       = null;
+    this.onPlayerLeave       = null;  // intentional leave broadcast
     this.onAIUpdate          = null;
     this.onPlayAgain         = null;
     this.onGameStart         = null;
@@ -65,6 +66,7 @@ export class Network {
       this.channel.on('broadcast', { event }, ({ payload }) => cb?.(payload));
 
     on('player_hello',      p => this.onPlayerHello?.(p));
+    on('player_leave',      p => this.onPlayerLeave?.(p));
     on('ai_update',         p => this.onAIUpdate?.(p));
     on('play_again',        p => this.onPlayAgain?.(p));
     on('game_start',        p => this.onGameStart?.(p));
@@ -99,6 +101,10 @@ export class Network {
   }
 
   // ── Lobby ────────────────────────────────────────────────────────────────────
+  sendPlayerLeave(id) {
+    return this.#send('player_leave', { id });
+  }
+
   sendAIUpdate(aiPlayers) {
     return this.#send('ai_update', { aiPlayers });
   }

--- a/games/turborace/scripts/menu.js
+++ b/games/turborace/scripts/menu.js
@@ -291,6 +291,37 @@ export async function showOnlineTrkSel(){
 // PLAYER COLORS matching Bomber's 4-player palette
 const VS_COLORS=['#ff9a3c','#4af','#f44','#4f4'];
 
+// Interval handle for the 30-second presence safety-net prune.
+// Cleared in vsLeaveLobby() so it doesn't run after the lobby is torn down.
+let _vsLobbyPruneInterval=null;
+
+/**
+ * Merge-add incoming presence players into state.vsLobbyPlayers.
+ * Like Bomber's mergePresencePlayers: only ever ADDS or UPDATES slots,
+ * never removes — removal is handled exclusively by intentional broadcasts
+ * (player_leave / player_kick) and the 30-second safety-net interval.
+ * Returns true if the list changed.
+ */
+function _mergeVsPresencePlayers(incoming){
+  let changed=false;
+  for(const p of incoming){
+    const byId=state.vsLobbyPlayers.find(r=>r.id===p.id);
+    const byName=!byId&&state.vsLobbyPlayers.find(r=>r.name===p.name);
+    if(byName){
+      // Same name, new ID → reconnect; reclaim their slot
+      const idx=state.vsLobbyPlayers.indexOf(byName);
+      state.vsLobbyPlayers[idx]={...byName,id:p.id};
+      changed=true;
+    }else if(!byId){
+      state.vsLobbyPlayers.push(p);
+      changed=true;
+    }
+  }
+  // Keep host in slot 0, then guests in arrival order
+  state.vsLobbyPlayers.sort((a,b)=>(b.isHost?1:0)-(a.isHost?1:0));
+  return changed;
+}
+
 /** All players (real + AI) in slot order */
 function _allVsSlots(){
   return [...state.vsLobbyPlayers, ...state.vsLobbyAIs];
@@ -450,6 +481,8 @@ function _vsRemoveAI(id){
 
 function _vsKickPlayer(targetId){
   state.vsNetwork?.sendPlayerKick(targetId);
+  // Remove locally so the host's slot grid updates immediately
+  state.vsLobbyPlayers=state.vsLobbyPlayers.filter(p=>p.id!==targetId);
   _renderVsSlots();
 }
 
@@ -616,24 +649,38 @@ function _showVsRoomPanel(isHost){
 }
 
 function _attachVsHandlers(net, isHost){
+  // ── Presence join/sync: merge-add only, never remove ──────────────────────
+  // Using _mergeVsPresencePlayers means a brief Supabase WebSocket reconnection
+  // (which fires leave→join) can never cause a slot to disappear and reappear.
   net.onPresenceUpdate=(players)=>{
-    // Guard: an empty snapshot means Supabase hasn't synced yet — don't wipe
-    // the pre-seeded entry.
-    if(!players.length) return;
-    // Deduplicate by name so a reconnecting player (new UUID, same display name)
-    // never gets a second slot.  Last-write-wins: if old + new IDs briefly
-    // coexist in presenceState, the newer entry (appended last by Supabase)
-    // overwrites the stale one.
-    const seen=new Map(); // name → player
-    for(const p of players) seen.set(p.name, p);
-    // Always put the host in slot 0, then guests in order of arrival
-    state.vsLobbyPlayers=[...seen.values()].sort((a,b)=>(b.isHost?1:0)-(a.isHost?1:0));
-    _renderVsSlots();
+    if(!players.length) return; // empty snapshot = not yet synced; keep pre-seeded entry
+    if(_mergeVsPresencePlayers(players)){
+      _renderVsSlots();
+    }
     // When a new guest joins, host re-broadcasts current config
     if(isHost&&state.selTrk!=null){
       net.sendGameConfig(state.selTrk, state.selCar??0);
       net.sendAIUpdate(state.vsLobbyAIs);
     }
+  };
+
+  // ── Presence leave: intentionally ignored for pruning ─────────────────────
+  // Supabase fires spurious leave events during WebSocket reconnections.
+  // Pruning is handled only by onPlayerLeave (intentional) and the 30-second
+  // safety-net interval (true disconnects).
+  net.onPresenceLeave=(_leftPlayers)=>{
+    // Nothing to do here for lobby slots.
+    // (Host departure detection could go here if needed.)
+  };
+
+  // ── Intentional leave broadcast ────────────────────────────────────────────
+  // A player who clicks "leave" broadcasts player_leave before disconnecting.
+  // Remove them immediately so the slot opens up without waiting 30 seconds.
+  net.onPlayerLeave=({id})=>{
+    if(id===net.myId) return;
+    const before=state.vsLobbyPlayers.length;
+    state.vsLobbyPlayers=state.vsLobbyPlayers.filter(p=>p.id!==id);
+    if(state.vsLobbyPlayers.length!==before) _renderVsSlots();
   };
 
   net.onAIUpdate=({aiPlayers})=>{
@@ -684,8 +731,27 @@ function _attachVsHandlers(net, isHost){
     if(targetId===net.myId){
       _vsSetStatus('You were kicked from the lobby.');
       vsLeaveLobby();
+    } else {
+      // Host already updated local state in _vsKickPlayer; guests need to remove too
+      const before=state.vsLobbyPlayers.length;
+      state.vsLobbyPlayers=state.vsLobbyPlayers.filter(p=>p.id!==targetId);
+      if(state.vsLobbyPlayers.length!==before) _renderVsSlots();
     }
   };
+
+  // ── 30-second safety-net: prune truly disconnected players ────────────────
+  // This is the ONLY mechanism that removes players due to disconnection.
+  // Running every 30s gives Supabase plenty of time to re-establish presence
+  // after a reconnect before we ever prune.
+  if(_vsLobbyPruneInterval) clearInterval(_vsLobbyPruneInterval);
+  _vsLobbyPruneInterval=setInterval(()=>{
+    if(state.gState!=='vsLobby') return;
+    const fresh=net.getPresencePlayers();
+    const freshIds=new Set(fresh.map(p=>p.id));
+    const before=state.vsLobbyPlayers.length;
+    state.vsLobbyPlayers=state.vsLobbyPlayers.filter(p=>freshIds.has(p.id));
+    if(state.vsLobbyPlayers.length!==before) _renderVsSlots();
+  }, 30000);
 }
 
 function _buildSlots(){
@@ -728,7 +794,15 @@ export function vsStartRace(){
 }
 
 export function vsLeaveLobby(){
-  if(state.vsNetwork){ state.vsNetwork.leave().catch(()=>{}); state.vsNetwork=null; }
+  // Clear the safety-net prune interval before tearing down
+  if(_vsLobbyPruneInterval){ clearInterval(_vsLobbyPruneInterval); _vsLobbyPruneInterval=null; }
+  if(state.vsNetwork){
+    // Broadcast intentional leave so other clients remove us immediately
+    // (before unsubscribe disconnects us from the channel).
+    state.vsNetwork.sendPlayerLeave(state.vsMyId||state.vsNetwork.myId);
+    state.vsNetwork.leave().catch(()=>{});
+    state.vsNetwork=null;
+  }
   state.vsMode=false;
   disposeCarCardPreviews();
   showMain();

--- a/games/turborace/scripts/vs-network.js
+++ b/games/turborace/scripts/vs-network.js
@@ -14,7 +14,9 @@ export class VsNetwork {
     this.isHost   = false;
 
     // Callbacks — assign before joinRoom()
-    this.onPresenceUpdate  = null;  // (players[]) any join/leave/sync
+    this.onPresenceUpdate  = null;  // (players[]) join/sync events — merge-add only
+    this.onPresenceLeave   = null;  // (leftPlayers[]) raw leave event — informational
+    this.onPlayerLeave     = null;  // ({id}) intentional leave broadcast
     this.onAIUpdate        = null;  // ({aiPlayers}) host pushed AI list
     this.onGameConfig      = null;  // ({trackId, hostCarIdx}) host config
     this.onGuestReady      = null;  // ({id, carIdx}) guest car selection
@@ -35,18 +37,32 @@ export class VsNetwork {
       },
     });
 
+    // sync and join fire onPresenceUpdate (merge-add, never remove).
+    // leave fires the separate onPresenceLeave so the lobby can decide
+    // whether to prune — by default we ignore it to prevent spurious removals
+    // during WebSocket reconnections.
     const _presenceChanged = () => {
       if (!this.onPresenceUpdate) return;
       const players = Object.values(this.channel.presenceState()).flat();
       this.onPresenceUpdate(players);
     };
-    this.channel.on('presence', { event: 'sync' },  _presenceChanged);
-    this.channel.on('presence', { event: 'join' },  _presenceChanged);
-    this.channel.on('presence', { event: 'leave' }, _presenceChanged);
+    this.channel.on('presence', { event: 'sync' }, _presenceChanged);
+    this.channel.on('presence', { event: 'join' }, _presenceChanged);
+    this.channel.on('presence', { event: 'leave' }, ({ leftPresences }) => {
+      const left = leftPresences.flat();
+      if (this.onPresenceLeave) {
+        this.onPresenceLeave(left);
+      }
+      // Do NOT call _presenceChanged here — the full presenceState() snapshot
+      // from which _presenceChanged builds the player list will already have
+      // removed the leaver, causing immediate (and potentially false) removal
+      // during Supabase WebSocket reconnections.
+    });
 
     const on = (event, cb) =>
       this.channel.on('broadcast', { event }, ({ payload }) => cb?.(payload));
 
+    on('player_leave',    p => this.onPlayerLeave?.(p));
     on('ai_update',       p => this.onAIUpdate?.(p));
     on('game_config',     p => this.onGameConfig?.(p));
     on('guest_ready',     p => this.onGuestReady?.(p));
@@ -88,6 +104,11 @@ export class VsNetwork {
   }
 
   // ── Lobby ────────────────────────────────────────────────────────────────────
+  /** Broadcast intentional leave so others remove this slot immediately. */
+  sendPlayerLeave(id) {
+    return this.#send('player_leave', { id });
+  }
+
   /** Host → all: updated AI player list */
   sendAIUpdate(aiPlayers) {
     return this.#send('ai_update', { aiPlayers });


### PR DESCRIPTION
## Summary
- Fix spurious lobby disconnects in Bomber and Turbo Race games
- Attach VS presence handlers before joinRoom to fix both-on-slot-0 bug in turborace
- Improve player visibility and stability in multiplayer lobbies

---
_Generated by [Claude Code](https://claude.ai/code/session_01EdBZY8eS6riGDozSX1KLSp)_