### PR TITLE
F³ Racing: VS rematch-to-lobby, online tracks, car colour picker

### DIFF
--- a/games/turborace/index.html
+++ b/games/turborace/index.html
@@ -16,7 +16,7 @@
   <div class="menuActions">
     <button id="introStartBtn" class="btn btn-p">START GAME</button>
   </div>
-  <div class="menuVersion" aria-label="Game version">v0.130</div>
+  <div class="menuVersion" aria-label="Game version">v0.131</div>
 </div>
 <div id="hud" role="status" aria-live="polite">
   <div id="raceTop">
@@ -146,13 +146,18 @@
     <button id="mainSettingsBtn" class="btn btn-s">SETTINGS</button>
     <button id="backToSelectionBtn" class="btn btn-s">BACK TO GAME SELECTION</button>
   </div>
-  <div class="menuVersion" aria-label="Game version">v0.130</div>
+  <div class="menuVersion" aria-label="Game version">v0.131</div>
 </div>
 
 <!-- CAR SELECT -->
 <div class="screen" id="sCar" style="display:none">
   <h2>Select Your Car</h2>
   <div class="cards" id="carCards"></div>
+  <div class="carColorRow">
+    <span class="carColorLabel">Car Colour</span>
+    <input id="carColorPicker" type="color" class="carColorInput" value="#ff2222">
+    <button id="carColorResetBtn" class="btn btn-s btn-tight">DEFAULT</button>
+  </div>
   <div class="menuActions menuActions-inline">
     <button id="showTrkSelBtn" class="btn btn-s">BACK</button>
     <button id="btnGo" class="btn btn-p" disabled>RACE!</button>
@@ -272,10 +277,17 @@
       <div class="vsSection">
         <div class="vsLabel">Pick a Track</div>
         <div id="vsTrackCards" class="vsTrackList"></div>
+        <div style="text-align:center;margin-top:10px;">
+          <button id="vsLoadOnlineTracksBtn" class="btn btn-s btn-tight">LOAD ONLINE TRACKS</button>
+        </div>
       </div>
       <div class="vsSection">
         <div class="vsLabel">Your Car</div>
         <div id="vsHostCarRow" class="vsCarRow"></div>
+        <div class="vsColorRow">
+          <span class="carColorLabel">Colour</span>
+          <input id="vsHostColor" type="color" class="carColorInput" value="#ff2222">
+        </div>
       </div>
       <button id="vsStartBtn" class="btn btn-p" disabled style="min-width:200px;font-size:1rem;">START RACE</button>
     </div>
@@ -285,6 +297,10 @@
       <div class="vsSection">
         <div class="vsLabel">Your Car</div>
         <div id="vsGuestCarRow" class="vsCarRow"></div>
+        <div class="vsColorRow">
+          <span class="carColorLabel">Colour</span>
+          <input id="vsGuestColor" type="color" class="carColorInput" value="#ff2222">
+        </div>
       </div>
     </div>
 

--- a/games/turborace/scripts/car-model.js
+++ b/games/turborace/scripts/car-model.js
@@ -12,15 +12,16 @@ export function getOpponentCarModels(cars, selectedCarIndex, count=4){
   return models;
 }
 
-export function createCarVisual(data){
-  const builder=new CarModelBuilder(data);
+export function createCarVisual(data, colorOverride){
+  const builder=new CarModelBuilder(data, colorOverride);
   const mesh=builder.buildMesh();
   return { mesh, tailLights:builder.tl, wheels:builder.wh };
 }
 
 class CarModelBuilder{
-  constructor(data){
+  constructor(data, colorOverride){
     this.data=data;
+    this.bodyCol=(colorOverride!=null)?colorOverride:data.col;
     this.tl=[];
     this.wh=[];
   }
@@ -35,7 +36,7 @@ default: return this.buildSportsMesh();
 
   // ── Existing sports coupe (Thunder V8) ──────────────
   buildSportsMesh(){
-    const g=new THREE.Group(), C=this.data.col;
+    const g=new THREE.Group(), C=this.bodyCol;
     const Bm=mat(C), Dm=mat(0x111111), Gm=matT(0x7799bb,.55), Wm=mat(0x111111), Rm=mat(0x777777);
     const Lm=matE(0xffee88,0x443300), TLm=matE(0xee1100,0x220000);
     addB(g,1.8,.48,4.0,0,.44,0,Bm); addB(g,1.38,.48,1.78,0,.93,.08,Bm);
@@ -51,7 +52,7 @@ default: return this.buildSportsMesh();
 
   // ── Lamborghini-style low wedge (Viper GT) ──────────
   buildWedgeMesh(){
-    const g=new THREE.Group(), C=this.data.col;
+    const g=new THREE.Group(), C=this.bodyCol;
     const Bm=mat(C), Dm=mat(0x0e0e0e), Gm=matT(0x66aacc,.50), Wm=mat(0x0e0e0e), Rm=mat(0x666666);
     const Lm=matE(0xffffaa,0x554400), TLm=matE(0xff1100,0x330000);
     // Splitter / nosecone (very low)
@@ -99,7 +100,7 @@ default: return this.buildSportsMesh();
 
   // ── Jeep / off-road (Rally Storm) ───────────────────
   buildJeepMesh(){
-    const g=new THREE.Group(), C=this.data.col;
+    const g=new THREE.Group(), C=this.bodyCol;
     const Bm=mat(C), Dm=mat(0x181818), Gm=matT(0x88aacc,.52), Wm=mat(0x181818), Rm=mat(0x555555);
     const Lm=matE(0xffffcc,0x443300), TLm=matE(0xff2200,0x330000);
     // High chassis body
@@ -147,7 +148,7 @@ default: return this.buildSportsMesh();
 
   // ── Hatchback (Flash Hatch) ─────────────────────────
   buildHatchMesh(){
-    const g=new THREE.Group(), C=this.data.col;
+    const g=new THREE.Group(), C=this.bodyCol;
     const Bm=mat(C), Dm=mat(0x111111), Gm=matT(0x7799bb,.55), Wm=mat(0x111111), Rm=mat(0x666666);
     const Lm=matE(0xffee88,0x443300);
     // Main body — compact, short

--- a/games/turborace/scripts/car.js
+++ b/games/turborace/scripts/car.js
@@ -30,8 +30,9 @@ function nearestWallPoint(px,pz,walls){
 }
 
 class Car {
-  constructor(data, pos, hdg, isPlayer, scene) {
+  constructor(data, pos, hdg, isPlayer, scene, colorOverride) {
     this.data = data; this.isPlayer = isPlayer;
+    this.colorOverride = colorOverride;
     this.pos = new THREE.Vector3(pos.x, pos.y, pos.z);
     this.hdg = hdg; this.spd = 0; this.gear = 1;
     this.gearbox = buildGearboxForCar(this.data);
@@ -46,7 +47,7 @@ class Car {
     this.stuckTimer = 0;               // for boundary recovery
     this.isReversing = false; this.revSpd = 0; this.reverseTimer = 0;
     this.onGravel = false;
-    const visual = createCarVisual(this.data);
+    const visual = createCarVisual(this.data, this.colorOverride);
     this.mesh = visual.mesh; this.tl = visual.tailLights; this.wh = visual.wheels;
     this.mesh.position.copy(this.pos); this.mesh.rotation.y = this.hdg;
     scene.add(this.mesh);
@@ -331,7 +332,7 @@ export function buildRaceGrid(trackPoints){
 
 export function instantiateRaceCars({ trackPoints, cars, selectedCarIndex, scene, createAIController, aiCount=4 }){
   const grid=buildRaceGrid(trackPoints);
-  const playerCar=new Car(getPlayerCarModel(cars, selectedCarIndex),grid[0].pos,grid[0].hdg,true,scene);
+  const playerCar=new Car(getPlayerCarModel(cars, selectedCarIndex),grid[0].pos,grid[0].hdg,true,scene,state.carColor);
 
   const aiCars=[];
   const aiControllers=[];

--- a/games/turborace/scripts/game.js
+++ b/games/turborace/scripts/game.js
@@ -49,7 +49,8 @@ import {
   showMain, showIntro, showTrkSel, showCarSel,
   showDiffSel, showOnlineTrkSel, showSettings, closeSettings,
   showVsLobby, vsCreateRoom, vsJoinRoom, vsStartRace, vsLeaveLobby,
-  vsCopyCode, vsCopyInviteLink
+  vsCopyCode, vsCopyInviteLink, vsLoadOnlineTracks,
+  onCarColorInput, resetCarColor, onVsColorInput
 } from './menu.js';
 import {
   closeTrackLeaderboardModal
@@ -279,6 +280,8 @@ document.getElementById('mainSettingsBtn').addEventListener('click',function(){t
 document.getElementById('backToSelectionBtn').addEventListener('click',()=>{ window.location.href='../index.html'; });
 document.getElementById('showTrkSelBtn').addEventListener('click',showDiffSel);
 document.getElementById('btnGo').addEventListener('click',startRace);
+document.getElementById('carColorPicker').addEventListener('input',e=>onCarColorInput(e.target.value));
+document.getElementById('carColorResetBtn').addEventListener('click',resetCarColor);
 document.getElementById('trkSelBackBtn').addEventListener('click',showMain);
 document.getElementById('loadOnlineTracksBtn').addEventListener('click',showOnlineTrkSel);
 document.getElementById('onlineTrkBackBtn').addEventListener('click',showTrkSel);
@@ -336,6 +339,9 @@ document.getElementById('vsLeaveLobbyBtn').addEventListener('click', vsLeaveLobb
 document.getElementById('vsLobbyBackBtn').addEventListener('click', vsLeaveLobby);
 document.getElementById('vsCopyCodeBtn').addEventListener('click', vsCopyCode);
 document.getElementById('vsCopyInviteBtn').addEventListener('click', vsCopyInviteLink);
+document.getElementById('vsLoadOnlineTracksBtn').addEventListener('click', vsLoadOnlineTracks);
+document.getElementById('vsHostColor').addEventListener('input', e=>onVsColorInput(e.target.value));
+document.getElementById('vsGuestColor').addEventListener('input', e=>onVsColorInput(e.target.value));
 
 // ═══════════════════════════════════════════════════════
 //  BOOT

--- a/games/turborace/scripts/menu.js
+++ b/games/turborace/scripts/menu.js
@@ -12,7 +12,7 @@ import {
 import { clearGhostVisual } from './ghost.js';
 import {
   loadEditorTracks, syncEditorTracksFromCloud,
-  loadTracksFromFolder
+  loadTracksFromFolder, getAllTracks, hexNumToCss, cssToHexNum
 } from './editor.js';
 import { VsNetwork, generateRoomCode, BOT_NAMES } from './vs-network.js';
 import { getArcadeUser } from './user.js';
@@ -148,11 +148,12 @@ export function showCarSel(){
       <div class="stat"><span class="sl">GRIP</span><div class="st"><div class="sf" style="width:${Math.round(c.hdl*100)}%"></div></div><span class="sv">${Math.round(c.hdl*100)}%</span></div>
       <div class="stat"><span class="sl">BRAKES</span><div class="st"><div class="sf" style="width:${Math.min(100,Math.round(c.brake*4))}%"></div></div><span class="sv">${c.brake}</span></div>`;
     const canvas=d.querySelector('.carCardCanvas');
-    const visual=createCarVisual(c);
+    const useColor=(state.selCar===i&&state.carColor!=null)?state.carColor:null;
+    const visual=createCarVisual(c,useColor);
     visual.mesh.scale.setScalar(0.72);
     visual.mesh.rotation.x=-0.1;
     visual.mesh.position.set(0,-0.2,0);
-    const preview={host:d,canvas,model:visual.mesh,hovered:false,selected:state.selCar===i,angle:0,spinSpeed:0,baseYaw:-0.55,
+    const preview={host:d,canvas,model:visual.mesh,hovered:false,selected:state.selCar===i,carIdx:i,angle:0,spinSpeed:0,baseYaw:-0.55,
       renderer:new THREE.WebGLRenderer({canvas,alpha:true,antialias:true,powerPreference:'low-power'})};
     preview.renderer.setPixelRatio(Math.min(window.devicePixelRatio||1,1.6));
     preview.renderer.outputColorSpace=THREE.SRGBColorSpace;
@@ -161,6 +162,8 @@ export function showCarSel(){
       document.querySelectorAll('#carCards .card').forEach(x=>x.classList.remove('sel'));
       d.classList.add('sel'); state.selCar=i; document.getElementById('btnGo').disabled=false;
       state.carCardPreviews.forEach(item=>{ item.selected=item.host===d; });
+      _syncCarColorPicker();
+      _refreshSpCarColors();
       startCarCardPreviews();
     };
     d.onmouseenter=()=>{ preview.hovered=true; startCarCardPreviews(); };
@@ -168,6 +171,47 @@ export function showCarSel(){
     d.onclick=setSel;
     ct.appendChild(d);
   });
+  _syncCarColorPicker();
+  startCarCardPreviews();
+}
+
+// Rebuild a preview's 3D model with an optional body-colour override.
+function _recolorPreviewModel(preview,colorNum){
+  if(preview.carIdx==null) return;
+  const visual=createCarVisual(CARS[preview.carIdx],colorNum);
+  visual.mesh.scale.setScalar(0.72);
+  visual.mesh.rotation.x=-0.1;
+  visual.mesh.position.set(0,-0.2,0);
+  preview.model=visual.mesh;
+}
+
+// Single-player car cards: selected card shows the chosen colour, others stay default.
+function _refreshSpCarColors(){
+  state.carCardPreviews.filter(p=>!p._vsContainer).forEach(p=>{
+    _recolorPreviewModel(p,(p.selected&&state.carColor!=null)?state.carColor:null);
+  });
+}
+
+// Point the colour <input> at the current selection's colour (custom or car default).
+function _syncCarColorPicker(){
+  const cp=document.getElementById('carColorPicker');
+  if(!cp) return;
+  const def=CARS[state.selCar??0]?.hex||'#ffffff';
+  cp.value=state.carColor!=null?hexNumToCss(state.carColor):def;
+}
+
+// Wired from the car-select colour <input>.
+export function onCarColorInput(css){
+  state.carColor=cssToHexNum(css);
+  _refreshSpCarColors();
+  startCarCardPreviews();
+}
+
+// Wired from the "default" button — revert to the car's stock colour.
+export function resetCarColor(){
+  state.carColor=null;
+  _syncCarColorPicker();
+  _refreshSpCarColors();
   startCarCardPreviews();
 }
 
@@ -299,6 +343,7 @@ let _vsRoster = [];
 let _vsTrackId = null;
 let _vsGameRunning = false;
 let _vsLobbyPruneInterval = null;
+let _vsShowOnline = false;   // host loaded online (custom/cloud) tracks into the picker
 
 // ── Internal helpers ──────────────────────────────────────────────────────────
 
@@ -376,7 +421,7 @@ function _renderVsSlots() {
       else                     statusEl.textContent = `${total} player${total > 1 ? 's' : ''} ready!`;
     } else {
       const trk = _vsTrackId
-        ? (state.folderTracks.find(t => String(t.id) === String(_vsTrackId))?.name ?? 'selected')
+        ? (getAllTracks().find(t => String(t.id) === String(_vsTrackId))?.name ?? 'selected')
         : null;
       statusEl.textContent = trk
         ? `Track: ${trk} — waiting for host to start…`
@@ -419,7 +464,7 @@ function _vsKickPlayer(id) {
 function _buildVsTrkCards() {
   const container = document.getElementById('vsTrackCards');
   if (!container) return;
-  const tracks = state.folderTracks || [];
+  const tracks = _vsShowOnline ? getAllTracks() : (state.folderTracks || []);
   const COLORS = ['#4488ff', '#44cc66', '#ffaa22', '#ff4488', '#22ddaa', '#dd66ff', '#66bbff'];
   container.innerHTML = '';
   tracks.forEach((t, i) => {
@@ -438,6 +483,18 @@ function _buildVsTrkCards() {
     };
     container.appendChild(card);
   });
+}
+
+// Host: pull custom/cloud tracks into the VS picker (mirrors single-player "load online tracks")
+export async function vsLoadOnlineTracks() {
+  if (!state.vsIsHost) return;
+  const btn = document.getElementById('vsLoadOnlineTracksBtn');
+  if (btn) { btn.disabled = true; btn.textContent = 'LOADING…'; }
+  loadEditorTracks();
+  await syncEditorTracksFromCloud().catch(() => {});
+  _vsShowOnline = true;
+  _buildVsTrkCards();
+  if (btn) { btn.disabled = false; btn.textContent = '✓ ONLINE TRACKS LOADED'; }
 }
 
 // ── Inline car selector ───────────────────────────────────────────────────────
@@ -463,12 +520,13 @@ function _buildVsCarRow(containerId, onSelect) {
     const nm = document.createElement('span'); nm.textContent = c.name;
     d.appendChild(cvs); d.appendChild(nm);
 
-    const visual = createCarVisual(c);
+    const useColor = (state.selCar === i && state.carColor != null) ? state.carColor : null;
+    const visual = createCarVisual(c, useColor);
     visual.mesh.scale.setScalar(0.72);
     visual.mesh.rotation.x = -0.1;
     visual.mesh.position.set(0, -0.2, 0);
     const preview = {
-      host: d, canvas: cvs, model: visual.mesh, hovered: false, selected: state.selCar === i,
+      host: d, canvas: cvs, model: visual.mesh, hovered: false, selected: state.selCar === i, carIdx: i,
       angle: 0, spinSpeed: 0, baseYaw: -0.55, _vsContainer: containerId,
       renderer: new THREE.WebGLRenderer({ canvas: cvs, alpha: true, antialias: true, powerPreference: 'low-power' }),
     };
@@ -482,12 +540,45 @@ function _buildVsCarRow(containerId, onSelect) {
       container.querySelectorAll('.vsCarChip').forEach(x => x.classList.remove('sel'));
       d.classList.add('sel'); state.selCar = i;
       state.carCardPreviews.forEach(item => { item.selected = item.host === d; });
+      _refreshVsCarColors(containerId);
       startCarCardPreviews();
       onSelect(i);
     };
     container.appendChild(d);
   });
+  _refreshVsCarColors(containerId);
   startCarCardPreviews();
+}
+
+// VS car chips: selected chip shows the chosen colour, others stay default.
+function _refreshVsCarColors(containerId) {
+  state.carCardPreviews.filter(p => p._vsContainer === containerId).forEach(p => {
+    _recolorPreviewModel(p, (p.selected && state.carColor != null) ? state.carColor : null);
+  });
+}
+
+// Wired from the VS car-colour <input> (host + guest share one element id each).
+export function onVsColorInput(css) {
+  state.carColor = cssToHexNum(css);
+  if (state.vsIsHost) {
+    const me = _vsRoster.find(e => e.id === state.vsNetwork?.myId);
+    if (me) { me.color = state.carColor; _hostSyncRoster(); }
+    _refreshVsCarColors('vsHostCarRow');
+  } else {
+    state.vsNetwork?.sendGuestReady(state.selCar ?? 0, state.carColor);
+    _refreshVsCarColors('vsGuestCarRow');
+  }
+  startCarCardPreviews();
+}
+
+// Point the VS colour inputs at the current chosen colour (custom or car default).
+function _syncVsColorPickers() {
+  const def = CARS[state.selCar ?? 0]?.hex || '#ffffff';
+  const val = state.carColor != null ? hexNumToCss(state.carColor) : def;
+  ['vsHostColor', 'vsGuestColor'].forEach(id => {
+    const el = document.getElementById(id);
+    if (el) el.value = val;
+  });
 }
 
 // ── Room panel (shown after connect) ─────────────────────────────────────────
@@ -501,16 +592,22 @@ function _showVsRoomPanel(isHost) {
   document.getElementById('vsGuestSection').style.display = isHost ? 'none' : 'flex';
 
   _renderVsSlots();
+  _syncVsColorPickers();
 
   if (isHost) {
+    const onlineBtn = document.getElementById('vsLoadOnlineTracksBtn');
+    if (onlineBtn) {
+      onlineBtn.disabled = false;
+      onlineBtn.textContent = _vsShowOnline ? '✓ ONLINE TRACKS LOADED' : 'LOAD ONLINE TRACKS';
+    }
     _buildVsTrkCards();
     _buildVsCarRow('vsHostCarRow', carIdx => {
       const me = _vsRoster.find(e => e.id === state.vsNetwork?.myId);
-      if (me) { me.carIdx = carIdx; _hostSyncRoster(); }
+      if (me) { me.carIdx = carIdx; me.color = state.carColor; _hostSyncRoster(); }
     });
   } else {
     _buildVsCarRow('vsGuestCarRow', carIdx => {
-      state.vsNetwork?.sendGuestReady(carIdx);
+      state.vsNetwork?.sendGuestReady(carIdx, state.carColor);
     });
   }
 }
@@ -522,7 +619,7 @@ function _attachVsHandlers(net, isHost) {
   net.onPresenceLeave = (_left) => { /* pruning handled by interval */ };
 
   // player_hello: a new player joined the channel
-  net.onPlayerHello = ({ id, name, isHost: playerIsHost, carIdx }) => {
+  net.onPlayerHello = ({ id, name, isHost: playerIsHost, carIdx, color }) => {
     if (!isHost) return; // only host manages the roster
     if (_vsRoster.find(e => e.id === id)) {
       // Already in roster — resync so the new arrival gets full state
@@ -535,7 +632,7 @@ function _attachVsHandlers(net, isHost) {
       stale.id = id;
       stale.isHost = !!playerIsHost;
     } else {
-      _vsRoster.push({ id, name, isAI: false, isHost: !!playerIsHost, carIdx: carIdx ?? 0 });
+      _vsRoster.push({ id, name, isAI: false, isHost: !!playerIsHost, carIdx: carIdx ?? 0, color: color ?? null });
     }
     _hostSyncRoster();
   };
@@ -549,10 +646,10 @@ function _attachVsHandlers(net, isHost) {
   };
 
   // guest_ready: guest changed car selection — host updates roster entry
-  net.onGuestReady = ({ id, carIdx }) => {
+  net.onGuestReady = ({ id, carIdx, color }) => {
     if (!isHost) return;
     const entry = _vsRoster.find(e => e.id === id);
-    if (entry) { entry.carIdx = carIdx; _hostSyncRoster(); }
+    if (entry) { entry.carIdx = carIdx; if (color !== undefined) entry.color = color; _hostSyncRoster(); }
   };
 
   // lobby_state: host-authoritative snapshot (guests apply, host ignores)
@@ -567,15 +664,12 @@ function _attachVsHandlers(net, isHost) {
 
   // return_lobby: host sent everyone back after a race
   net.onReturnLobby = () => {
-    if (!isHost) {
-      _vsGameRunning = false;
-      _showVsRoomPanel(false);
-    }
+    if (!isHost) _enterVsLobbyRoom();
   };
 
   // game_start: all clients launch the race
-  net.onGameStart = ({ slots, trackId }) => {
-    _launchVsRace(slots, trackId);
+  net.onGameStart = ({ slots, trackId, trackData }) => {
+    _launchVsRace(slots, trackId, trackData);
   };
 
   // player_kick
@@ -606,9 +700,14 @@ function _attachVsHandlers(net, isHost) {
   };
 
   // 30-second safety-net: prune truly disconnected players (host only)
+  if (isHost) _startVsLobbyPrune(net);
+}
+
+// Host-only safety-net interval that drops players who vanished from presence.
+function _startVsLobbyPrune(net) {
   if (_vsLobbyPruneInterval) clearInterval(_vsLobbyPruneInterval);
   _vsLobbyPruneInterval = setInterval(() => {
-    if (state.gState !== 'vsLobby' || !isHost) return;
+    if (state.gState !== 'vsLobby' || !state.vsIsHost) return;
     const fresh = net.getPresencePlayers();
     if (!fresh.length) return; // presence not yet synced — don't prune
     const freshIds = new Set(fresh.map(p => p.id));
@@ -621,12 +720,46 @@ function _attachVsHandlers(net, isHost) {
 
 // ── Race launch ───────────────────────────────────────────────────────────────
 
-function _launchVsRace(slots, trackId) {
+function _launchVsRace(slots, trackId, trackData) {
   state.vsMode = true;
+  _vsGameRunning = true;
   if (_vsLobbyPruneInterval) { clearInterval(_vsLobbyPruneInterval); _vsLobbyPruneInterval = null; }
   disposeCarCardPreviews();
   document.querySelectorAll('.screen,#results').forEach(s => s.style.display = 'none');
-  import('./race.js').then(m => m.initVsRace(slots, trackId));
+  import('./race.js').then(m => m.initVsRace(slots, trackId, trackData));
+}
+
+// Bring everyone back to the lobby room panel after a race (keeps the network/roster alive).
+// Host broadcasts return_lobby; guests get here via net.onReturnLobby.
+export function vsReturnToLobby() {
+  if (!state.vsNetwork) { showMain(); return; }
+  if (state.vsIsHost) state.vsNetwork.sendReturnLobby();
+  _enterVsLobbyRoom();
+}
+
+function _enterVsLobbyRoom() {
+  state.vsMode = false;
+  _vsGameRunning = false;
+  // Tear down the finished race scene (keep the network/roster alive)
+  stopAudio();
+  for (const c of state.allCars) scene.remove(c.mesh);
+  state.allCars = []; state.aiCars = []; state.pCar = null;
+  state.vsCarsById = {}; state.vsCarStates = {}; state.vsCarBuffers = {}; state.vsFinished = {};
+  clearGhostVisual();
+  document.querySelectorAll('.screen,#results').forEach(s => s.style.display = 'none');
+  document.getElementById('hud').style.display = 'none';
+  document.getElementById('hint').style.display = 'none';
+  document.getElementById('pauseMenu').style.display = 'none';
+  document.getElementById('touchControls').style.display = 'none';
+  dc.style.display = 'none';
+  document.getElementById('sVsLobby').style.display = 'flex';
+  document.getElementById('vsJoinPanel').style.display = 'none';
+  state.gState = 'vsLobby';
+  updateTouchControlsVisibility(state.gState);
+  releaseAllTouchControls();
+  if (audioReady) startMusic();
+  if (state.vsIsHost && state.vsNetwork) _startVsLobbyPrune(state.vsNetwork);
+  _showVsRoomPanel(state.vsIsHost);
 }
 
 // ── Copy helpers ──────────────────────────────────────────────────────────────
@@ -648,9 +781,14 @@ export function showVsLobby() {
   _vsRoster = [];
   _vsTrackId = null;
   _vsGameRunning = false;
+  _vsShowOnline = false;
   if (_vsLobbyPruneInterval) { clearInterval(_vsLobbyPruneInterval); _vsLobbyPruneInterval = null; }
 
   loadTracksFromFolder().catch(() => {});
+  // Pre-load custom/cloud tracks on every client so guests can resolve an online
+  // track the host might pick (the host also gets them via the LOAD ONLINE button).
+  loadEditorTracks();
+  syncEditorTracksFromCloud().catch(() => {});
 
   document.querySelectorAll('.screen,#results').forEach(s => s.style.display = 'none');
   document.getElementById('sVsLobby').style.display = 'flex';
@@ -688,13 +826,13 @@ export async function vsCreateRoom() {
   state.vsMyId = net.myId;
 
   // Pre-seed own slot so the UI isn't empty while connecting
-  _vsRoster = [{ id: net.myId, name, isAI: false, isHost: true, carIdx: state.selCar }];
+  _vsRoster = [{ id: net.myId, name, isAI: false, isHost: true, carIdx: state.selCar, color: state.carColor }];
 
   _attachVsHandlers(net, true);
 
   _vsSetStatus('Connecting…');
   try {
-    await net.joinRoom(code, name, true, state.selCar);
+    await net.joinRoom(code, name, true, state.selCar, state.carColor);
   } catch (e) {
     _vsSetStatus('❌ Connection failed: ' + e.message);
     return;
@@ -722,13 +860,13 @@ export async function vsJoinRoom() {
   state.vsMyId = net.myId;
 
   // Pre-seed own slot so the UI isn't empty while connecting
-  _vsRoster = [{ id: net.myId, name, isAI: false, isHost: false, carIdx: state.selCar }];
+  _vsRoster = [{ id: net.myId, name, isAI: false, isHost: false, carIdx: state.selCar, color: state.carColor }];
 
   _attachVsHandlers(net, false);
 
   _vsSetStatus('Joining…');
   try {
-    await net.joinRoom(code, name, false, state.selCar);
+    await net.joinRoom(code, name, false, state.selCar, state.carColor);
   } catch (e) {
     _vsSetStatus('❌ Connection failed: ' + e.message);
     return;
@@ -743,9 +881,10 @@ export function vsStartRace() {
   if (_vsRoster.length < 2) { _vsSetStatus('❌ Need at least 2 players/AIs'); return; }
 
   _vsGameRunning = true;
-  const slots = _vsRoster.map(p => ({ id: p.id, name: p.name, isAI: p.isAI, carIdx: p.carIdx ?? 0 }));
-  state.vsNetwork.sendGameStart(slots, _vsTrackId);
-  _launchVsRace(slots, _vsTrackId);
+  const slots = _vsRoster.map(p => ({ id: p.id, name: p.name, isAI: p.isAI, carIdx: p.carIdx ?? 0, color: p.color ?? null }));
+  const trackData = getAllTracks().find(t => String(t.id) === String(_vsTrackId)) || null;
+  state.vsNetwork.sendGameStart(slots, _vsTrackId, trackData);
+  _launchVsRace(slots, _vsTrackId, trackData);
 }
 
 export function vsLeaveLobby() {

--- a/games/turborace/scripts/race.js
+++ b/games/turborace/scripts/race.js
@@ -82,7 +82,7 @@ export async function initRace(){
  * @param {Array} slots   [{id, name, isAI, carIdx}] ordered by grid position
  * @param {string} trackId
  */
-export async function initVsRace(slots, trackId){
+export async function initVsRace(slots, trackId, trackData){
   // Clean up previous race
   for(const ctrl of state.aiControllers)if(ctrl.destroy)ctrl.destroy();
   for(const c of state.allCars)scene.remove(c.mesh);
@@ -93,7 +93,8 @@ export async function initVsRace(slots, trackId){
 
   state.vsSlots=slots;
   state.selTrk=trackId;
-  state.trkData=getTrackById(trackId);
+  // Prefer the track data sent by the host (covers online tracks a guest hasn't synced yet)
+  state.trkData=trackData||getTrackById(trackId);
   try{ buildTrack(state.trkData); }catch(e){ console.error('buildTrack VS error:',e); }
   setupLights();
 
@@ -105,7 +106,7 @@ export async function initVsRace(slots, trackId){
     const carData=CARS[slot.carIdx??0];
     const gp=grid[i]||grid[grid.length-1];
     const isMe=slot.id===state.vsMyId;
-    const car=new Car(carData, gp.pos, gp.hdg, isMe, scene);
+    const car=new Car(carData, gp.pos, gp.hdg, isMe, scene, slot.color);
     car.aiAgg=0.88+i*0.03;
     state.vsCarsById[slot.id]=car;
     state.allCars.push(car);
@@ -320,8 +321,8 @@ export function restartRace(){
   releaseAllTouchControls();
   document.getElementById('results').style.display='none';
   if(state.vsMode){
-    // Go back to main menu — VS session ends after one race
-    import('./menu.js').then(m=>m.showMain());
+    // Return everyone to the VS lobby so they can pick a new track/car
+    import('./menu.js').then(m=>m.vsReturnToLobby());
     return;
   }
   void initRace();

--- a/games/turborace/scripts/state.js
+++ b/games/turborace/scripts/state.js
@@ -23,6 +23,7 @@ export const state = {
     camMode: 'chase',
     gState: 'menu',
     selCar: null,
+    carColor: null,          // chosen car body colour (hex number) or null = car default
     selTrk: null,
     aiDifficulty: 'medium',  // 'easy' | 'medium' | 'hard'
     opponentMode: 'ai',      // 'ai' | 'ghost'

--- a/games/turborace/scripts/version.js
+++ b/games/turborace/scripts/version.js
@@ -1,1 +1,1 @@
-export const TURBORACE_VERSION = 'v0.130';
+export const TURBORACE_VERSION = 'v0.131';

--- a/games/turborace/scripts/vs-network.js
+++ b/games/turborace/scripts/vs-network.js
@@ -25,7 +25,7 @@ export class VsNetwork {
     this.onPlayerFinished = null;  // ({id, finTime})
   }
 
-  async joinRoom(roomCode, playerName, isHost, carIdx = 0) {
+  async joinRoom(roomCode, playerName, isHost, carIdx = 0, color = null) {
     this.roomCode = roomCode;
 
     this.channel = supabase.channel(`turborace-vs:${roomCode}`, {
@@ -61,7 +61,7 @@ export class VsNetwork {
           } catch (e) {
             console.warn('[vs-network] presence track failed:', e);
           }
-          this.#send('player_hello', { id: this.myId, name: playerName, isHost, carIdx });
+          this.#send('player_hello', { id: this.myId, name: playerName, isHost, carIdx, color });
           resolve();
         } else if (status === 'CHANNEL_ERROR' || status === 'TIMED_OUT') {
           reject(new Error(`Channel ${status}`));
@@ -77,7 +77,7 @@ export class VsNetwork {
   // ── Lobby ─────────────────────────────────────────────────────────────────────
   sendPlayerLeave(id) { return this.#send('player_leave', { id }); }
 
-  sendGuestReady(carIdx) { return this.#send('guest_ready', { id: this.myId, carIdx }); }
+  sendGuestReady(carIdx, color = null) { return this.#send('guest_ready', { id: this.myId, carIdx, color }); }
 
   // Host broadcasts the full ordered roster so every client renders identical UI.
   // roster: [{id, name, isAI, isHost, carIdx}]; trackId: string|null; gameRunning: bool
@@ -90,7 +90,7 @@ export class VsNetwork {
   sendPlayerKick(targetId) { return this.#send('player_kick', { targetId }); }
 
   // ── Race ──────────────────────────────────────────────────────────────────────
-  sendGameStart(slots, trackId) { return this.#send('game_start', { slots, trackId }); }
+  sendGameStart(slots, trackId, trackData = null) { return this.#send('game_start', { slots, trackId, trackData }); }
 
   sendPosUpdate(id, x, z, hdg, spd, lap, totalProg) {
     return this.#send('pos_update', { id, x, z, hdg, spd, lap, totalProg });

--- a/games/turborace/styles/game.css
+++ b/games/turborace/styles/game.css
@@ -243,6 +243,14 @@ body{background:#000;overflow:hidden;font-family:'Rajdhani',sans-serif;color:#ff
 .vsCarChip:hover,.vsCarChip.sel{border-color:#c44aff;background:rgba(196,74,255,.08);color:#d88eff;transform:translateY(-2px);box-shadow:0 4px 16px rgba(196,74,255,.2);}
 .vsCarCanvas{display:block;width:80px;height:56px;border-radius:6px;background:radial-gradient(circle at 50% 65%,rgba(255,255,255,.06),transparent 70%);}
 
+/* Car colour pickers (car-select + VS lobby) */
+.carColorRow{display:flex;align-items:center;justify-content:center;gap:12px;margin:14px 0 4px;}
+.vsColorRow{display:flex;align-items:center;justify-content:center;gap:10px;margin-top:12px;}
+.carColorLabel{font-family:'Orbitron',monospace;font-size:10px;letter-spacing:3px;color:#445;text-transform:uppercase;}
+.carColorInput{width:46px;height:34px;padding:2px;border:2px solid rgba(255,255,255,.12);border-radius:8px;background:rgba(255,255,255,.03);cursor:pointer;}
+.carColorInput::-webkit-color-swatch{border:none;border-radius:5px;}
+.carColorInput::-moz-color-swatch{border:none;border-radius:5px;}
+
 /* VS track cards */
 .vsTrackList{display:flex;gap:10px;flex-wrap:wrap;justify-content:center;}
 .vsTrackCard{display:flex;flex-direction:column;align-items:center;gap:6px;padding:8px;border-radius:8px;border:2px solid rgba(255,255,255,.06);background:rgba(255,255,255,.02);cursor:pointer;transition:all .12s;font-size:10px;color:#778;font-family:'Orbitron',monospace;letter-spacing:1px;text-align:center;}


### PR DESCRIPTION
## Summary

- F³ Racing VS mode: rematch from lobby, online tracks, car colour picker
- AI Trainer game added; F³ Racing Experimental removed
- Remote car movement: dead-reckoning + error correction
- Snapshot-buffered interpolation for remote VS cars
- Bomber: fix chain explosions, lobby kicks, bomb timer desync
- Bomber: fix lobby presence race and player display
- Bomber: rework lobby into persistent, host-authoritative room
- Fix spurious lobby disconnects
- Bomberman: music, SFX, bomb kicking, points system & leaderboards
- Turborace: VS online multiplayer with 4-player lobby
- Auto-create PR after every git push

---
_Generated by [Claude Code](https://claude.ai/code/session_01HGApbD8iH5jPsd2jj8sqX5)_