### PR TITLE
fix(ai-trainer): lap-2 wrapPi overflow, WASM loading, GPU backend

### DIFF
--- a/games/ai-trainer/index.html
+++ b/games/ai-trainer/index.html
@@ -393,7 +393,7 @@
   <span class="hud-chip" id="hudBest">REWARD —</span>
   <span class="hud-chip" id="hudAvg">BEST LAP —</span>
   <span class="hud-chip" id="hudSigma" title="Policy exploration noise σ (steer/throttle) — shrinks as AI gets confident">σ —</span>
-  <span class="hud-chip" id="hudWasm" title="Gradient computation backend — WASM = compiled native code, JS = fallback" style="color:#888;font-size:.65rem;">JS</span>
+  <span class="hud-chip" id="hudWasm" title="Gradient compute backend — GPU = WebGPU, WASM = compiled native code, JS = fallback" style="color:#888;font-size:.65rem;">…</span>
   <span class="hud-sep">│</span>
   <span class="hud-chip" id="hudTrack" style="color:#4af;">—</span>
   <button class="btn" id="mapsBtn" title="Choose a different map">MAPS</button>
@@ -559,6 +559,11 @@
     <!-- Training -->
     <div class="config-panel">
       <div class="config-panel-title">📊 TRAINING</div>
+      <div class="config-row">
+        <span class="config-label">COMPUTE BACKEND</span>
+        <div class="opt-group" id="configBackendBtns"></div>
+        <span style="color:#445;font-size:.58rem;">AUTO = multi-core WASM · GPU = WebGPU (experimental, self-validating) · JS = plain fallback</span>
+      </div>
       <div class="config-row">
         <span class="config-label">STEPS PER UPDATE (HORIZON)</span>
         <div class="opt-group" id="configHorizonBtns"></div>

--- a/games/ai-trainer/scripts/gpu-grad.js
+++ b/games/ai-trainer/scripts/gpu-grad.js
@@ -1,0 +1,340 @@
+'use strict';
+// ─────────────────────────────────────────────────────────────────────────────
+//  gpu-grad.js — WebGPU PPO gradient backend (experimental)
+//
+//  Computes the same gradient sums as nn-core.js accumulatePPOGrads(), but on
+//  the GPU: each shader thread processes a group of samples (forward + PPO
+//  loss + backward) into its own gradient slab; a second kernel reduces the
+//  slabs into one gradient vector that is read back to the CPU for the Adam
+//  step.
+//
+//  WGSL is generated per network architecture with all layer sizes and buffer
+//  offsets baked in as constants (full layer unrolling — no runtime-indexed
+//  size tables).  Precision is f32; the sim-worker validates the first GPU
+//  minibatch against the f64 JS path and disables the backend on mismatch.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const LOG_2PI = Math.log(2 * Math.PI);
+
+function paramCount(sizes) {
+  let n = 0;
+  for (let l = 0; l < sizes.length - 1; l++) n += sizes[l] * sizes[l + 1] + sizes[l + 1];
+  return n;
+}
+
+// Per-layer weight/bias offsets within a flat array starting at `base`.
+function layerOffsets(sizes, base) {
+  const wOff = [], bOff = [];
+  let off = base;
+  for (let l = 0; l < sizes.length - 1; l++) {
+    wOff.push(off); off += sizes[l] * sizes[l + 1];
+    bOff.push(off); off += sizes[l + 1];
+  }
+  return { wOff, bOff };
+}
+
+// Activation base offsets within the shared acts array (input at 0).
+function actBases(sizes) {
+  const bases = [0];
+  for (let l = 0; l < sizes.length; l++) bases.push(bases[l] + sizes[l]);
+  return bases; // bases[l] = start of layer-l activations
+}
+
+function emitForward(sizes, wOff, bOff, bases) {
+  let code = '';
+  for (let l = 0; l < sizes.length - 1; l++) {
+    const nIn = sizes[l], nOut = sizes[l + 1];
+    const last = l === sizes.length - 2;
+    code += `
+    for (var j = 0u; j < ${nOut}u; j++) {
+      var sum = weights[${bOff[l]}u + j];
+      let row = ${wOff[l]}u + j * ${nIn}u;
+      for (var i = 0u; i < ${nIn}u; i++) { sum += weights[row + i] * acts[${bases[l]}u + i]; }
+      acts[${bases[l + 1]}u + j] = ${last ? 'sum' : 'tanh(sum)'};
+    }`;
+  }
+  return code;
+}
+
+// Backward pass: reads delta from dcur[0..nOut), accumulates into the slab
+// (same offsets as the weights array — the slab mirrors its layout), and
+// leaves the previous layer's delta in dcur for the next iteration.
+function emitBackward(sizes, wOff, bOff, bases) {
+  let code = '';
+  for (let l = sizes.length - 2; l >= 0; l--) {
+    const nIn = sizes[l], nOut = sizes[l + 1];
+    const hasPrev = l > 0;
+    code += `
+    ${hasPrev ? `for (var i = 0u; i < ${nIn}u; i++) { dnxt[i] = 0.0; }` : ''}
+    for (var j = 0u; j < ${nOut}u; j++) {
+      let dj = dcur[j];
+      if (dj != 0.0) {
+        slabs[sb + ${bOff[l]}u + j] += dj;
+        let row = ${wOff[l]}u + j * ${nIn}u;
+        for (var i = 0u; i < ${nIn}u; i++) {
+          slabs[sb + row + i] += dj * acts[${bases[l]}u + i];
+          ${hasPrev ? 'dnxt[i] += dj * weights[row + i];' : ''}
+        }
+      }
+    }
+    ${hasPrev ? `
+    for (var i = 0u; i < ${nIn}u; i++) {
+      let av = acts[${bases[l]}u + i];
+      dcur[i] = dnxt[i] * (1.0 - av * av);
+    }` : ''}`;
+  }
+  return code;
+}
+
+function genWGSL(lay) {
+  const { AS, CS, I, A, CAP, GROUP, SLAB, aP, cP, OUT } = lay;
+  const aOffs = layerOffsets(AS, 0);
+  const cOffs = layerOffsets(CS, aP);
+  const aBases = actBases(AS);
+  const cBases = actBases(CS); // shares the acts array; safe — critic runs after actor backward
+  const ACTS = Math.max(aBases[AS.length], cBases[CS.length]);
+  const MAXW = Math.max(...AS, ...CS);
+  const MUB  = aBases[AS.length - 1];   // actor output (means) base
+  const CVB  = cBases[CS.length - 1];   // critic output base
+  const LS   = aP + cP;                 // logStd offset in weights buffer
+  const GLS  = aP + cP;                 // gLogStd offset in slab
+  const LOSS = aP + cP + A;             // [pi, v, ent] offset in slab
+  // batch buffer region offsets (capacity-based)
+  const OB = 0, AB = CAP * I, LB = CAP * (I + A), DB = LB + CAP, RB = DB + CAP;
+
+  return /* wgsl */ `
+struct Uni { n: u32, nGroups: u32, clip: f32, entCoef: f32, vfCoef: f32 };
+@group(0) @binding(0) var<storage, read>        weights : array<f32>;
+@group(0) @binding(1) var<storage, read>        batch   : array<f32>;
+@group(0) @binding(2) var<storage, read_write>  slabs   : array<f32>;
+@group(0) @binding(3) var<storage, read_write>  outg    : array<f32>;
+@group(0) @binding(4) var<uniform>              uni     : Uni;
+
+@compute @workgroup_size(64)
+fn grad_main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let g = gid.x;
+  if (g >= uni.nGroups) { return; }
+  let sb = g * ${SLAB}u;
+  var acts : array<f32, ${ACTS}>;
+  var dcur : array<f32, ${MAXW}>;
+  var dnxt : array<f32, ${MAXW}>;
+  var lossPi  = 0.0;
+  var lossV   = 0.0;
+  var lossEnt = 0.0;
+
+  let k0 = g * ${GROUP}u;
+  let k1 = min(uni.n, k0 + ${GROUP}u);
+  for (var k = k0; k < k1; k++) {
+    for (var i = 0u; i < ${I}u; i++) { acts[i] = batch[${OB}u + k * ${I}u + i]; }
+
+    // ── Actor forward ──
+    ${emitForward(AS, aOffs.wOff, aOffs.bOff, aBases)}
+
+    // ── Gaussian log-prob of the stored action ──
+    var lp = 0.0;
+    for (var d = 0u; d < ${A}u; d++) {
+      let ls = weights[${LS}u + d];
+      let sd = exp(ls);
+      let z  = (batch[${AB}u + k * ${A}u + d] - acts[${MUB}u + d]) / sd;
+      lp += -0.5 * z * z - ls - ${0.5 * LOG_2PI};
+    }
+
+    // ── PPO clipped surrogate ──
+    let ratio = exp(min(20.0, lp - batch[${LB}u + k]));
+    let advk  = batch[${DB}u + k];
+    let clp   = clamp(ratio, 1.0 - uni.clip, 1.0 + uni.clip);
+    let surr1 = ratio * advk;
+    let surr2 = clp * advk;
+    lossPi += -min(surr1, surr2);
+
+    var coef = 0.0;
+    if (surr1 <= surr2) { coef = -advk * ratio; }
+    if (coef != 0.0) {
+      for (var d = 0u; d < ${A}u; d++) {
+        let ls   = weights[${LS}u + d];
+        let sd2  = exp(2.0 * ls);
+        let diff = batch[${AB}u + k * ${A}u + d] - acts[${MUB}u + d];
+        dcur[d] = coef * diff / sd2;
+        slabs[sb + ${GLS}u + d] += coef * (diff * diff / sd2 - 1.0);
+      }
+      // ── Actor backward ──
+      ${emitBackward(AS, aOffs.wOff, aOffs.bOff, aBases)}
+    }
+
+    // ── Entropy bonus ──
+    for (var d = 0u; d < ${A}u; d++) {
+      slabs[sb + ${GLS}u + d] += -uni.entCoef;
+      lossEnt += weights[${LS}u + d] + ${0.5 * (LOG_2PI + 1)};
+    }
+
+    // ── Critic forward (overwrites actor hidden acts — actor pass is done) ──
+    ${emitForward(CS, cOffs.wOff, cOffs.bOff, cBases)}
+    let v  = acts[${CVB}u];
+    let dr = v - batch[${RB}u + k];
+    lossV += 0.5 * dr * dr;
+    dcur[0] = uni.vfCoef * dr;
+    // ── Critic backward ──
+    ${emitBackward(CS, cOffs.wOff, cOffs.bOff, cBases)}
+  }
+
+  slabs[sb + ${LOSS}u + 0u] = lossPi;
+  slabs[sb + ${LOSS}u + 1u] = lossV;
+  slabs[sb + ${LOSS}u + 2u] = lossEnt;
+}
+
+@compute @workgroup_size(256)
+fn reduce_main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let p = gid.x;
+  if (p >= ${OUT}u) { return; }
+  var s = 0.0;
+  for (var g = 0u; g < uni.nGroups; g++) { s += slabs[g * ${SLAB}u + p]; }
+  outg[p] = s;
+}
+`;
+}
+
+export class GpuGrad {
+  // Returns { ok: true, gpu } or { ok: false, error } — never throws.
+  static async create(actorSizes, criticSizes, cap) {
+    try {
+      if (!(self.navigator && navigator.gpu)) {
+        return { ok: false, error: 'WebGPU not available in this browser/worker' };
+      }
+      const adapter = await navigator.gpu.requestAdapter();
+      if (!adapter) return { ok: false, error: 'no WebGPU adapter (GPU blocked or unsupported)' };
+      const device = await adapter.requestDevice();
+      const g = new GpuGrad(device, actorSizes, criticSizes, cap | 0 || 256);
+      await g._build();
+      return { ok: true, gpu: g };
+    } catch (err) {
+      return { ok: false, error: String(err && err.message || err) };
+    }
+  }
+
+  constructor(device, actorSizes, criticSizes, cap) {
+    this.device = device;
+    this.lost = false;
+    device.lost.then(() => { this.lost = true; });
+
+    const AS = actorSizes.slice(), CS = criticSizes.slice();
+    const I = AS[0], A = AS[AS.length - 1];
+    const aP = paramCount(AS), cP = paramCount(CS);
+    const SLAB = aP + cP + A + 4;          // grads + gLogStd + [pi, v, ent, pad]
+    const OUT  = aP + cP + A + 4;
+
+    // Samples per thread: keep the slab buffer under ~48 MB.
+    let GROUP = 4;
+    while (Math.ceil(cap / GROUP) * SLAB * 4 > 48 * 1024 * 1024) GROUP *= 2;
+
+    this.lay = { AS, CS, I, A, CAP: cap, GROUP, SLAB, aP, cP, OUT };
+    this.cap = cap;
+    this.W = aP + cP + A;                  // weights buffer length (floats)
+    this._wScratch = new Float32Array(this.W);
+  }
+
+  async _build() {
+    const d = this.device;
+    const { CAP, I, A, SLAB, OUT } = this.lay;
+    const nGroupsMax = Math.ceil(CAP / this.lay.GROUP);
+
+    const module = d.createShaderModule({ code: genWGSL(this.lay) });
+    const info = await module.getCompilationInfo();
+    const errs = info.messages.filter(m => m.type === 'error');
+    if (errs.length) {
+      throw new Error('WGSL: ' + errs.map(m => `${m.lineNum}:${m.linePos} ${m.message}`).join(' | '));
+    }
+
+    const layout = d.createBindGroupLayout({
+      entries: [
+        { binding: 0, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'read-only-storage' } },
+        { binding: 1, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'read-only-storage' } },
+        { binding: 2, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } },
+        { binding: 3, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } },
+        { binding: 4, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'uniform' } },
+      ],
+    });
+    const pipeLayout = d.createPipelineLayout({ bindGroupLayouts: [layout] });
+    [this.gradPipe, this.reducePipe] = await Promise.all([
+      d.createComputePipelineAsync({ layout: pipeLayout, compute: { module, entryPoint: 'grad_main' } }),
+      d.createComputePipelineAsync({ layout: pipeLayout, compute: { module, entryPoint: 'reduce_main' } }),
+    ]);
+
+    const mk = (size, usage) => d.createBuffer({ size, usage });
+    this.bufWeights = mk(this.W * 4,                     GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST);
+    this.bufBatch   = mk((CAP * (I + A) + 3 * CAP) * 4,  GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST);
+    this.bufSlabs   = mk(nGroupsMax * SLAB * 4,          GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST);
+    this.bufOut     = mk(OUT * 4,                        GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC);
+    this.bufUni     = mk(32,                             GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST);
+    this.bufStage   = mk(OUT * 4,                        GPUBufferUsage.MAP_READ | GPUBufferUsage.COPY_DST);
+
+    this.bindGroup = d.createBindGroup({
+      layout,
+      entries: [
+        { binding: 0, resource: { buffer: this.bufWeights } },
+        { binding: 1, resource: { buffer: this.bufBatch } },
+        { binding: 2, resource: { buffer: this.bufSlabs } },
+        { binding: 3, resource: { buffer: this.bufOut } },
+        { binding: 4, resource: { buffer: this.bufUni } },
+      ],
+    });
+  }
+
+  // slice: { n, obs, act, logp, adv, ret } (Float64Arrays from packSlice)
+  async compute(actorFlat, criticFlat, logStd, hp, slice) {
+    if (this.lost) throw new Error('GPU device lost');
+    const d = this.device, q = d.queue;
+    const { I, A, CAP, GROUP, aP, cP, OUT } = this.lay;
+    const n = slice.n;
+    const nGroups = Math.ceil(n / GROUP);
+
+    // weights + logStd  (f64 → f32)
+    const w = this._wScratch;
+    w.set(actorFlat, 0);          // TypedArray.set converts f64 → f32
+    w.set(criticFlat, aP);
+    for (let k = 0; k < A; k++) w[aP + cP + k] = logStd[k];
+    q.writeBuffer(this.bufWeights, 0, w);
+
+    // batch regions
+    q.writeBuffer(this.bufBatch, 0,                     Float32Array.from(slice.obs));
+    q.writeBuffer(this.bufBatch, CAP * I * 4,           Float32Array.from(slice.act));
+    q.writeBuffer(this.bufBatch, CAP * (I + A) * 4,     Float32Array.from(slice.logp));
+    q.writeBuffer(this.bufBatch, (CAP * (I + A) + CAP) * 4,     Float32Array.from(slice.adv));
+    q.writeBuffer(this.bufBatch, (CAP * (I + A) + 2 * CAP) * 4, Float32Array.from(slice.ret));
+
+    // uniforms
+    const ub = new ArrayBuffer(32);
+    const u32 = new Uint32Array(ub), f32 = new Float32Array(ub);
+    u32[0] = n; u32[1] = nGroups;
+    f32[2] = hp.clip; f32[3] = hp.entropyCoef; f32[4] = hp.vfCoef;
+    q.writeBuffer(this.bufUni, 0, ub);
+
+    const enc = d.createCommandEncoder();
+    enc.clearBuffer(this.bufSlabs);
+    const pass = enc.beginComputePass();
+    pass.setBindGroup(0, this.bindGroup);
+    pass.setPipeline(this.gradPipe);
+    pass.dispatchWorkgroups(Math.ceil(nGroups / 64));
+    pass.setPipeline(this.reducePipe);
+    pass.dispatchWorkgroups(Math.ceil(OUT / 256));
+    pass.end();
+    enc.copyBufferToBuffer(this.bufOut, 0, this.bufStage, 0, OUT * 4);
+    q.submit([enc.finish()]);
+
+    await this.bufStage.mapAsync(GPUMapMode.READ);
+    const res = new Float32Array(this.bufStage.getMappedRange()).slice();
+    this.bufStage.unmap();
+
+    return {
+      aG:  Float64Array.from(res.subarray(0, aP)),
+      cG:  Float64Array.from(res.subarray(aP, aP + cP)),
+      gLs: Float64Array.from(res.subarray(aP + cP, aP + cP + A)),
+      pi:  res[aP + cP + A],
+      v:   res[aP + cP + A + 1],
+      ent: res[aP + cP + A + 2],
+    };
+  }
+
+  destroy() {
+    try { this.device.destroy(); } catch (_) { /* already gone */ }
+  }
+}

--- a/games/ai-trainer/scripts/grad-worker.js
+++ b/games/ai-trainer/scripts/grad-worker.js
@@ -2,100 +2,65 @@
 // ─────────────────────────────────────────────────────────────────────────────
 //  grad-worker.js — parallel PPO gradient computation
 //
-//  Uses a WASM module (nn_wasm.wasm) for the hot inner loop when available,
-//  with an automatic fallback to the pure-JS path in nn-core.js.
+//  Uses the compiled WASM module (nn_wasm.wasm, fetched from this directory)
+//  for the hot inner loop, with automatic fallback to the pure-JS path in
+//  nn-core.js.  Load status is reported to the sim-worker via
+//  { type: 'wasmStatus' } messages so failures are visible, never silent.
 //
-//  Spawned by sim-worker.js.  Each message carries network weights + a batch
-//  slice; we return gradient sums via transferable buffers.
+//  Spawned by sim-worker.js.  Each { type: 'grad' } message carries network
+//  weights + a batch slice; the reply is tagged { type: 'gradResult' } with
+//  gradient sums in transferable buffers and `mode: 'wasm' | 'js'`.
 // ─────────────────────────────────────────────────────────────────────────────
 
 import { Net, accumulatePPOGrads } from './nn-core.js';
 
-// ── Inline WASM binary (base64) ──────────────────────────────────────────────
-// Generated from nn_wasm.c:
-//   clang --target=wasm32 -nostdlib -O3 -ffast-math \
-//         -Wl,--no-entry -Wl,--export-all -Wl,--allow-undefined \
-//         nn_wasm.c -o nn_wasm.wasm
-const WASM_B64 =
-  'AGFzbQEAAAABPwdgAXwBfGADf39/AX9gAABgFn9/f39/f39/f398fHx/f39/f39/f38AYAV/f39/' +
-  'fwF/YAZ/f39/f38AYAABfwIjAwNlbnYDZXhwAAADZW52BHRhbmgAAANlbnYGbWVtc2V0AAEDBgUC' +
-  'AwQFBgUDAQADBkEKfwFBgIgJC38AQYCICQt/AEGACAt/AEGAiAULfwBBgIgFC38AQYCICQt/AEGA' +
-  'CAt/AEGAgAwLfwBBAAt/AEEBCwfFAQ0GbWVtb3J5AgARX193YXNtX2NhbGxfY3RvcnMAAxFjb21w' +
-  'dXRlX3Bwb19ncmFkcwAEDWdldF9oZWFwX2Jhc2UABwtfX2hlYXBfYmFzZQMBDF9fZHNvX2hhbmRs' +
-  'ZQMCC19fZGF0YV9lbmQDAwtfX3N0YWNrX2xvdwMEDF9fc3RhY2tfaGlnaAMFDV9fZ2xvYmFsX2Jh' +
-  'c2UDBgpfX2hlYXBfZW5kAwcNX19tZW1vcnlfYmFzZQMIDF9fdGFibGVfYmFzZQMJCrAYBQIAC9UH' +
-  'CAF/A3wFfwJ8An8CfAV/A3wjgICAgABBkCBrIhYkgICAgAACQAJAIABBAU4NAEQAAAAAAAAAACEXRAAAAAAAAAAAIRhEAAAAAAAAAAAhGQwBCyAFQX9qIRogA0F/aiEbIAJBA3QhHCACQf7///8HcSEdIAJBAXEhHiAKRAAAAAAAAPA/oCEfRAAAAAAAAPA/IAqhISBBACEhRAAAAAAAAAAAIRlEAAAAAAAAAAAhGEQAAAAAAAAAACEXA0AgESAhQQN0IiJqKwMAISMgECAiaisDACEkIBsgBCAHIA0gISABbEEDdGoiJUGAiICAABCFgICAACEmRAAAAAAAAAAAIQoCQCACQQFIIicNAEQAAAAAAAAAACEKIAkhBSAOIQMgJiEoIAIhKQNAIApEtL5kyPFn7b+gIAUrAwAiCqEgAysDACAoKwMAoSAKmhCAgICAAKIiCiAKokQAAAAAAADgv6KgIQogBUEIaiEFIANBCGohAyAoQQhqISggKUF/aiIpDQALCwJARAAAAAAAADRAIAogDyAiaisDAKEiCiAKRAAAAAAAADRAZBsQgICAgAAiCiAkmqJEAAAAAAAAAAAgCiAkoiIqICAgHyAKIAogH2QbIAogIGMbICSiIitlGyIkRAAAAAAAAAAAYQ0AAkAgJw0AQQAhBSACIQMDQCAWQRBqIAVqIA4gBWorAwAgJiAFaisDAKEiCiAkoiAJIAVqKwMAIiwgLKAQgICAgAAiLKM5AwAgFCAFaiIoIAogCqIgLKNEAAAAAAAA8L+gICSiICgrAwCgOQMAIAVBCGohBSADQX9qIgMNAAsLIBsgBCAHIBJBgIiAgAAgFkEQahCGgICAAAsgKiArpCEkAkAgJw0AQQAhKAJAIAJBAUYNAEEAISggCSEDIBQhBQNAIAUgBSsDACALoTkDACADKwMAIQogBUEIaiIpICkrAwAgC6E5AwAgCiAXRFpfMuT4s/Y/oKBEWl8y5Piz9j+gIANBCGorAwCgIRcgA0EQaiEDIAVBEGohBSAdIChBAmoiKEcNAAsLIB5FDQAgFCAoQQN0IgVqIgMgAysDACALoTkDACAXRFpfMuT4s/Y/oCAJIAVqKwMAoCEXCyAZICShIRkgFiAaIAYgCCAlQYCogoAAEIWAgIAAKwMAICOhIgogDKI5AwggGiAGIAggE0GAqIKAACAWQQhqEIaAgIAAIAogCqJEAAAAAAAA4D+iIBigIRggDiAcaiEOICFBAWoiISAARw0ACwsgFSAXOQMQIBUgGDkDCCAVIBk5AwAgFkGQIGokgICAgAALlAcCEn8BfAJAIAEoAgAiBUEBSA0AIAVBA3EhBkEAIQcCQCAFQQRJDQAgBUH8////B3EhCEEAIQlBACEHA0AgBCAJaiIKIAMgCWoiCysDADkDACAKQQhqIAtBCGorAwA5AwAgCkEQaiALQRBqKwMAOQMAIApBGGogC0EYaisDADkDACAJQSBqIQkgCCAHQQRqIgdHDQALCyAGRQ0AIAMgB0EDdCIKaiEJIAQgCmohCgNAIAogCSsDADkDACAJQQhqIQkgCkEIaiEKIAZBf2oiBg0ACwsCQCAAQQFODQAgBA8LIABBf2ohDCAEIQdBACEKQQAhDQNAIAUiCSABIA0iDkEBaiINQQJ0aigCACIFbCAKaiEPIAQgDUEMdGohEAJAIAVBAUgNACACIA9BA3RqIRECQCAJQQFIDQAgAiAKQQN0aiEGIAlBA3QhEiAJQQNxIRNBACEUQQAgCUH8////B3FrIQggCUEESSEVA0AgESAUQQN0IhZqKwMAIRcCQAJAIBVFDQBBACEJDAELQQAhCUEAIQMDQCAHIAlqIgpBGGorAwAgBiAJaiILQRhqKwMAoiAKQRBqKwMAIAtBEGorAwCiIApBCGorAwAgC0EIaisDAKIgCisDACALKwMAoiAXoKCgoCEXIAlBIGohCSAIIANBfGoiA0cNAAtBACADayEJCwJAIBNFDQAgCUEDdCEJIBMhCgNAIAcgCWorAwAgBiAJaisDAKIgF6AhFyAJQQhqIQkgCkF/aiIKDQALCwJAIA4gDEYNACAXEIGAgIAAIRcLIBAgFmogFzkDACAGIBJqIQYgFEEBaiIUIAVGDQIMAAsLAkAgDiAMRg0AQYAgIQkgBSEKA0AgByAJaiARIAlqQYBgaisDABCBgICAADkDACAJQQhqIQkgCkF/aiIKDQAMAgsLIAVBA3EhBkEAIQkCQCAFQQRJDQBBACEJQQAgBUH8////B3FrIQhBACEDA0AgByAJaiIKQYAgaiARIAlqIgsrAwA5AwAgCkGIIGogC0EIaisDADkDACAKQZAgaiALQRBqKwMAOQMAIApBmCBqIAtBGGorAwA5AwAgCUEgaiEJIAggA0F8aiIDRw0AC0EAIANrIQkLIAZFDQAgCUEDdCEJA0AgByAJakGAIGogESAJaisDADkDACAJQQhqIQkgBkF/aiIGDQALCyAPIAVqIQogB0GAIGohByANIABHDQALIBALtAkDEn8BfAJ/I4CAgIAAQcAAayIGJICAgIAAAkAgAEEBSA0AIABBAXEhByABKAIAIQhBACEJAkACQCAAQQFHDQBBACEKDAELIAFBBGohCyAAQf7///8HcSEMQQAhCSAGQSBqIQ0gBiEOQQAhCgNAIA0gCTYCACAOIAsoAgAiDyAIbCAJaiIJNgIAIA1BBGogCSAPaiIJNgIAIA5BBGogDyALQQRqKAIAIghsIAlqIgk2AgAgCSAIaiEJIA5BCGohDiANQQhqIQ0gC0EIaiELIAwgCkECaiIKRw0ACwsCQCAHRQ0AIAZBIGogCkECdCILaiAJNgIAIAYgC2ogASALakEEaigCACAIbCAJajYCAAsgAEEBSA0AIABBDHQgBGpBgGBqIQ8gASAAQQJ0aigCACEQQQEhEQNAIABBf2oiEkEMdCENIAYgEkECdCILaigCACEOIAZBIGogC2ooAgAhCSABIAtqKAIAIRNBACEUAkAgAEEBRg0AQYDIhIAAQYDohIAAIBEbIRQgE0EBSA0AIBRBACATQQN0EIKAgIAAGgsgBCANaiEVAkAgEEEBSA0AIAMgDkEDdGohFiADIAlBA3QiC2ohDAJAIBRFDQAgAiALaiEHIBNBA3QhF0EAIQoDQAJAIAUgCkEDdCILaisDACIYRAAAAAAAAAAAYQ0AIBYgC2oiCyALKwMAIBigOQMAIBNBAUgNACAPIQ4gDCELIAchCSAUIQ0gEyEIA0AgCyALKwMAIA4rAwAgGKKgOQMAIA0gDSsDACAJKwMAIBiioDkDACAOQQhqIQ4gC0EIaiELIAlBCGohCSANQQhqIQ0gCEF/aiIIDQALCyAMIBdqIQwgByAXaiEHIApBAWoiCiAQRw0ADAILCyATQQN0IRcgE0EBcSEZQQAhB0EAIBNB/v///wdxayEKIBNBAEohGiAMIQgDQAJAIAUgB0EDdCILaisDACIYRAAAAAAAAAAAYQ0AIBYgC2oiCyALKwMAIBigOQMAIBpFDQBBACELAkAgE0EBRg0AQQAhC0EAIQ4DQCAIIAtqIg0gDSsDACAPIAtqIgkrAwAgGKKgOQMAIA1BCGoiDSANKwMAIAlBCGorAwAgGKKgOQMAIAtBEGohCyAKIA5BfmoiDkcNAAtBACAOayELCyAZRQ0AIAwgByATbEEDdGogC0EDdCILaiINIA0rAwAgFSALaisDACAYoqA5AwALIAggF2ohCCAHQQFqIgcgEEcNAAsLAkAgFEUNAAJAIBNBAUgNACATQQFxIQpBACELAkAgE0EBRg0AQQAhC0EAIBNB/v///wdxayEIQQAhDgNAIBQgC2oiDUQAAAAAAADwPyAPIAtqIgkrAwAiGCAYoqEgDSsDAKI5AwAgDUEIaiINRAAAAAAAAPA/IAlBCGorAwAiGCAYoqEgDSsDAKI5AwAgC0EQaiELIAggDkF+aiIORw0AC0EAIA5rIQsLIApFDQAgFCALQQN0IgtqIg1EAAAAAAAA8D8gFSALaisDACIYIBiioSANKwMAojkDAAsgEUUhESAUIQULIA9BgGBqIQ8gAEEBSiELIBMhECASIQAgCw0ACwsgBkHAAGokgICAgAALCABBgIiJgAALAI4BBG5hbWUADQxubl93YXNtLndhc20BZAgAA2V4cAEEdGFuaAIGbWVtc2V0AxFfX3dhc21fY2FsbF9jdG9ycwQRY29tcHV0ZV9wcG9fZ3JhZHMFC25ldF9mb3J3YXJkBgxuZXRfYmFja3dhcmQHDWdldF9oZWFwX2Jhc2UHEgEAD19fc3RhY2tfcG9pbnRlcgA4CXByb2R1Y2VycwEMcHJvY2Vzc2VkLWJ5AQxVYnVudHUgY2xhbmcRMTguMS4zICgxdWJ1bnR1MSkALA90YXJnZXRfZmVhdHVyZXMCKw9tdXRhYmxlLWdsb2JhbHMrCHNpZ24tZXh0';
+// ── WASM loading ─────────────────────────────────────────────────────────────
 
-// ── WASM loader ──────────────────────────────────────────────────────────────
-
-function b64ToBytes(b64) {
-  const bin = atob(b64);
-  const buf = new Uint8Array(bin.length);
-  for (let i = 0; i < bin.length; i++) buf[i] = bin.charCodeAt(i);
-  return buf;
-}
+let wasmInst  = null;
+let wasmReady = false;
 
 const wasmImports = {
   env: {
-    exp:    Math.exp,
-    tanh:   Math.tanh,
-    // memset is used internally by LLVM; provide a fast version
+    exp:  Math.exp,
+    tanh: Math.tanh,
     memset: (ptr, val, len) => {
-      const mem8 = new Uint8Array(wasmInst.exports.memory.buffer);
-      mem8.fill(val & 0xff, ptr, ptr + len);
+      new Uint8Array(wasmInst.exports.memory.buffer).fill(val & 0xff, ptr, ptr + len);
       return ptr;
     },
   },
 };
 
-let wasmInst = null;     // WebAssembly.Instance once ready
-let wasmReady = false;
-let wasmFailed = false;
-
-// Load asynchronously so the worker can still answer its first message via JS
-// while WASM is compiling.
 (async () => {
   try {
-    const bytes  = b64ToBytes(WASM_B64);
-    const result = await WebAssembly.instantiate(bytes, wasmImports);
+    const url = new URL('./nn_wasm.wasm', import.meta.url);
+    let result;
+    try {
+      result = await WebAssembly.instantiateStreaming(fetch(url), wasmImports);
+    } catch (_) {
+      // server may send a wrong MIME type — fall back to ArrayBuffer compile
+      const resp = await fetch(url);
+      if (!resp.ok) throw new Error(`fetch ${resp.status} ${resp.statusText}`);
+      result = await WebAssembly.instantiate(await resp.arrayBuffer(), wasmImports);
+    }
     wasmInst  = result.instance;
     wasmReady = true;
+    postMessage({ type: 'wasmStatus', ok: true });
   } catch (err) {
-    wasmFailed = true;
-    // JS fallback will be used automatically.
+    postMessage({ type: 'wasmStatus', ok: false, error: String(err && err.message || err) });
   }
 })();
 
-// ── WASM memory allocator ────────────────────────────────────────────────────
+// ── WASM memory layout ───────────────────────────────────────────────────────
 //
-// Layout (all in WASM linear memory, starting at heapBase):
-//
-//   actorSizesOff   : nActorLayers × 4  (i32)
-//   criticSizesOff  : nCriticLayers × 4
-//   actorFlatOff    : nActorParams × 8  (f64)
-//   criticFlatOff   : nCriticParams × 8
-//   logStdOff       : actDim × 8
-//   obsOff          : n × obsDim × 8
-//   actOff          : n × actDim × 8
-//   logpOff         : n × 8
-//   advOff          : n × 8
-//   retOff          : n × 8
-//   actorGradOff    : nActorParams × 8  (output)
-//   criticGradOff   : nCriticParams × 8 (output)
-//   gLogStdOff      : actDim × 8        (output)
-//   lossOutOff      : 3 × 8             (output: pi, v, ent)
-//
-// All allocations are aligned to 8 bytes.
+// All inputs/outputs live in WASM linear memory starting at the module's heap
+// base; the layout is recomputed only when the architecture or slice size
+// changes.  Offsets are 8-byte aligned.
 
-let wasmHeap   = 0;       // byte offset of our arena (set after module loads)
-let arenaBase  = 0;
-const ALIGN    = 8;
-
-function align8(n) { return (n + 7) & ~7; }
-
-// Per-architecture layout cache (avoid re-computing when sizes unchanged)
+let arenaBase    = 0;
 let cachedLayout = null;
 let cachedKey    = '';
+
+function align8(n) { return (n + 7) & ~7; }
 
 function getLayout(actorSizes, criticSizes, n, obsDim, actDim) {
   const key = `${actorSizes}|${criticSizes}|${n}`;
@@ -104,11 +69,10 @@ function getLayout(actorSizes, criticSizes, n, obsDim, actDim) {
   const nAL = actorSizes.length;
   const nCL = criticSizes.length;
   let nActorParams = 0;
-  for (let l = 0; l < nAL - 1; l++) nActorParams += actorSizes[l] * actorSizes[l+1] + actorSizes[l+1];
+  for (let l = 0; l < nAL - 1; l++) nActorParams += actorSizes[l] * actorSizes[l + 1] + actorSizes[l + 1];
   let nCriticParams = 0;
-  for (let l = 0; l < nCL - 1; l++) nCriticParams += criticSizes[l] * criticSizes[l+1] + criticSizes[l+1];
+  for (let l = 0; l < nCL - 1; l++) nCriticParams += criticSizes[l] * criticSizes[l + 1] + criticSizes[l + 1];
 
-  // Compute needed byte size
   const szActorSizes  = align8(nAL * 4);
   const szCriticSizes = align8(nCL * 4);
   const szActorFlat   = align8(nActorParams  * 8);
@@ -116,30 +80,21 @@ function getLayout(actorSizes, criticSizes, n, obsDim, actDim) {
   const szLogStd      = align8(actDim * 8);
   const szObs         = align8(n * obsDim * 8);
   const szAct         = align8(n * actDim * 8);
-  const szN           = align8(n * 8);    // for logp, adv, ret
-  const szGrad        = szActorFlat;      // same size as weights
-  const szCGrad       = szCriticFlat;
-  const szGLogStd     = szLogStd;
+  const szN           = align8(n * 8);
   const szLoss        = align8(3 * 8);
 
   const totalBytes = szActorSizes + szCriticSizes +
                      szActorFlat + szCriticFlat + szLogStd +
                      szObs + szAct + szN * 3 +
-                     szGrad + szCGrad + szGLogStd + szLoss;
+                     szActorFlat + szCriticFlat + szLogStd + szLoss;
 
-  // Grow WASM memory if needed
-  const mem       = wasmInst.exports.memory;
-  const heapBase  = wasmInst.exports.get_heap_base();
-  if (arenaBase === 0) arenaBase = heapBase;
-
-  const needed    = arenaBase + totalBytes;
-  const curBytes  = mem.buffer.byteLength;
-  if (needed > curBytes) {
-    const pages = Math.ceil((needed - curBytes) / 65536);
-    mem.grow(pages);
+  const mem = wasmInst.exports.memory;
+  if (arenaBase === 0) arenaBase = wasmInst.exports.get_heap_base();
+  const needed = arenaBase + totalBytes;
+  if (needed > mem.buffer.byteLength) {
+    mem.grow(Math.ceil((needed - mem.buffer.byteLength) / 65536));
   }
 
-  // Assign offsets
   let off = arenaBase;
   const lay = {};
   lay.actorSizesOff  = off; off += szActorSizes;
@@ -152,9 +107,9 @@ function getLayout(actorSizes, criticSizes, n, obsDim, actDim) {
   lay.logpOff        = off; off += szN;
   lay.advOff         = off; off += szN;
   lay.retOff         = off; off += szN;
-  lay.actorGradOff   = off; off += szGrad;
-  lay.criticGradOff  = off; off += szCGrad;
-  lay.gLogStdOff     = off; off += szGLogStd;
+  lay.actorGradOff   = off; off += szActorFlat;
+  lay.criticGradOff  = off; off += szCriticFlat;
+  lay.gLogStdOff     = off; off += szLogStd;
   lay.lossOutOff     = off;
   lay.nActorParams   = nActorParams;
   lay.nCriticParams  = nCriticParams;
@@ -166,8 +121,6 @@ function getLayout(actorSizes, criticSizes, n, obsDim, actDim) {
   return lay;
 }
 
-// ── WASM gradient computation ────────────────────────────────────────────────
-
 function computeGradsWasm(d) {
   const { actorSizes, criticSizes, actorFlat, criticFlat, n, obsDim, actDim,
           obs, act, logp, adv, ret, hp } = d;
@@ -176,37 +129,27 @@ function computeGradsWasm(d) {
   const lay = getLayout(actorSizes, criticSizes, n, obsDim, actDim);
   const buf = wasmInst.exports.memory.buffer;
 
-  // Write inputs into WASM memory
   const i32 = new Int32Array(buf);
-  const f64 = new Float64Array(buf);
-
-  // Actor + critic layer sizes (i32 arrays)
   const asI = lay.actorSizesOff >> 2;
   for (let i = 0; i < lay.nAL; i++) i32[asI + i] = actorSizes[i];
   const csI = lay.criticSizesOff >> 2;
   for (let i = 0; i < lay.nCL; i++) i32[csI + i] = criticSizes[i];
 
-  // Float64 data
-  const f64View = (off, src) => {
-    const v = new Float64Array(buf, off, src.length);
-    v.set(src);
-  };
-  f64View(lay.actorFlatOff,  actorFlat);
-  f64View(lay.criticFlatOff, criticFlat);
-  f64View(lay.logStdOff,     logStd);
-  f64View(lay.obsOff,        obs);
-  f64View(lay.actOff,        act);
-  f64View(lay.logpOff,       logp);
-  f64View(lay.advOff,        adv);
-  f64View(lay.retOff,        ret);
+  const put = (off, src) => { new Float64Array(buf, off, src.length).set(src); };
+  put(lay.actorFlatOff,  actorFlat);
+  put(lay.criticFlatOff, criticFlat);
+  put(lay.logStdOff,     logStd);
+  put(lay.obsOff,        obs);
+  put(lay.actOff,        act);
+  put(lay.logpOff,       logp);
+  put(lay.advOff,        adv);
+  put(lay.retOff,        ret);
 
-  // Zero output regions
   new Float64Array(buf, lay.actorGradOff,  lay.nActorParams).fill(0);
   new Float64Array(buf, lay.criticGradOff, lay.nCriticParams).fill(0);
   new Float64Array(buf, lay.gLogStdOff,    actDim).fill(0);
   new Float64Array(buf, lay.lossOutOff,    3).fill(0);
 
-  // Call WASM
   wasmInst.exports.compute_ppo_grads(
     n, obsDim, actDim,
     lay.nAL, lay.actorSizesOff,
@@ -218,7 +161,6 @@ function computeGradsWasm(d) {
     lay.actorGradOff, lay.criticGradOff, lay.gLogStdOff, lay.lossOutOff,
   );
 
-  // Read outputs — copy out of WASM memory into fresh transferable buffers
   const aG  = new Float64Array(lay.nActorParams);
   const cG  = new Float64Array(lay.nCriticParams);
   const gLs = new Float64Array(actDim);
@@ -265,13 +207,14 @@ self.onmessage = function (e) {
   const d = e.data;
   if (d.type !== 'grad') return;
 
-  let r;
-  if (wasmReady) {
+  let r, mode = 'js';
+  if (wasmReady && d.force !== 'js') {
     try {
       r = computeGradsWasm(d);
+      mode = 'wasm';
     } catch (err) {
-      wasmFailed = true;
-      wasmReady  = false;
+      wasmReady = false;
+      postMessage({ type: 'wasmStatus', ok: false, error: 'runtime: ' + String(err && err.message || err) });
       r = computeGradsJS(d);
     }
   } else {
@@ -279,8 +222,8 @@ self.onmessage = function (e) {
   }
 
   postMessage(
-    { aG: r.aG, cG: r.cG, gLs: r.gLs, pi: r.pi, v: r.v, ent: r.ent, n: d.n,
-      wasmOk: wasmReady && !wasmFailed },
+    { type: 'gradResult', aG: r.aG, cG: r.cG, gLs: r.gLs,
+      pi: r.pi, v: r.v, ent: r.ent, n: d.n, mode },
     [r.aG.buffer, r.cG.buffer, r.gLs.buffer],
   );
 };

--- a/games/ai-trainer/scripts/sim-worker.js
+++ b/games/ai-trainer/scripts/sim-worker.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import { Net, gauss, LOG_2PI, accumulatePPOGrads } from './nn-core.js';
+import { GpuGrad } from './gpu-grad.js';
 
 // ─────────────────────────────────────────────────────────────────────────────
 //  AI Trainer — Simulation Worker (PPO)
@@ -53,6 +54,7 @@ let cfg = {
   minibatch: 256,
   hiddenSize: 64,        // restart required
   hiddenLayers: 1,       // restart required
+  backend: 'auto',       // 'auto' | 'gpu' | 'wasm' | 'js' — restart required
   // reward shaping
   progressReward: 0.2,   // per metre of forward progress along the centerline
   gravelPenalty: 1.0,    // per second on gravel
@@ -105,7 +107,12 @@ function raySegment(ox, oz, dx, dz, ax, az, bx, bz) {
   return -1;
 }
 
-function wrapPi(a) { return ((a + Math.PI * 3) % (Math.PI * 2)) - Math.PI; }
+// Wrap to (-π, π]. Valid for ANY input magnitude — the previous formula
+// ((a + 3π) % 2π) − π silently returned values < −π once its argument
+// dropped below −3π, which happens when car.hdg accumulates +2π per lap
+// on counterclockwise tracks. That inverted every angle observation on
+// lap 2+ and made the policy steer hard into the wall at a fixed spot.
+function wrapPi(a) { return a - 2 * Math.PI * Math.round(a / (2 * Math.PI)); }
 
 function buildArcTable() {
   const useCity = !!(cityAiPts && cityAiPts.pts && cityAiPts.pts.length);
@@ -123,14 +130,38 @@ function buildArcTable() {
   if (trackLen < 1) trackLen = 1;
 }
 
-// Continuous arc position (metres along centerline) of a world point.
-function arcPosition(px, pz) {
-  const n = navPts.length;
+// Hint-based nearest point search. When `hint` is a valid previous index the
+// scan is restricted to a window around it — this keeps the matched position
+// CONTINUOUS along the route even where the track passes close to itself
+// (city routes legitimately cross the same intersection several times), and
+// turns an O(n) scan into O(win). Falls back to a global scan when the local
+// match is implausibly far (respawn, teleport, first call).
+const RESEED_D2 = 30 * 30;
+
+function nearestIdx(px, pz, pts, hint, win) {
+  const n = pts.length;
   let md = Infinity, ni = 0;
+  if (hint >= 0 && hint < n) {
+    for (let k = -win; k <= win; k++) {
+      const i = ((hint + k) % n + n) % n;
+      const d = (px - pts[i].x) ** 2 + (pz - pts[i].z) ** 2;
+      if (d < md) { md = d; ni = i; }
+    }
+    if (md <= RESEED_D2) return { idx: ni, d2: md };
+  }
+  md = Infinity; ni = 0;
   for (let i = 0; i < n; i++) {
-    const d = (px - navPts[i].x) ** 2 + (pz - navPts[i].z) ** 2;
+    const d = (px - pts[i].x) ** 2 + (pz - pts[i].z) ** 2;
     if (d < md) { md = d; ni = i; }
   }
+  return { idx: ni, d2: md };
+}
+
+// Continuous arc position (metres along centerline) of a world point.
+function arcPosition(px, pz, hint = -1) {
+  const n = navPts.length;
+  const r = nearestIdx(px, pz, navPts, hint, 25);
+  const ni = r.idx, md = r.d2;
   const a = navPts[ni], b = navPts[(ni + 1) % n];
   const abx = b.x - a.x, abz = b.z - a.z;
   const ab2 = abx * abx + abz * abz || 1;
@@ -176,6 +207,10 @@ class SimCar {
     this.stuckTimer   = 0;
     this.lap          = 0;
     this.lapTimes     = [];
+    // nearest-point hints (−1 = unknown → global search on next lookup)
+    this.arcHint    = -1;   // into navPts
+    this.trkHint    = -1;   // into trkPts
+    this.gravelHint = -1;   // into gravelProfile.pts
   }
 
   reset(pos, hdg) {
@@ -184,6 +219,7 @@ class SimCar {
     this.isReversing = false; this.revSpd = 0; this.reverseTimer = 0;
     this.onGravel = false; this.stuckTimer = 0;
     this.lap = 0; this.lapTimes = [];
+    this.arcHint = -1; this.trkHint = -1; this.gravelHint = -1;
   }
 
   update(inp, dt) {
@@ -228,6 +264,9 @@ class SimCar {
       this.pos.z += Math.cos(this.hdg) * this.spd * dt;
     }
 
+    // keep hdg bounded — it would otherwise grow ±2π per lap forever
+    if (this.hdg > Math.PI || this.hdg < -Math.PI) this.hdg = wrapPi(this.hdg);
+
     this.pos.y = this._groundY();
     this.boundary(dt);
     this.checkGravel();
@@ -235,12 +274,9 @@ class SimCar {
 
   _groundY() {
     if (!trkPts.length) return 0;
-    let md = Infinity, ny = 0;
-    for (const p of trkPts) {
-      const d = (this.pos.x - p.x) ** 2 + (this.pos.z - p.z) ** 2;
-      if (d < md) { md = d; ny = p.y; }
-    }
-    return ny;
+    const r = nearestIdx(this.pos.x, this.pos.z, trkPts, this.trkHint, 25);
+    this.trkHint = r.idx;
+    return trkPts[r.idx].y;
   }
 
   boundary(dt) {
@@ -270,11 +306,9 @@ class SimCar {
       return;
     }
 
-    let md = Infinity, ni = 0;
-    for (let i = 0; i < trkPts.length; i++) {
-      const d = (this.pos.x - trkPts[i].x) ** 2 + (this.pos.z - trkPts[i].z) ** 2;
-      if (d < md) { md = d; ni = i; }
-    }
+    const near = nearestIdx(this.pos.x, this.pos.z, trkPts, this.trkHint, 25);
+    const ni = near.idx, md = near.d2;
+    this.trkHint = ni;
     const np  = trkPts[ni];
     const nxt = trkPts[(ni + 1) % trkPts.length];
     const prv = trkPts[(ni + trkPts.length - 1) % trkPts.length];
@@ -330,11 +364,9 @@ class SimCar {
     if (!profile) { this.onGravel = false; return; }
     const { pts, leftRunoff, rightRunoff, rw } = profile;
     const n = pts.length;
-    let md = Infinity, ni = 0;
-    for (let i = 0; i < n; i++) {
-      const d = (this.pos.x - pts[i].x) ** 2 + (this.pos.z - pts[i].z) ** 2;
-      if (d < md) { md = d; ni = i; }
-    }
+    const near = nearestIdx(this.pos.x, this.pos.z, pts, this.gravelHint, 40);
+    const ni = near.idx;
+    this.gravelHint = ni;
     const p   = pts[ni];
     const nxt = pts[(ni + 1) % n], prv = pts[(ni + n - 1) % n];
     const tx  = nxt.x - prv.x, tz = nxt.z - prv.z;
@@ -415,12 +447,19 @@ const SLOPE_NORM  = 0.30;   // |Δy/Δs| considered "max steep"
 //  [24..35] 6 probes × (relative angle, slope between probes)
 const OBS_DIM = 24 + PROBE_DISTS.length * 2;
 
+// Arc position of a car, using and updating its locality hint.
+function carArc(car) {
+  const ap = arcPosition(car.pos.x, car.pos.z, car.arcHint);
+  car.arcHint = ap.nearestIdx;
+  return ap;
+}
+
 function buildObs(car, out) {
   castRayFan(car, RAY_ANGLES, RAY_DIST, out, 0);
   for (let k = 0; k < RAY_ANGLES.length; k++) out[k] = Math.sqrt(out[k]);
   castRayFan(car, EDGE_RAY_ANGLES, EDGE_RAY_DIST, out, 11);
 
-  const ap = arcPosition(car.pos.x, car.pos.z);
+  const ap = carArc(car);
   const speedFrac = car.spd / car.data.maxSpd;
 
   // Dynamic look-ahead waypoint heading error (same idea as the original AI)
@@ -539,7 +578,7 @@ function makeEnv(i) {
   return {
     car,
     // arc tracking for progress reward + lap detection
-    prevS: arcPosition(car.pos.x, car.pos.z).s,
+    prevS: carArc(car).s,
     lapAcc: 0,            // accumulated forward metres this lap
     lapTime: 0,
     epTime: 0,
@@ -560,7 +599,7 @@ function makeEnv(i) {
 function resetEnv(env, i) {
   const sp = spawnPose(i);
   env.car.reset(sp.pos, sp.hdg);
-  env.prevS = arcPosition(env.car.pos.x, env.car.pos.z).s;
+  env.prevS = carArc(env.car).s;
   env.lapAcc = 0; env.lapTime = 0;
   env.epTime = 0; env.epReturn = 0;
   env.offTrackTime = 0; env.noProgTime = 0; env.prevStuck = 0;
@@ -646,7 +685,7 @@ function stepOnce(dt) {
     totalSteps++;
 
     // ── Reward ──
-    const ap = arcPosition(car.pos.x, car.pos.z);
+    const ap = carArc(car);
     let ds = ap.s - env.prevS;
     if (ds >  trackLen / 2) ds -= trackLen;
     if (ds < -trackLen / 2) ds += trackLen;
@@ -719,6 +758,14 @@ function stepOnce(dt) {
 // ─────────────────────────────────────────────────────────────────────────────
 
 let gradPool = null;   // Worker[] — empty array means "fall back to local compute"
+let _wasmOk  = false;  // a grad-worker confirmed its WASM module loaded
+let _wasmErr = '';     // last WASM load/runtime error reported by a grad-worker
+
+// GPU backend (cfg.backend === 'gpu')
+let gpu          = null;     // GpuGrad instance
+let gpuState     = 'off';    // 'off' | 'init' | 'ready' | 'failed'
+let gpuInfo      = '';
+let gpuValidated = false;    // first GPU minibatch is checked against the JS path
 
 function initGradPool() {
   if (gradPool !== null) return;
@@ -732,6 +779,14 @@ function initGradPool() {
         for (const x of gradPool) { try { x.terminate(); } catch (_) { /* already dead */ } }
         gradPool = [];
       };
+      // persistent status listener — independent of per-task onmessage
+      w.addEventListener('message', e => {
+        const d = e.data;
+        if (d && d.type === 'wasmStatus') {
+          if (d.ok) _wasmOk = true;
+          else if (d.error) _wasmErr = d.error;
+        }
+      });
       gradPool.push(w);
     }
   } catch (err) {
@@ -739,10 +794,24 @@ function initGradPool() {
   }
 }
 
+function initGpu() {
+  if (gpu) { try { gpu.destroy(); } catch (_) { /* dead */ } gpu = null; }
+  gpuValidated = false;
+  if (cfg.backend !== 'gpu') { gpuState = 'off'; gpuInfo = ''; return; }
+  gpuState = 'init'; gpuInfo = 'GPU initializing…';
+  GpuGrad.create(actor.sizes, critic.sizes, cfg.minibatch).then(res => {
+    if (res.ok) { gpu = res.gpu; gpuState = 'ready'; gpuInfo = 'WebGPU active'; }
+    else        { gpu = null;    gpuState = 'failed'; gpuInfo = 'GPU unavailable: ' + res.error; }
+  });
+}
+
 function gradTask(w, msg, transfers) {
   return new Promise((resolve, reject) => {
-    w.onmessage = e => resolve(e.data);
-    w.onerror   = e => reject(e);
+    w.onmessage = e => {
+      if (e.data && e.data.type === 'gradResult') resolve(e.data);
+      // ignore status messages — handled by the persistent listener
+    };
+    w.onerror = e => reject(e);
     w.postMessage(msg, transfers);
   });
 }
@@ -751,8 +820,7 @@ function gradTask(w, msg, transfers) {
 //  PPO batch preparation (synchronous — runs once per horizon fill)
 // ─────────────────────────────────────────────────────────────────────────────
 
-let _ppoRunning  = false;
-let _wasmActive  = false;   // true once a grad-worker confirms WASM is running
+let _ppoRunning = false;
 
 function _flushBatch() {
   // Close any open repeat windows; envs get fresh decisions next tick.
@@ -836,8 +904,43 @@ async function _runPPO(batch) {
       const end = Math.min(N, start + cfg.minibatch);
       const bs = end - start;
       let gLs, mbPi, mbV, mbEnt;
+      let handled = false;
 
-      const pool = gradPool && gradPool.length ? gradPool : null;
+      // ── GPU path (experimental, opt-in): whole minibatch on WebGPU ──
+      if (gpuState === 'ready' && gpu && bs <= gpu.cap) {
+        const slice = packSlice(OBS, ACT, LOGP, ADV, RET, idx, start, end);
+        try {
+          const r = await gpu.compute(actor.flatF64(), critic.flatF64(), logStd, hp, slice);
+          if (!gpuValidated) {
+            // one-time numeric check against the reference JS implementation
+            actor.zeroGrad(); critic.zeroGrad();
+            accumulatePPOGrads(actor, critic, logStd, hp, slice);
+            const refA = actor.gradFlatF64(), refC = critic.gradFlatF64();
+            const relL2 = (x, y) => {
+              let e2 = 0, n2 = 0;
+              for (let q = 0; q < x.length; q++) { const e = x[q] - y[q]; e2 += e * e; n2 += y[q] * y[q]; }
+              return Math.sqrt(e2 / (n2 + 1e-12));
+            };
+            const ea = relL2(r.aG, refA), ec = relL2(r.cG, refC);
+            if (ea > 5e-3 || ec > 5e-3) {
+              throw new Error(`validation failed (rel err actor ${ea.toExponential(1)}, critic ${ec.toExponential(1)})`);
+            }
+            gpuValidated = true;
+            gpuInfo = 'WebGPU active (validated)';
+          }
+          actor.loadGradFlat(r.aG);
+          critic.loadGradFlat(r.cG);
+          gLs = r.gLs; mbPi = r.pi; mbV = r.v; mbEnt = r.ent;
+          handled = true;
+        } catch (err) {
+          gpuState = 'failed';
+          gpuInfo = 'GPU disabled: ' + (err && err.message || err);
+          try { gpu.destroy(); } catch (_) { /* dead */ }
+          gpu = null;
+        }
+      }
+
+      const pool = !handled && gradPool && gradPool.length ? gradPool : null;
       if (pool) {
         // ── Parallel: split the minibatch across the pool ──
         const K = Math.min(pool.length, Math.max(1, Math.floor(bs / 32)));
@@ -851,6 +954,7 @@ async function _runPPO(batch) {
           const slice = packSlice(OBS, ACT, LOGP, ADV, RET, idx, s0, s1);
           tasks.push(gradTask(pool[c], {
             type: 'grad',
+            force: cfg.backend === 'js' ? 'js' : 'auto',
             actorSizes: actor.sizes, criticSizes: critic.sizes,
             actorFlat: aFlat, criticFlat: cFlat, logStd: lsArr,
             hp, ...slice,
@@ -875,11 +979,11 @@ async function _runPPO(batch) {
           for (let k = 0; k < cG.length; k++) cG[k] += r.cG[k];
           for (let d = 0; d < ACT_DIM; d++) gLs[d] += r.gLs[d];
           mbPi += r.pi; mbV += r.v; mbEnt += r.ent;
-          if (r.wasmOk) _wasmActive = true;
+          if (r.mode === 'wasm') _wasmOk = true;
         }
         actor.loadGradFlat(aG);
         critic.loadGradFlat(cG);
-      } else {
+      } else if (!handled) {
         // ── Local fallback: single-threaded gradient computation ──
         actor.zeroGrad(); critic.zeroGrad();
         const slice = packSlice(OBS, ACT, LOGP, ADV, RET, idx, start, end);
@@ -939,7 +1043,13 @@ function buildSnapshot() {
     bufferFill: Math.min(1, agentSteps / (cfg.horizon * cfg.numEnvs)),
     phase: _ppoRunning ? 'updating' : 'collecting',
     gradThreads: gradPool ? gradPool.length : 0,
-    wasmActive: _wasmActive,
+    backend: gpuState === 'ready' ? 'gpu'
+           : (gradPool && gradPool.length && _wasmOk && cfg.backend !== 'js') ? 'wasm'
+           : 'js',
+    backendInfo: gpuState === 'failed' ? gpuInfo
+               : gpuState === 'init'   ? gpuInfo
+               : _wasmErr ? 'WASM unavailable: ' + _wasmErr
+               : '',
     avgReturn,
     bestLap: Number.isFinite(bestLap) ? bestLap : null,
     episodes: recentReturns.length,
@@ -1022,6 +1132,7 @@ self.onmessage = function (e) {
     stopLoop();
     initGradPool();
     initSim(model || null);
+    initGpu();
     postMessage({
       type: 'ready', obsDim: OBS_DIM, actorSizes: actor.sizes,
       numEnvs: cfg.numEnvs, gradThreads: gradPool ? gradPool.length : 0,

--- a/games/ai-trainer/scripts/trainer-app.js
+++ b/games/ai-trainer/scripts/trainer-app.js
@@ -150,6 +150,7 @@ const OBS_DIM = 36; // must match sim-worker.js
 const simCfg = {
   hiddenLayers: 1,       // restart required
   hiddenSize: 64,        // restart required
+  backend: 'auto',       // restart required — 'auto' | 'gpu' | 'wasm' | 'js'
   numEnvs: 8,            // restart required
   speedMult: 1,
   episodeLen: 60,
@@ -258,23 +259,23 @@ function refreshHUD(d) {
     bar.style.background = 'linear-gradient(90deg, #4af, #4f4)';
     wrap.title = 'Collecting rollout — bar fills then policy updates';
   }
-  const threads    = d.gradThreads || 0;
-  const wasmActive = d.wasmActive  || false;
+  const threads = d.gradThreads || 0;
   const phaseEl = document.getElementById('hudPhase');
   if (phase === 'updating') {
-    const coreStr = threads ? ` ×${threads}` : '';
-    const wasmStr = wasmActive ? ' WASM' : '';
-    phaseEl.textContent = `⚙ UPDATING${coreStr}${wasmStr}`;
+    phaseEl.textContent = threads ? `⚙ UPDATING ×${threads}` : '⚙ UPDATING';
     phaseEl.style.color = '#fa4';
   } else {
     phaseEl.textContent = '● COLLECTING';
     phaseEl.style.color = '#4f4';
   }
-  // Show WASM badge in dedicated element if it exists
-  const wasmEl = document.getElementById('hudWasm');
-  if (wasmEl) {
-    wasmEl.textContent = wasmActive ? 'WASM ✓' : 'JS';
-    wasmEl.style.color  = wasmActive ? '#4fa' : '#888';
+  // Compute-backend badge: GPU / WASM / JS, tooltip carries failure reasons
+  const backendEl = document.getElementById('hudWasm');
+  if (backendEl && d.backend) {
+    const labels = { gpu: 'GPU ✓', wasm: `WASM ×${threads}`, js: `JS ×${threads || 1}` };
+    const colors = { gpu: '#c9f', wasm: '#4fa', js: '#888' };
+    backendEl.textContent = labels[d.backend] || d.backend;
+    backendEl.style.color = colors[d.backend] || '#888';
+    backendEl.title = d.backendInfo || 'Gradient compute backend';
   }
 
   if (d.sigma) {
@@ -368,7 +369,7 @@ function makeOptBtnGroup(containerId, options, key, onChange) {
     b.dataset.val = val;
     b.addEventListener('click', () => {
       simCfg[key] = val;
-      wrap.querySelectorAll('.opt-btn').forEach(el => el.classList.toggle('sel', +el.dataset.val === val));
+      wrap.querySelectorAll('.opt-btn').forEach(el => el.classList.toggle('sel', el.dataset.val === String(val)));
       onChange && onChange(val);
     });
     wrap.appendChild(b);
@@ -398,6 +399,11 @@ function initConfigMenu() {
   makeOptBtnGroup('configHorizonBtns',
     [{ label: '256', val: 256 }, { label: '512', val: 512 }, { label: '1024', val: 1024 }],
     'horizon');
+
+  makeOptBtnGroup('configBackendBtns',
+    [{ label: 'AUTO', val: 'auto' }, { label: 'GPU', val: 'gpu' },
+     { label: 'WASM', val: 'wasm' }, { label: 'JS', val: 'js' }],
+    'backend');
 
   wireConfigSlider('configAgentSlider',  'configAgentVal',  'numEnvs',  v => Math.round(v) + ' agents');
   wireConfigSlider('configEpLenSlider',  'configEpLenVal',  'episodeLen', v => v + 's');


### PR DESCRIPTION
## Summary

- **wrapPi fix**: Fixed overflow bug where the function would silently return values < −π once arguments dropped below −3π. Replaced with round-based formula valid for any input magnitude.
- **Heading normalization**: Added per-tick normalization of car heading (hdg) in SimCar.update() to prevent accumulation of ±2π per lap.
- **Arc position search**: Implemented hint-based local nearest-point search with global reseed beyond 30 m to handle tracks with self-intersections safely.
- **WASM loading**: Fixed corrupted inline base64 blob by fetching nn_wasm.wasm directly with instantiateStreaming fallback. Added wasmStatus messages to surface load failures in HUD.
- **GPU compute backend**: New experimental WebGPU PPO gradients backend with auto-validation against f64 JS path and auto-disable on mismatch. Config menu selector added (AUTO/GPU/WASM/JS).
- **HUD badge**: Shows active backend with failure reasons in tooltip.

## Testing
- Headless test: 210 PPO updates on jeff geometry with bounded heading, no NaN.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GLMhBrNdMQrodBay2k9rCu)_