### PR TITLE
ai-trainer: pace GPU submissions + consistency guard with best-policy auto-revert

### DIFF
--- a/games/ai-trainer/index.html
+++ b/games/ai-trainer/index.html
@@ -449,6 +449,28 @@
     </div>
   </div>
 
+  <div class="ctrl-section">
+    <div class="ctrl-title live-title">🏅 CONSISTENCY GUARD</div>
+    <label class="toggle-row" title="Snapshot the policy whenever its consistency score (mean − weight·spread of recent episode returns) hits a new best, and automatically restore that snapshot if training regresses below it for too many updates">
+      <span>AUTO-REVERT</span>
+      <input type="checkbox" id="ckptToggle" checked>
+    </label>
+    <div class="ctrl-row" title="How strongly inconsistency is punished in the score: 0 = best average only, higher = strongly prefer policies whose episodes all score alike">
+      <span class="ctrl-label">CONSISTENCY</span>
+      <span class="ctrl-val" id="consVal">0.5</span>
+      <input type="range" id="consSlider" min="0" max="2" value="0.5" step="0.1" style="accent-color:#fa4;">
+    </div>
+    <div class="ctrl-row" title="Updates spent significantly below the best score before auto-reverting">
+      <span class="ctrl-label">PATIENCE</span>
+      <span class="ctrl-val" id="patienceVal">25</span>
+      <input type="range" id="patienceSlider" min="5" max="100" value="25" step="5" style="accent-color:#fa4;">
+    </div>
+    <div class="ctrl-actions">
+      <button class="btn" id="revertBtn" title="Restore the best checkpoint right now (applies after the current update finishes)">⤺ REVERT TO BEST</button>
+    </div>
+    <div id="ckptStatus" style="color:#667;font-size:.6rem;margin-top:6px;">no checkpoint yet</div>
+  </div>
+
   <div>
     <button class="rewards-toggle-btn" id="rewardsToggle">▶ REWARDS &amp; PENALTIES</button>
   </div>

--- a/games/ai-trainer/scripts/gpu-grad.js
+++ b/games/ai-trainer/scripts/gpu-grad.js
@@ -2,11 +2,18 @@
 // ─────────────────────────────────────────────────────────────────────────────
 //  gpu-grad.js — WebGPU PPO gradient backend
 //
-//  computeEpoch() processes an entire shuffled epoch in ONE GPU round-trip:
-//  all minibatch gradient dispatches are encoded into a single command buffer,
-//  submitted once, and all results are read back with a single mapAsync.
-//  This avoids the 96 sequential CPU-GPU fences that caused the CPU core spike
-//  in the per-minibatch approach.
+//  computeEpoch() processes an entire shuffled epoch with ONE readback:
+//  minibatch gradient dispatches are encoded into command buffers of a few
+//  minibatches each, results accumulate on-device, and everything is read
+//  back with a single mapAsync at the end. Chunking matters: a single
+//  epoch-sized command buffer can occupy the GPU for hundreds of ms (seconds
+//  on integrated GPUs) without any chance of preemption — the OS compositor
+//  and the browser starve (system-wide lag), and drivers with a hang
+//  watchdog reset the device ("GPU driver crash"). Chunk size adapts to keep
+//  each submit near a small time budget, and a short pause between chunks
+//  leaves the GPU idle gaps for the rest of the system. The chunks grow
+//  toward whole epochs on fast GPUs, so the fence count stays far below the
+//  96 sequential per-minibatch round-trips that caused the old CPU spike.
 //
 //  WGSL is generated per architecture with all sizes baked in as constants.
 //  GROUP = 1: one GPU thread per training sample (maximum parallelism, shortest
@@ -278,6 +285,24 @@ export class GpuGrad {
 
     // Maximum minibatches per epoch.
     this._nMBMax = Math.ceil(epochCap / mbs);
+
+    // Minibatches per command-buffer submit — adapted at runtime so each
+    // submit stays near _TARGET_MS of GPU time (see computeEpoch).
+    this._chunk = 1;
+  }
+
+  // Await a GPU promise with a hard timeout so a hung driver surfaces as a
+  // catchable error (→ CPU fallback) instead of freezing the update forever.
+  async _awaitGpu(promise, ms, label) {
+    let to;
+    try {
+      await Promise.race([
+        promise,
+        new Promise((_, rej) => { to = setTimeout(() => rej(new Error(label)), ms); }),
+      ]);
+    } finally {
+      clearTimeout(to);
+    }
   }
 
   async _build() {
@@ -380,32 +405,46 @@ export class GpuGrad {
       q.writeBuffer(this.uniBufs[m], 0, uBuf);
     }
 
-    // ── Encode all minibatch dispatches in ONE command buffer ─────────────────
-    // One mapAsync at the end instead of 96 sequential round-trips.
+    // ── Encode minibatch dispatches in paced chunks ───────────────────────────
+    // Each chunk is its own submit; we wait for it to drain before sending the
+    // next, so the GPU gets preemption points for the compositor/browser and a
+    // hang watchdog never sees one monolithic multi-second command buffer.
+    const TARGET_MS = 15;
     d.pushErrorScope('validation');
     d.pushErrorScope('out-of-memory');
-    const enc = d.createCommandEncoder();
-    for (let m = 0; m < nMB; m++) {
-      const bs = Math.min(mbs, N - m * mbs);
-      const nGroups = Math.ceil(bs / GROUP);
-      enc.clearBuffer(this.bufSlabs, 0, nGroups * SLAB * 4);
-      const pass = enc.beginComputePass();
-      pass.setBindGroup(0, this.bindGroups[m]);
-      pass.setPipeline(this.gradPipe);
-      pass.dispatchWorkgroups(Math.ceil(nGroups / 64));
-      pass.setPipeline(this.reducePipe);
-      pass.dispatchWorkgroups(Math.ceil(OUT / 256));
-      pass.end();
-      enc.copyBufferToBuffer(this.bufOut, 0, this.bufAllOut, m * OUT * 4, OUT * 4);
+    let m = 0;
+    while (m < nMB) {
+      const mEnd = Math.min(nMB, m + this._chunk);
+      const enc = d.createCommandEncoder();
+      for (; m < mEnd; m++) {
+        const bs = Math.min(mbs, N - m * mbs);
+        const nGroups = Math.ceil(bs / GROUP);
+        enc.clearBuffer(this.bufSlabs, 0, nGroups * SLAB * 4);
+        const pass = enc.beginComputePass();
+        pass.setBindGroup(0, this.bindGroups[m]);
+        pass.setPipeline(this.gradPipe);
+        pass.dispatchWorkgroups(Math.ceil(nGroups / 64));
+        pass.setPipeline(this.reducePipe);
+        pass.dispatchWorkgroups(Math.ceil(OUT / 256));
+        pass.end();
+        enc.copyBufferToBuffer(this.bufOut, 0, this.bufAllOut, m * OUT * 4, OUT * 4);
+      }
+      q.submit([enc.finish()]);
+      const t0 = performance.now();
+      await this._awaitGpu(q.onSubmittedWorkDone(), 15000, 'GPU work timeout (>15s) — driver hung?');
+      const ms = performance.now() - t0;
+      if (ms < TARGET_MS * 0.5 && this._chunk < this._nMBMax) this._chunk = Math.min(this._chunk * 2, this._nMBMax);
+      else if (ms > TARGET_MS * 2 && this._chunk > 1)         this._chunk = Math.max(1, this._chunk >> 1);
+      // idle gap ∝ chunk runtime (≤25 % overhead) so other GPU users get a turn
+      if (m < nMB) await new Promise(res => setTimeout(res, Math.min(8, Math.max(1, ms / 4))));
     }
-    enc.copyBufferToBuffer(this.bufAllOut, 0, this.bufStage, 0, nMB * OUT * 4);
-    q.submit([enc.finish()]);
 
-    // ── Single mapAsync for the entire epoch ──────────────────────────────────
-    const mapP = this.bufStage.mapAsync(GPUMapMode.READ, 0, nMB * OUT * 4);
-    const timeout = new Promise((_, rej) =>
-      setTimeout(() => rej(new Error('GPU mapAsync timeout (>30s)')), 30000));
-    await Promise.race([mapP, timeout]);
+    // ── Single readback for the entire epoch ──────────────────────────────────
+    const encC = d.createCommandEncoder();
+    encC.copyBufferToBuffer(this.bufAllOut, 0, this.bufStage, 0, nMB * OUT * 4);
+    q.submit([encC.finish()]);
+    await this._awaitGpu(this.bufStage.mapAsync(GPUMapMode.READ, 0, nMB * OUT * 4),
+                         30000, 'GPU mapAsync timeout (>30s)');
 
     const raw = new Float32Array(this.bufStage.getMappedRange(0, nMB * OUT * 4)).slice();
     this.bufStage.unmap();

--- a/games/ai-trainer/scripts/nn-core.js
+++ b/games/ai-trainer/scripts/nn-core.js
@@ -93,6 +93,17 @@ export class Net {
     for (const g of this.gb) g.fill(0);
   }
 
+  // Clear Adam moments + step count — required after externally overwriting
+  // the weights (checkpoint restore), or the stale momentum immediately
+  // pushes the restored weights back toward the abandoned policy.
+  resetAdam() {
+    for (const m of this.mW) m.fill(0);
+    for (const v of this.vW) v.fill(0);
+    for (const m of this.mb) m.fill(0);
+    for (const v of this.vb) v.fill(0);
+    this.t = 0;
+  }
+
   adamStep(lr, scale) {
     this.t++;
     const b1 = 0.9, b2 = 0.999, eps = 1e-8;

--- a/games/ai-trainer/scripts/sim-worker.js
+++ b/games/ai-trainer/scripts/sim-worker.js
@@ -62,6 +62,10 @@ let cfg = {
   wallPenalty: 2.0,      // per second of wall contact
   terminalPenalty: 10,   // on off-track / stuck termination
   lapBonus: 20,          // on lap completion
+  // consistency guard — best-policy checkpoint + auto-revert
+  ckptEnable: true,        // snapshot the best policy, revert on sustained regression
+  consistencyWeight: 0.5,  // score = mean(returns) − weight·std(returns)
+  revertPatience: 25,      // updates below the best score before auto-revert
 };
 
 const FIXED_DT = 1 / 60;
@@ -575,6 +579,22 @@ let recentReturns = [];     // last completed episode returns
 let bestLap = Infinity;
 let lastLoss = { pi: 0, v: 0, ent: 0 };
 
+// ── Consistency guard state ──────────────────────────────────────────────────
+// PPO is on-policy: once the policy drifts into a worse strategy (and σ has
+// shrunk) there is nothing in vanilla PPO that can pull it back to an earlier,
+// better policy. The guard snapshots the policy whenever a consistency-aware
+// score — mean(recent returns) − w·std(recent returns), which rewards HIGH and
+// STABLE returns — reaches a new best, and restores that snapshot after
+// `revertPatience` consecutive updates spent significantly below it.
+let ckpt          = null;   // { aFlat, cFlat, logStd, score, mean, std, iter }
+let curScore      = null;   // last computed { score, mean, std }
+let regressCount  = 0;      // consecutive updates below the checkpoint score
+let revertCount   = 0;      // total reverts this run
+let _revertPending = false; // manual revert requested while an update is in flight
+
+const CKPT_WINDOW  = 20;    // episodes used for the score
+const CKPT_MIN_EPS = 12;    // minimum episodes before scoring
+
 function spawnPose(envIdx) {
   const n = trkPts.length;
   if (!n) return { pos: { x: 0, y: 0, z: 0 }, hdg: 0 };
@@ -637,6 +657,8 @@ function initSim(modelOverride) {
   recentReturns = []; bestLap = Infinity;
   simTime = 0;
   lastLoss = { pi: 0, v: 0, ent: 0 };
+  ckpt = null; curScore = null;
+  regressCount = 0; revertCount = 0; _revertPending = false;
 }
 
 // Finalize the pending transition of an env into its rollout chain.
@@ -938,6 +960,75 @@ function packEpochData(OBS, ACT, LOGP, ADV, RET, idx, N) {
   return { N, obs, act, logp, adv, ret };
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+//  Consistency guard
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Consistency-aware policy score over the recent episode window.
+// Subtracting the std means an erratic policy (huge spread between its best
+// and worst episodes) scores below a steady one with the same mean.
+function policyScore() {
+  const tail = recentReturns.slice(-CKPT_WINDOW);
+  if (tail.length < CKPT_MIN_EPS) return null;
+  let mean = 0; for (const r of tail) mean += r; mean /= tail.length;
+  let varr = 0; for (const r of tail) varr += (r - mean) ** 2;
+  const std = Math.sqrt(varr / tail.length);
+  return { score: mean - cfg.consistencyWeight * std, mean, std };
+}
+
+function updateCheckpoint() {
+  if (!cfg.ckptEnable) { regressCount = 0; return; }
+  const s = policyScore();
+  if (!s) return;
+  curScore = s;
+  if (!ckpt || s.score > ckpt.score) {
+    ckpt = {
+      aFlat: actor.flatF64(), cFlat: critic.flatF64(),
+      logStd: Float64Array.from(logStd),
+      score: s.score, mean: s.mean, std: s.std, iter: iteration,
+    };
+    regressCount = 0;
+    return;
+  }
+  // Sustained, significant regression → restore the best snapshot. The margin
+  // keeps ordinary episode-return noise from triggering reverts.
+  const margin = Math.max(2, Math.abs(ckpt.score) * 0.1);
+  if (s.score < ckpt.score - margin) {
+    if (++regressCount >= Math.max(1, cfg.revertPatience | 0)) restoreCheckpoint();
+  } else {
+    regressCount = 0;
+  }
+}
+
+// Restore the best snapshot. Only call between PPO updates (weights must not
+// change while gradient tasks are in flight).
+function restoreCheckpoint() {
+  if (!ckpt) return;
+  actor.loadFlat(ckpt.aFlat);
+  critic.loadFlat(ckpt.cFlat);
+  logStd.set(ckpt.logStd);
+  actor.resetAdam();
+  critic.resetAdam();
+  lsM.fill(0); lsV.fill(0); lsT = 0;
+  // Re-open exploration a little: the policy already proved the abandoned
+  // direction is a dead end, so it needs noise to find a DIFFERENT one.
+  for (let d = 0; d < ACT_DIM; d++) logStd[d] = Math.min(0.3, logStd[d] + 0.25);
+  // Drop rollouts and episode stats gathered under the abandoned policy —
+  // stale transitions would train the restored weights toward it again, and
+  // stale returns would immediately re-trigger the regression counter.
+  for (const env of envs) {
+    const b = env.buf;
+    b.obs.length = 0; b.act.length = 0; b.logp.length = 0;
+    b.val.length = 0; b.rew.length = 0; b.done.length = 0;
+    env.pendObs = null; env.rewAcc = 0; env.repCount = 0;
+  }
+  agentSteps = 0;
+  recentReturns = [];
+  curScore = null;
+  regressCount = 0;
+  revertCount++;
+}
+
 async function _runPPO(batch) {
   const { OBS, ACT, LOGP, ADV, RET } = batch;
   const N = OBS.length;
@@ -1105,6 +1196,8 @@ async function _runPPO(batch) {
 
   if (nMB) lastLoss = { pi: sumPi / nMB, v: sumV / nMB, ent: sumEnt / nMB };
   iteration++;
+  if (_revertPending) { _revertPending = false; restoreCheckpoint(); }
+  else updateCheckpoint();
   _ppoRunning = false;
   if (_poolRebuild) { _poolRebuild = false; initGradPool(true); }
 }
@@ -1151,6 +1244,11 @@ function buildSnapshot() {
     episodes: recentReturns.length,
     loss: lastLoss,
     sigma: logStd ? [Math.exp(logStd[0]), Math.exp(logStd[1])] : null,
+    ckpt: ckpt ? {
+      score: ckpt.score, iter: ckpt.iter,
+      cur: curScore ? curScore.score : null,
+      regress: regressCount, reverts: revertCount,
+    } : null,
   };
   // actor weights for the visualiser — heavy, send ~once per second
   if (vizCounter++ % POST_HZ === 0 && actor) {
@@ -1270,6 +1368,13 @@ self.onmessage = function (e) {
 
   if (type === 'getSnapshot') {
     if (actor) postMessage(buildSnapshot());
+    return;
+  }
+
+  if (type === 'revertBest') {
+    if (!ckpt) return;
+    if (_ppoRunning) _revertPending = true;  // applied when the update finishes
+    else restoreCheckpoint();
     return;
   }
 

--- a/games/ai-trainer/scripts/trainer-app.js
+++ b/games/ai-trainer/scripts/trainer-app.js
@@ -165,6 +165,9 @@ const simCfg = {
   wallPenalty: 2.0,
   terminalPenalty: 10,
   lapBonus: 20,
+  ckptEnable: true,
+  consistencyWeight: 0.5,
+  revertPatience: 25,
 };
 
 function mkWorker() {
@@ -288,6 +291,22 @@ function refreshHUD(d) {
 
   if (d.sigma) {
     document.getElementById('hudSigma').textContent = 'σ ' + d.sigma.map(s => s.toFixed(2)).join('/');
+  }
+
+  const ckptEl = document.getElementById('ckptStatus');
+  if (ckptEl) {
+    const ck = d.ckpt;
+    if (ck) {
+      let txt = `best ${fmt(ck.score)} @ update ${ck.iter}`;
+      if (ck.cur != null) txt += ` · now ${fmt(ck.cur)}`;
+      if (ck.regress > 0) txt += ` · regressing ${ck.regress}`;
+      if (ck.reverts > 0) txt += ` · reverts ${ck.reverts}`;
+      ckptEl.textContent = txt;
+      ckptEl.style.color = ck.regress > 0 ? '#fa4' : '#4a8';
+    } else if (Object.prototype.hasOwnProperty.call(d, 'ckpt')) {
+      ckptEl.textContent = 'no checkpoint yet — needs ~12 finished episodes';
+      ckptEl.style.color = '#667';
+    }
   }
 
   if (lastCars.length) {
@@ -523,6 +542,18 @@ function initUI() {
   wireSlider('wallSlider',    'wallVal',    'wallPenalty',     v => v.toFixed(1));
   wireSlider('termSlider',    'termVal',    'terminalPenalty', v => Math.round(v));
   wireSlider('lapBonusSlider','lapBonusVal','lapBonus',        v => Math.round(v));
+
+  wireSlider('consSlider',     'consVal',     'consistencyWeight', v => v.toFixed(1));
+  wireSlider('patienceSlider', 'patienceVal', 'revertPatience',    v => Math.round(v));
+  const ckptTog = document.getElementById('ckptToggle');
+  ckptTog.checked = simCfg.ckptEnable;
+  ckptTog.addEventListener('change', () => {
+    simCfg.ckptEnable = ckptTog.checked;
+    if (worker) worker.postMessage({ type: 'setConfig', config: { ckptEnable: ckptTog.checked } });
+  });
+  document.getElementById('revertBtn').addEventListener('click', () => {
+    if (worker) worker.postMessage({ type: 'revertBest' });
+  });
 
   document.getElementById('startBtn').addEventListener('click', () => {
     if (!workerReady) return;


### PR DESCRIPTION
## Summary

- **GPU Pacing**: Fixed system-wide lag by breaking up epoch compute dispatches into adaptively sized chunks (~15ms each) instead of submitting the whole epoch at once. Keeps single end-of-epoch readback for efficiency while preventing GPU hangs and driver crashes on slower hardware.
- **Consistency Guard**: Added defense against bad local optima by scoring policies as mean − w·std of recent returns (favoring good *and* consistent strategies). Auto-snapshots and restores best policy after sustained regression with fresh optimizer state and reopened exploration.
- **UI Enhancements**: Sidebar now exposes consistency weight, revert patience, on/off toggle, and manual REVERT TO BEST button for interactive control.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WRj5GSk72sciW25d4g4gwU)_