### PR TITLE
ai-trainer: rework GPU pacing with real fences + duty-cycle cap

### DIFF
--- a/games/ai-trainer/index.html
+++ b/games/ai-trainer/index.html
@@ -402,7 +402,7 @@
   <button class="btn" id="restartBtn" title="Restart training with same settings">RESTART</button>
   <button class="btn btn-danger" id="resetBtn" title="Wipe all learned weights and start from scratch">RESET AI</button>
   <span class="hud-sep">│</span>
-  <button class="btn" id="exportBtn">EXPORT</button>
+  <button class="btn" id="exportBtn" title="Save the model as JSON — exports the best-average network snapshot once one exists, otherwise the live weights">EXPORT</button>
   <button class="btn" id="importBtn">IMPORT</button>
   <input type="file" id="importFile" accept=".json" style="display:none">
   <span class="hud-sep">│</span>
@@ -449,26 +449,12 @@
     </div>
   </div>
 
-  <div class="ctrl-section">
-    <div class="ctrl-title live-title">🏅 CONSISTENCY GUARD</div>
-    <label class="toggle-row" title="Snapshot the policy whenever its consistency score (mean − weight·spread of recent episode returns) hits a new best, and automatically restore that snapshot if training regresses below it for too many updates">
-      <span>AUTO-REVERT</span>
-      <input type="checkbox" id="ckptToggle" checked>
-    </label>
-    <div class="ctrl-row" title="How strongly inconsistency is punished in the score: 0 = best average only, higher = strongly prefer policies whose episodes all score alike">
-      <span class="ctrl-label">CONSISTENCY</span>
-      <span class="ctrl-val" id="consVal">0.5</span>
-      <input type="range" id="consSlider" min="0" max="2" value="0.5" step="0.1" style="accent-color:#fa4;">
-    </div>
-    <div class="ctrl-row" title="Updates spent significantly below the best score before auto-reverting">
-      <span class="ctrl-label">PATIENCE</span>
-      <span class="ctrl-val" id="patienceVal">25</span>
-      <input type="range" id="patienceSlider" min="5" max="100" value="25" step="5" style="accent-color:#fa4;">
-    </div>
+  <div class="ctrl-section" title="The trainer keeps a snapshot of the network whose recent episodes had the best AVERAGE return across all agents — judged by how well everyone does with it, not by one lucky run. EXPORT saves this snapshot.">
+    <div class="ctrl-title live-title">🏅 BEST NETWORK (AVG OF ALL AGENTS)</div>
+    <div id="bestStatus" style="color:#667;font-size:.6rem;margin-bottom:8px;">no snapshot yet</div>
     <div class="ctrl-actions">
-      <button class="btn" id="revertBtn" title="Restore the best checkpoint right now (applies after the current update finishes)">⤺ REVERT TO BEST</button>
+      <button class="btn" id="loadBestBtn" title="Continue training from the best-average snapshot (applies once the in-flight update finishes)">⤺ LOAD BEST</button>
     </div>
-    <div id="ckptStatus" style="color:#667;font-size:.6rem;margin-top:6px;">no checkpoint yet</div>
   </div>
 
   <div>

--- a/games/ai-trainer/scripts/gpu-grad.js
+++ b/games/ai-trainer/scripts/gpu-grad.js
@@ -2,18 +2,17 @@
 // ─────────────────────────────────────────────────────────────────────────────
 //  gpu-grad.js — WebGPU PPO gradient backend
 //
-//  computeEpoch() processes an entire shuffled epoch with ONE readback:
-//  minibatch gradient dispatches are encoded into command buffers of a few
-//  minibatches each, results accumulate on-device, and everything is read
-//  back with a single mapAsync at the end. Chunking matters: a single
-//  epoch-sized command buffer can occupy the GPU for hundreds of ms (seconds
-//  on integrated GPUs) without any chance of preemption — the OS compositor
-//  and the browser starve (system-wide lag), and drivers with a hang
-//  watchdog reset the device ("GPU driver crash"). Chunk size adapts to keep
-//  each submit near a small time budget, and a short pause between chunks
-//  leaves the GPU idle gaps for the rest of the system. The chunks grow
-//  toward whole epochs on fast GPUs, so the fence count stays far below the
-//  96 sequential per-minibatch round-trips that caused the old CPU spike.
+//  computeEpoch() runs the epoch's minibatch gradient dispatches in SMALL,
+//  PACED command-buffer submits. After each submit a 4-byte fence readback
+//  waits until the GPU has actually finished it — onSubmittedWorkDone() is
+//  NOT used because some browsers resolve it before the work completes,
+//  which would let the chunk size balloon back into one monolithic submit.
+//  Between submits the loop idles long enough to cap the trainer's GPU duty
+//  cycle (GPU_DUTY): without that the trainer monopolises the GPU, the OS
+//  compositor and the browser starve (system-wide lag, browser crashes) and
+//  a driver hang watchdog can reset the device ("GPU driver crash").
+//  Gradients accumulate on-device; one mapAsync at the end reads back the
+//  whole epoch.
 //
 //  WGSL is generated per architecture with all sizes baked in as constants.
 //  GROUP = 1: one GPU thread per training sample (maximum parallelism, shortest
@@ -287,7 +286,7 @@ export class GpuGrad {
     this._nMBMax = Math.ceil(epochCap / mbs);
 
     // Minibatches per command-buffer submit — adapted at runtime so each
-    // submit stays near _TARGET_MS of GPU time (see computeEpoch).
+    // submit stays near the per-submit GPU time budget (see computeEpoch).
     this._chunk = 1;
   }
 
@@ -343,6 +342,9 @@ export class GpuGrad {
     this.bufOut     = mk(OUT  * 4,                                GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC);
     this.bufAllOut  = mk(nMBMax * OUT * 4,                        GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC);
     this.bufStage   = mk(nMBMax * OUT * 4,                        GPUBufferUsage.MAP_READ | GPUBufferUsage.COPY_DST);
+    // 4-byte fence target: mapping this after a submit is a completion signal
+    // that works on every implementation (unlike onSubmittedWorkDone).
+    this.bufFence   = mk(4,                                       GPUBufferUsage.MAP_READ | GPUBufferUsage.COPY_DST);
 
     // One uniform buffer + one bind group per max-minibatch slot.
     // Written fresh each computeEpoch call, before the command encoder.
@@ -405,11 +407,15 @@ export class GpuGrad {
       q.writeBuffer(this.uniBufs[m], 0, uBuf);
     }
 
-    // ── Encode minibatch dispatches in paced chunks ───────────────────────────
-    // Each chunk is its own submit; we wait for it to drain before sending the
-    // next, so the GPU gets preemption points for the compositor/browser and a
-    // hang watchdog never sees one monolithic multi-second command buffer.
-    const TARGET_MS = 15;
+    // ── Encode minibatch dispatches in small, paced submits ───────────────────
+    // Each submit is fenced (real completion, see bufFence) and followed by an
+    // idle period that caps this trainer's share of the GPU at GPU_DUTY. The
+    // GPU therefore always has preemption points and guaranteed free time for
+    // the compositor/browser, and a hang watchdog never sees one monolithic
+    // multi-second command buffer.
+    const TARGET_MS = 10;   // GPU busy time to aim for per submit
+    const GPU_DUTY  = 0.5;  // max fraction of wall time the GPU works for us
+    const MAX_CHUNK = 8;    // hard cap on minibatches per submit
     d.pushErrorScope('validation');
     d.pushErrorScope('out-of-memory');
     let m = 0;
@@ -429,14 +435,25 @@ export class GpuGrad {
         pass.end();
         enc.copyBufferToBuffer(this.bufOut, 0, this.bufAllOut, m * OUT * 4, OUT * 4);
       }
+      enc.copyBufferToBuffer(this.bufOut, 0, this.bufFence, 0, 4);
       q.submit([enc.finish()]);
+
+      // Fence: mapAsync on the 4-byte target cannot resolve before every
+      // command in this submit has executed.
       const t0 = performance.now();
-      await this._awaitGpu(q.onSubmittedWorkDone(), 15000, 'GPU work timeout (>15s) — driver hung?');
-      const ms = performance.now() - t0;
-      if (ms < TARGET_MS * 0.5 && this._chunk < this._nMBMax) this._chunk = Math.min(this._chunk * 2, this._nMBMax);
-      else if (ms > TARGET_MS * 2 && this._chunk > 1)         this._chunk = Math.max(1, this._chunk >> 1);
-      // idle gap ∝ chunk runtime (≤25 % overhead) so other GPU users get a turn
-      if (m < nMB) await new Promise(res => setTimeout(res, Math.min(8, Math.max(1, ms / 4))));
+      await this._awaitGpu(this.bufFence.mapAsync(GPUMapMode.READ, 0, 4),
+                           15000, 'GPU work timeout (>15s) — driver hung?');
+      this.bufFence.unmap();
+      const busy = performance.now() - t0;
+
+      if (busy < TARGET_MS * 0.5 && this._chunk < MAX_CHUNK) this._chunk++;
+      else if (busy > TARGET_MS * 2 && this._chunk > 1)      this._chunk = Math.max(1, this._chunk >> 1);
+
+      // Duty-cycle enforcement: idle long enough that our busy share of wall
+      // time stays at GPU_DUTY. Applies after the last chunk too, so
+      // back-to-back epochs/updates can't merge into continuous GPU load.
+      const idle = Math.min(500, busy * (1 - GPU_DUTY) / GPU_DUTY);
+      await new Promise(res => setTimeout(res, Math.max(1, idle)));
     }
 
     // ── Single readback for the entire epoch ──────────────────────────────────

--- a/games/ai-trainer/scripts/sim-worker.js
+++ b/games/ai-trainer/scripts/sim-worker.js
@@ -62,10 +62,6 @@ let cfg = {
   wallPenalty: 2.0,      // per second of wall contact
   terminalPenalty: 10,   // on off-track / stuck termination
   lapBonus: 20,          // on lap completion
-  // consistency guard — best-policy checkpoint + auto-revert
-  ckptEnable: true,        // snapshot the best policy, revert on sustained regression
-  consistencyWeight: 0.5,  // score = mean(returns) − weight·std(returns)
-  revertPatience: 25,      // updates below the best score before auto-revert
 };
 
 const FIXED_DT = 1 / 60;
@@ -579,21 +575,19 @@ let recentReturns = [];     // last completed episode returns
 let bestLap = Infinity;
 let lastLoss = { pi: 0, v: 0, ent: 0 };
 
-// ── Consistency guard state ──────────────────────────────────────────────────
-// PPO is on-policy: once the policy drifts into a worse strategy (and σ has
-// shrunk) there is nothing in vanilla PPO that can pull it back to an earlier,
-// better policy. The guard snapshots the policy whenever a consistency-aware
-// score — mean(recent returns) − w·std(recent returns), which rewards HIGH and
-// STABLE returns — reaches a new best, and restores that snapshot after
-// `revertPatience` consecutive updates spent significantly below it.
-let ckpt          = null;   // { aFlat, cFlat, logStd, score, mean, std, iter }
-let curScore      = null;   // last computed { score, mean, std }
-let regressCount  = 0;      // consecutive updates below the checkpoint score
-let revertCount   = 0;      // total reverts this run
-let _revertPending = false; // manual revert requested while an update is in flight
+// ── Best-network snapshot ────────────────────────────────────────────────────
+// A network is judged by the AVERAGE return over the recent episodes of ALL
+// parallel agents — one lucky agent or one lucky episode is not enough. The
+// best-average snapshot is what 'exportModel' saves by default, and training
+// can be manually reset to it ('loadBest') after the policy drifts somewhere
+// worse (PPO is on-policy and has no built-in way back out of a bad local
+// optimum once exploration noise has shrunk).
+let best = null;            // { aFlat, cFlat, logStd, avg, iter }
+let curAvg = null;          // average return of the current window
+let _loadBestPending = false; // manual restore requested while an update runs
 
-const CKPT_WINDOW  = 20;    // episodes used for the score
-const CKPT_MIN_EPS = 12;    // minimum episodes before scoring
+const BEST_WINDOW  = 20;    // episodes in the scoring window
+const BEST_MIN_EPS = 12;    // minimum episodes before scoring
 
 function spawnPose(envIdx) {
   const n = trkPts.length;
@@ -657,8 +651,7 @@ function initSim(modelOverride) {
   recentReturns = []; bestLap = Infinity;
   simTime = 0;
   lastLoss = { pi: 0, v: 0, ent: 0 };
-  ckpt = null; curScore = null;
-  regressCount = 0; revertCount = 0; _revertPending = false;
+  best = null; curAvg = null; _loadBestPending = false;
 }
 
 // Finalize the pending transition of an env into its rollout chain.
@@ -961,61 +954,38 @@ function packEpochData(OBS, ACT, LOGP, ADV, RET, idx, N) {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-//  Consistency guard
+//  Best-network snapshot (by average return across all agents)
 // ─────────────────────────────────────────────────────────────────────────────
 
-// Consistency-aware policy score over the recent episode window.
-// Subtracting the std means an erratic policy (huge spread between its best
-// and worst episodes) scores below a steady one with the same mean.
-function policyScore() {
-  const tail = recentReturns.slice(-CKPT_WINDOW);
-  if (tail.length < CKPT_MIN_EPS) return null;
-  let mean = 0; for (const r of tail) mean += r; mean /= tail.length;
-  let varr = 0; for (const r of tail) varr += (r - mean) ** 2;
-  const std = Math.sqrt(varr / tail.length);
-  return { score: mean - cfg.consistencyWeight * std, mean, std };
-}
-
-function updateCheckpoint() {
-  if (!cfg.ckptEnable) { regressCount = 0; return; }
-  const s = policyScore();
-  if (!s) return;
-  curScore = s;
-  if (!ckpt || s.score > ckpt.score) {
-    ckpt = {
+function updateBestSnapshot() {
+  const tail = recentReturns.slice(-BEST_WINDOW);
+  if (tail.length < BEST_MIN_EPS) { curAvg = null; return; }
+  let avg = 0; for (const r of tail) avg += r; avg /= tail.length;
+  curAvg = avg;
+  if (!best || avg > best.avg) {
+    best = {
       aFlat: actor.flatF64(), cFlat: critic.flatF64(),
       logStd: Float64Array.from(logStd),
-      score: s.score, mean: s.mean, std: s.std, iter: iteration,
+      avg, iter: iteration,
     };
-    regressCount = 0;
-    return;
-  }
-  // Sustained, significant regression → restore the best snapshot. The margin
-  // keeps ordinary episode-return noise from triggering reverts.
-  const margin = Math.max(2, Math.abs(ckpt.score) * 0.1);
-  if (s.score < ckpt.score - margin) {
-    if (++regressCount >= Math.max(1, cfg.revertPatience | 0)) restoreCheckpoint();
-  } else {
-    regressCount = 0;
   }
 }
 
 // Restore the best snapshot. Only call between PPO updates (weights must not
 // change while gradient tasks are in flight).
-function restoreCheckpoint() {
-  if (!ckpt) return;
-  actor.loadFlat(ckpt.aFlat);
-  critic.loadFlat(ckpt.cFlat);
-  logStd.set(ckpt.logStd);
+function loadBestSnapshot() {
+  if (!best) return;
+  actor.loadFlat(best.aFlat);
+  critic.loadFlat(best.cFlat);
+  logStd.set(best.logStd);
   actor.resetAdam();
   critic.resetAdam();
   lsM.fill(0); lsV.fill(0); lsT = 0;
-  // Re-open exploration a little: the policy already proved the abandoned
-  // direction is a dead end, so it needs noise to find a DIFFERENT one.
+  // Re-open exploration a little: the abandoned direction was a dead end, so
+  // the restored policy needs noise to find a DIFFERENT improvement.
   for (let d = 0; d < ACT_DIM; d++) logStd[d] = Math.min(0.3, logStd[d] + 0.25);
   // Drop rollouts and episode stats gathered under the abandoned policy —
-  // stale transitions would train the restored weights toward it again, and
-  // stale returns would immediately re-trigger the regression counter.
+  // stale transitions would train the restored weights toward it again.
   for (const env of envs) {
     const b = env.buf;
     b.obs.length = 0; b.act.length = 0; b.logp.length = 0;
@@ -1024,9 +994,7 @@ function restoreCheckpoint() {
   }
   agentSteps = 0;
   recentReturns = [];
-  curScore = null;
-  regressCount = 0;
-  revertCount++;
+  curAvg = null;
 }
 
 async function _runPPO(batch) {
@@ -1196,8 +1164,8 @@ async function _runPPO(batch) {
 
   if (nMB) lastLoss = { pi: sumPi / nMB, v: sumV / nMB, ent: sumEnt / nMB };
   iteration++;
-  if (_revertPending) { _revertPending = false; restoreCheckpoint(); }
-  else updateCheckpoint();
+  if (_loadBestPending) { _loadBestPending = false; loadBestSnapshot(); }
+  else updateBestSnapshot();
   _ppoRunning = false;
   if (_poolRebuild) { _poolRebuild = false; initGradPool(true); }
 }
@@ -1244,11 +1212,7 @@ function buildSnapshot() {
     episodes: recentReturns.length,
     loss: lastLoss,
     sigma: logStd ? [Math.exp(logStd[0]), Math.exp(logStd[1])] : null,
-    ckpt: ckpt ? {
-      score: ckpt.score, iter: ckpt.iter,
-      cur: curScore ? curScore.score : null,
-      regress: regressCount, reverts: revertCount,
-    } : null,
+    best: best ? { avg: best.avg, iter: best.iter, cur: curAvg } : null,
   };
   // actor weights for the visualiser — heavy, send ~once per second
   if (vizCounter++ % POST_HZ === 0 && actor) {
@@ -1371,15 +1335,19 @@ self.onmessage = function (e) {
     return;
   }
 
-  if (type === 'revertBest') {
-    if (!ckpt) return;
-    if (_ppoRunning) _revertPending = true;  // applied when the update finishes
-    else restoreCheckpoint();
+  if (type === 'loadBest') {
+    if (!best) return;
+    if (_ppoRunning) _loadBestPending = true;  // applied when the update finishes
+    else loadBestSnapshot();
     return;
   }
 
   if (type === 'exportModel') {
     if (!actor) return;
+    // Default: export the best-average snapshot when one exists — the live
+    // weights may have drifted past their peak. { which: 'current' } forces
+    // the live weights.
+    const useBest = !!best && e.data.which !== 'current';
     postMessage({
       type: 'modelExport',
       model: {
@@ -1389,12 +1357,14 @@ self.onmessage = function (e) {
         algo: 'ppo',
         obsDim: OBS_DIM,
         actDim: ACT_DIM,
-        actor:  { sizes: actor.sizes,  flat: actor.flat()  },
-        critic: { sizes: critic.sizes, flat: critic.flat() },
-        logStd: Array.from(logStd),
-        iteration,
+        actor:  { sizes: actor.sizes,  flat: useBest ? Array.from(best.aFlat) : actor.flat()  },
+        critic: { sizes: critic.sizes, flat: useBest ? Array.from(best.cFlat) : critic.flat() },
+        logStd: Array.from(useBest ? best.logStd : logStd),
+        iteration: useBest ? best.iter : iteration,
         totalSteps,
         bestLap: Number.isFinite(bestLap) ? bestLap : null,
+        snapshot: useBest ? 'best-average' : 'current',
+        avgReturn: useBest ? best.avg : curAvg,
       },
     });
     return;

--- a/games/ai-trainer/scripts/trainer-app.js
+++ b/games/ai-trainer/scripts/trainer-app.js
@@ -165,9 +165,6 @@ const simCfg = {
   wallPenalty: 2.0,
   terminalPenalty: 10,
   lapBonus: 20,
-  ckptEnable: true,
-  consistencyWeight: 0.5,
-  revertPatience: 25,
 };
 
 function mkWorker() {
@@ -293,19 +290,19 @@ function refreshHUD(d) {
     document.getElementById('hudSigma').textContent = 'σ ' + d.sigma.map(s => s.toFixed(2)).join('/');
   }
 
-  const ckptEl = document.getElementById('ckptStatus');
-  if (ckptEl) {
-    const ck = d.ckpt;
-    if (ck) {
-      let txt = `best ${fmt(ck.score)} @ update ${ck.iter}`;
-      if (ck.cur != null) txt += ` · now ${fmt(ck.cur)}`;
-      if (ck.regress > 0) txt += ` · regressing ${ck.regress}`;
-      if (ck.reverts > 0) txt += ` · reverts ${ck.reverts}`;
-      ckptEl.textContent = txt;
-      ckptEl.style.color = ck.regress > 0 ? '#fa4' : '#4a8';
-    } else if (Object.prototype.hasOwnProperty.call(d, 'ckpt')) {
-      ckptEl.textContent = 'no checkpoint yet — needs ~12 finished episodes';
-      ckptEl.style.color = '#667';
+  const bestEl = document.getElementById('bestStatus');
+  if (bestEl && Object.prototype.hasOwnProperty.call(d, 'best')) {
+    if (d.best) {
+      let txt = `best avg ${fmt(d.best.avg)} @ update ${d.best.iter}`;
+      if (d.best.cur != null) txt += ` · current avg ${fmt(d.best.cur)}`;
+      bestEl.textContent = txt;
+      // amber when the current average has fallen clearly below the snapshot
+      const dropping = d.best.cur != null &&
+        d.best.cur < d.best.avg - Math.max(2, Math.abs(d.best.avg) * 0.1);
+      bestEl.style.color = dropping ? '#fa4' : '#4a8';
+    } else {
+      bestEl.textContent = 'no snapshot yet — needs ~12 finished episodes';
+      bestEl.style.color = '#667';
     }
   }
 
@@ -543,16 +540,8 @@ function initUI() {
   wireSlider('termSlider',    'termVal',    'terminalPenalty', v => Math.round(v));
   wireSlider('lapBonusSlider','lapBonusVal','lapBonus',        v => Math.round(v));
 
-  wireSlider('consSlider',     'consVal',     'consistencyWeight', v => v.toFixed(1));
-  wireSlider('patienceSlider', 'patienceVal', 'revertPatience',    v => Math.round(v));
-  const ckptTog = document.getElementById('ckptToggle');
-  ckptTog.checked = simCfg.ckptEnable;
-  ckptTog.addEventListener('change', () => {
-    simCfg.ckptEnable = ckptTog.checked;
-    if (worker) worker.postMessage({ type: 'setConfig', config: { ckptEnable: ckptTog.checked } });
-  });
-  document.getElementById('revertBtn').addEventListener('click', () => {
-    if (worker) worker.postMessage({ type: 'revertBest' });
+  document.getElementById('loadBestBtn').addEventListener('click', () => {
+    if (worker) worker.postMessage({ type: 'loadBest' });
   });
 
   document.getElementById('startBtn').addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- Replaced GPU queue.onSubmittedWorkDone() pacing with real buffer readbacks (mapAsync) to prevent adaptive chunk size ballooning
- Hard-cap chunks at 8 minibatches and idle proportionally to maintain ~50% GPU duty cycle
- Replaced consistency-guard scoring with single average-return metric across all parallel agents
- Add EXPORT snapshot of best-average network and LOAD BEST button for recovery

## Changes
- GPU: Real fences + duty-cycle cap (4-byte buffer readback, 8 minibatch hard cap, proportional idle)
- Scoring: Average return across all agents, snapshotted best-average network
- Add LOAD BEST button to restore best network snapshot

https://claude.ai/code/session_01WRj5GSk72sciW25d4g4gwU

---
_Generated by [Claude Code](https://claude.ai/code/session_01WRj5GSk72sciW25d4g4gwU)_