### PR TITLE
F³: add Free Drive mode — open-world island with drop-in multiplayer

### DIFF
--- a/games/turborace/index.html
+++ b/games/turborace/index.html
@@ -16,7 +16,7 @@
   <div class="menuActions">
     <button id="introStartBtn" class="btn btn-p">START GAME</button>
   </div>
-  <div class="menuVersion" aria-label="Game version">v0.131</div>
+  <div class="menuVersion" aria-label="Game version">v0.132</div>
 </div>
 <div id="hud" role="status" aria-live="polite">
   <div id="raceTop">
@@ -31,6 +31,7 @@
   <div id="gearBox" class="hudBottomDock"><div id="gearNum">1</div><div id="gearLabel">GEAR</div></div>
   <div id="camLabel" class="hudBottomDock">[ C ] COCKPIT VIEW</div>
   <div id="mm"><canvas id="mmc" width="150" height="150"></canvas></div>
+  <div id="fdOnlineTag" style="display:none;position:absolute;top:14px;left:50%;transform:translateX(-50%);font-family:Orbitron,monospace;font-size:.7rem;letter-spacing:2px;color:#4f9;background:rgba(5,5,20,.7);border:1px solid rgba(46,204,136,.4);border-radius:6px;padding:4px 14px;white-space:nowrap;"></div>
 </div>
 
 <!-- VS opponent nametag (floating over opponent's car) -->
@@ -142,11 +143,12 @@
   <div class="menuActions">
     <button id="gameStartBtn" class="btn btn-p">START RACE</button>
     <button id="vsModeBtn" class="btn btn-p" style="background:linear-gradient(135deg,#1a0a2e,#0d1a2e);border-color:#c44aff;">⚔️ VS MODE</button>
+    <button id="freeDriveBtn" class="btn btn-p" style="background:linear-gradient(135deg,#0a2e1a,#0d1a2e);border-color:#2ecc88;">🏝️ FREE DRIVE</button>
     <button id="trackEditorBtn" class="btn btn-s">TRACK EDITOR</button>
     <button id="mainSettingsBtn" class="btn btn-s">SETTINGS</button>
     <button id="backToSelectionBtn" class="btn btn-s">BACK TO GAME SELECTION</button>
   </div>
-  <div class="menuVersion" aria-label="Game version">v0.131</div>
+  <div class="menuVersion" aria-label="Game version">v0.132</div>
 </div>
 
 <!-- CAR SELECT -->
@@ -312,6 +314,38 @@
     </div>
 
     <button id="vsLeaveLobbyBtn" class="btn btn-s">LEAVE LOBBY</button>
+  </div>
+</div>
+
+<!-- FREE DRIVE SETUP -->
+<div class="screen" id="sFreeDrive" style="display:none">
+  <h2>🏝️ Free Drive</h2>
+  <div class="sub">Open-world island · three cities · cruise together</div>
+  <div id="fdStatusMsg" style="color:#fa4;font-size:.8rem;min-height:1.2em;text-align:center;width:100%;max-width:640px;"></div>
+  <div style="display:flex;align-items:center;gap:8px;margin-bottom:14px;">
+    <span style="color:#556;font-size:.75rem;font-family:Orbitron,monospace;letter-spacing:1px;">DRIVING AS</span>
+    <span id="fdMyNameLabel" style="color:#ffd700;font-family:Orbitron,monospace;font-size:.9rem;font-weight:700;letter-spacing:1px;"></span>
+  </div>
+  <div class="vsSection" style="max-width:700px;">
+    <div class="vsLabel">Your Car</div>
+    <div id="fdCarRow" class="vsCarRow"></div>
+    <div class="vsColorRow">
+      <span class="carColorLabel">Colour</span>
+      <input id="fdColor" type="color" class="carColorInput" value="#ff2222">
+    </div>
+  </div>
+  <label class="toggleRow" for="fdOnlineToggle" style="width:100%;max-width:700px;margin-top:14px;">
+    <span class="toggleLbl">ONLINE — JOIN OTHER DRIVERS ON THE ISLAND</span>
+    <input type="checkbox" id="fdOnlineToggle" checked>
+  </label>
+  <p style="color:#667;font-size:.78rem;max-width:640px;text-align:center;line-height:1.5;margin-top:12px;">
+    One shared island, no room codes — everyone with Online enabled drives together.
+    Three cities linked by highways, a winding coastal road and narrow country lanes.
+    Off the tarmac you'll slow right down… unless you bring the Rally Storm.
+  </p>
+  <div class="menuActions menuActions-inline">
+    <button id="fdBackBtn" class="btn btn-s">BACK</button>
+    <button id="fdStartBtn" class="btn btn-p">START DRIVING</button>
   </div>
 </div>
 

--- a/games/turborace/scripts/freedrive-net.js
+++ b/games/turborace/scripts/freedrive-net.js
@@ -1,0 +1,66 @@
+'use strict';
+import { supabase } from './supabase.js';
+
+/**
+ * FreeDriveNetwork — drop-in open-world multiplayer via Supabase channels.
+ *
+ * Unlike VS mode there is no lobby, no host and no room code: everyone who
+ * enables Online shares one persistent island channel. Presence is the
+ * roster (sync fires on every join/leave) and a single broadcast event
+ * carries position updates.
+ */
+export class FreeDriveNetwork {
+  constructor() {
+    this.channel = null;
+    this.myId = crypto.randomUUID();
+
+    // Callbacks — assign before join()
+    this.onRoster = null;  // ([{id, name, carIdx, color}]) full presence roster
+    this.onPos    = null;  // ({id, x, z, hdg, spd})
+  }
+
+  async join(worldId, name, carIdx, color) {
+    this.channel = supabase.channel(`turborace-freedrive:${worldId}`, {
+      config: {
+        broadcast: { self: false },
+        presence:  { key: this.myId },
+      },
+    });
+
+    this.channel.on('presence', { event: 'sync' }, () => {
+      this.onRoster?.(this.getPlayers());
+    });
+    this.channel.on('broadcast', { event: 'fd_pos' }, ({ payload }) => this.onPos?.(payload));
+
+    await new Promise((resolve, reject) => {
+      this.channel.subscribe(async status => {
+        if (status === 'SUBSCRIBED') {
+          try {
+            await this.channel.track({ id: this.myId, name, carIdx, color });
+          } catch (e) {
+            console.warn('[freedrive-net] presence track failed:', e);
+          }
+          resolve();
+        } else if (status === 'CHANNEL_ERROR' || status === 'TIMED_OUT') {
+          reject(new Error(`Channel ${status}`));
+        }
+      });
+    });
+  }
+
+  getPlayers() {
+    if (!this.channel) return [];
+    return Object.values(this.channel.presenceState()).flat();
+  }
+
+  sendPos(x, z, hdg, spd) {
+    return this.channel?.send({ type: 'broadcast', event: 'fd_pos', payload: { id: this.myId, x, z, hdg, spd } });
+  }
+
+  async leave() {
+    if (this.channel) {
+      await this.channel.unsubscribe();
+      this.channel = null;
+    }
+  }
+}

--- a/games/turborace/scripts/freedrive-world.js
+++ b/games/turborace/scripts/freedrive-world.js
@@ -1,0 +1,324 @@
+'use strict';
+import { state, scene } from './state.js';
+import { THREE } from './three.js';
+
+// ═══════════════════════════════════════════════════════
+//  FREE DRIVE — OPEN WORLD ISLAND
+//  One big island, three cities connected by highways,
+//  a winding coastal country road and narrow lanes.
+// ═══════════════════════════════════════════════════════
+
+export const ISLAND_R = 1200;     // grass radius — beach + water beyond
+export const WATER_R  = 1265;     // hard boundary (cars get pushed back)
+export const LAKE_R   = 170;      // central lake (also a boundary)
+
+export const FD_CITIES = [
+  { name: 'Aurora Heights', x: 0,    z: -650, beacon: 0xff3355 },
+  { name: 'Neon Bay',       x: 600,  z: 390,  beacon: 0x33ddff },
+  { name: 'Solace Springs', x: -600, z: 390,  beacon: 0xc44aff },
+];
+
+const CITY_HALF_W = 180, CITY_HALF_D = 135, BLOCK = 90;
+
+// Road types — hw is the HALF width in metres. Different sizes per request:
+// 22 m highways, 10 m country ring, 7 m lanes, 11 m city streets.
+const ROAD_STYLES = {
+  highway: { hw: 11,  y: 0.030, col: 0x17171d },
+  country: { hw: 5,   y: 0.012, col: 0x1e1c18 },
+  lane:    { hw: 3.5, y: 0.006, col: 0x211e16 },
+  street:  { hw: 5.5, y: 0.018, col: 0x191922 },
+};
+
+let fdWorld = null;
+export function getFreeDriveWorld(){ return fdWorld; }
+
+// ── Geometry helpers ─────────────────────────────────────
+
+function polylineNormal(pts, i, closed){
+  const n = pts.length;
+  const prev = pts[closed ? (i - 1 + n) % n : Math.max(0, i - 1)];
+  const next = pts[closed ? (i + 1) % n : Math.min(n - 1, i + 1)];
+  const tx = next.x - prev.x, tz = next.z - prev.z, l = Math.hypot(tx, tz) || 1;
+  return { nx: -tz / l, nz: tx / l, tx: tx / l, tz: tz / l };
+}
+
+function addStripMesh(pts, hw, y, material, closed){
+  const n = pts.length, verts = [], idx = [];
+  for(let i = 0; i < n; i++){
+    const p = pts[i], { nx, nz } = polylineNormal(pts, i, closed);
+    verts.push(p.x - nx * hw, y, p.z - nz * hw, p.x + nx * hw, y, p.z + nz * hw);
+  }
+  const segCount = closed ? n : n - 1;
+  for(let i = 0; i < segCount; i++){
+    const a = i * 2, b = ((i + 1) % n) * 2;
+    idx.push(a, b, a + 1, a + 1, b, b + 1);
+  }
+  const geo = new THREE.BufferGeometry();
+  geo.setAttribute('position', new THREE.Float32BufferAttribute(verts, 3));
+  geo.setIndex(idx); geo.computeVertexNormals();
+  const mesh = new THREE.Mesh(geo, material);
+  mesh.receiveShadow = true; mesh.userData.trk = true; scene.add(mesh);
+  return mesh;
+}
+
+function offsetPolyline(pts, off, closed){
+  return pts.map((p, i) => {
+    const { nx, nz } = polylineNormal(pts, i, closed);
+    return new THREE.Vector3(p.x + nx * off, 0, p.z + nz * off);
+  });
+}
+
+// Dashed centre line: one short quad every few sample points.
+function addDashes(pts, y, material, closed, stride = 3, frac = 0.42, w = 0.32){
+  const n = pts.length, verts = [], idx = []; let vi = 0;
+  const last = closed ? n : n - 1;
+  for(let i = 0; i < last; i += stride){
+    const p0 = pts[i], p1 = pts[(i + 1) % n];
+    const tx = p1.x - p0.x, tz = p1.z - p0.z, l = Math.hypot(tx, tz) || 1;
+    const ux = tx / l, uz = tz / l, nx = -uz, nz = ux;
+    const len = l * frac * 2.2;
+    const ax = p0.x, az = p0.z, bx = p0.x + ux * len, bz = p0.z + uz * len;
+    verts.push(ax - nx * w, y, az - nz * w, ax + nx * w, y, az + nz * w,
+               bx + nx * w, y, bz + nz * w, bx - nx * w, y, bz - nz * w);
+    idx.push(vi, vi + 1, vi + 2, vi, vi + 2, vi + 3); vi += 4;
+  }
+  if(!verts.length) return;
+  const geo = new THREE.BufferGeometry();
+  geo.setAttribute('position', new THREE.Float32BufferAttribute(verts, 3));
+  geo.setIndex(idx); geo.computeVertexNormals();
+  const mesh = new THREE.Mesh(geo, material);
+  mesh.userData.trk = true; scene.add(mesh);
+}
+
+function curvePoints(ctrl, closed, step = 10){
+  const curve = new THREE.CatmullRomCurve3(
+    ctrl.map(p => new THREE.Vector3(p[0], 0, p[1])), closed, 'centripetal', 0.5);
+  const len = curve.getLength();
+  const n = Math.max(8, Math.round(len / step));
+  return curve.getSpacedPoints(n);
+}
+
+// ── World build ──────────────────────────────────────────
+
+export function buildFreeDriveWorld(){
+  // Clear previous track/world meshes (same tag the race tracks use)
+  const rm = []; scene.traverse(o => { if(o.userData.trk) rm.push(o); }); rm.forEach(o => scene.remove(o));
+
+  // Reset race-track state so Car physics treat the island as open ground:
+  // empty trkPts → flat groundY, no walls, no checkpoints, no gravel profile.
+  state.trkData = null; state.trkCurve = null; state.trkPts = []; state.trkCurv = [];
+  state.trkWallLeft = []; state.trkWallRight = []; state.trkEdgeLeft = []; state.trkEdgeRight = [];
+  state.cityCorridors = null; state.cityAiPts = null; state.gravelProfile = null;
+  state.sceneryExclusionZones = [];
+
+  const roadSegs = [];          // {x0,z0,x1,z1,hw} for on/off-road queries
+  const mapRoads = [];          // {pts:[[x,z]...], type} for the minimap
+
+  const matFor = {};
+  for(const [type, s] of Object.entries(ROAD_STYLES)){
+    matFor[type] = new THREE.MeshLambertMaterial({ color: s.col });
+  }
+  const matEdge = new THREE.MeshLambertMaterial({ color: 0xcfcfd4 });
+  const matDashW = new THREE.MeshLambertMaterial({ color: 0xd8d8d8 });
+  const matDashY = new THREE.MeshLambertMaterial({ color: 0xbfa133 });
+
+  function addRoad(pts, type, closed){
+    const s = ROAD_STYLES[type];
+    addStripMesh(pts, s.hw, s.y, matFor[type], closed);
+    const segCount = closed ? pts.length : pts.length - 1;
+    for(let i = 0; i < segCount; i++){
+      const a = pts[i], b = pts[(i + 1) % pts.length];
+      roadSegs.push({ x0: a.x, z0: a.z, x1: b.x, z1: b.z, hw: s.hw });
+    }
+    mapRoads.push({ pts: pts.map(p => [p.x, p.z]), type, closed: !!closed });
+    if(type === 'highway'){
+      addStripMesh(offsetPolyline(pts, -(s.hw - 0.7), closed), 0.22, s.y + 0.006, matEdge, closed);
+      addStripMesh(offsetPolyline(pts, s.hw - 0.7, closed), 0.22, s.y + 0.006, matEdge, closed);
+      addDashes(pts, s.y + 0.006, matDashY, closed);
+    } else if(type === 'country'){
+      addDashes(pts, s.y + 0.006, matDashW, closed);
+    }
+  }
+
+  // ── Ground: water, beach, grass, lake ──
+  const water = new THREE.Mesh(new THREE.PlaneGeometry(7000, 7000),
+    new THREE.MeshLambertMaterial({ color: 0x0d3550 }));
+  water.rotation.x = -Math.PI / 2; water.position.y = -0.45; water.userData.trk = true; scene.add(water);
+
+  const beach = new THREE.Mesh(new THREE.RingGeometry(ISLAND_R - 14, ISLAND_R + 95, 96),
+    new THREE.MeshLambertMaterial({ color: 0x8a7a55 }));
+  beach.rotation.x = -Math.PI / 2; beach.position.y = -0.16; beach.userData.trk = true; scene.add(beach);
+
+  const grass = new THREE.Mesh(new THREE.CircleGeometry(ISLAND_R, 96),
+    new THREE.MeshLambertMaterial({ color: 0x1a3018 }));
+  grass.rotation.x = -Math.PI / 2; grass.position.y = -0.08; grass.receiveShadow = true;
+  grass.userData.trk = true; scene.add(grass);
+
+  const lake = new THREE.Mesh(new THREE.CircleGeometry(LAKE_R, 48),
+    new THREE.MeshLambertMaterial({ color: 0x0e3d5c }));
+  lake.rotation.x = -Math.PI / 2; lake.position.y = -0.02; lake.userData.trk = true; scene.add(lake);
+  const lakeShore = new THREE.Mesh(new THREE.RingGeometry(LAKE_R - 2, LAKE_R + 16, 48),
+    new THREE.MeshLambertMaterial({ color: 0x86764f }));
+  lakeShore.rotation.x = -Math.PI / 2; lakeShore.position.y = -0.05; lakeShore.userData.trk = true; scene.add(lakeShore);
+
+  // ── City plazas + street grids ──
+  const plazaMat = new THREE.MeshLambertMaterial({ color: 0x15151c });
+  for(const c of FD_CITIES){
+    const plaza = new THREE.Mesh(
+      new THREE.PlaneGeometry(CITY_HALF_W * 2 + 50, CITY_HALF_D * 2 + 50), plazaMat);
+    plaza.rotation.x = -Math.PI / 2; plaza.position.set(c.x, 0.002, c.z);
+    plaza.receiveShadow = true; plaza.userData.trk = true; scene.add(plaza);
+
+    for(let i = -2; i <= 2; i++){       // vertical streets (along z)
+      addRoad([new THREE.Vector3(c.x + i * BLOCK, 0, c.z - CITY_HALF_D - 25),
+               new THREE.Vector3(c.x + i * BLOCK, 0, c.z + CITY_HALF_D + 25)], 'street', false);
+    }
+    for(let j = 0; j < 4; j++){          // horizontal streets (along x)
+      const z = c.z - CITY_HALF_D + j * BLOCK;
+      addRoad([new THREE.Vector3(c.x - CITY_HALF_W - 25, 0, z),
+               new THREE.Vector3(c.x + CITY_HALF_W + 25, 0, z)], 'street', false);
+    }
+  }
+
+  // ── Highways between the three cities (run right into downtown) ──
+  const bulges = [150, -130, 170];
+  for(let i = 0; i < 3; i++){
+    const a = FD_CITIES[i], b = FD_CITIES[(i + 1) % 3];
+    const dx = b.x - a.x, dz = b.z - a.z, l = Math.hypot(dx, dz) || 1;
+    const ux = dx / l, uz = dz / l;
+    const mx = (a.x + b.x) / 2, mz = (a.z + b.z) / 2;
+    // Bulge outward (away from the island centre) so highways arc around the lake
+    const ml = Math.hypot(mx, mz) || 1;
+    const bx = mx + (mx / ml) * bulges[i], bz = mz + (mz / ml) * bulges[i];
+    const ctrl = [
+      [a.x, a.z],
+      [a.x + ux * 300, a.z + uz * 300],
+      [bx, bz],
+      [b.x - ux * 300, b.z - uz * 300],
+      [b.x, b.z],
+    ];
+    addRoad(curvePoints(ctrl, false, 10), 'highway', false);
+  }
+
+  // ── Coastal country ring road (winding, mid size) ──
+  const ringCtrl = [];
+  for(let k = 0; k < 26; k++){
+    const th = (k / 26) * Math.PI * 2;
+    const r = 1000 + 70 * Math.sin(th * 3 + 1.7) + 45 * Math.sin(th * 5.3 + 0.6);
+    ringCtrl.push([Math.cos(th) * r, Math.sin(th) * r]);
+  }
+  const ringPts = curvePoints(ringCtrl, true, 12);
+  addRoad(ringPts, 'country', true);
+
+  // ── Narrow country lanes: each city out to the coastal ring ──
+  for(const c of FD_CITIES){
+    const cl = Math.hypot(c.x, c.z) || 1;
+    const ox = c.x / cl, oz = c.z / cl;           // outward direction
+    const px = -oz, pz = ox;                       // perpendicular, for wiggle
+    // find the ring point closest to the city's outward ray
+    let best = ringPts[0], bd = Infinity;
+    for(const p of ringPts){
+      const d = (p.x - ox * 1010) ** 2 + (p.z - oz * 1010) ** 2;
+      if(d < bd){ bd = d; best = p; }
+    }
+    const ctrl = [
+      [c.x, c.z],
+      [c.x + ox * 190 + px * 45, c.z + oz * 190 + pz * 45],
+      [c.x + ox * 300 - px * 65, c.z + oz * 300 - pz * 65],
+      [(c.x + best.x) / 2 + px * 50, (c.z + best.z) / 2 + pz * 50],
+      [best.x, best.z],
+    ];
+    addRoad(curvePoints(ctrl, false, 10), 'lane', false);
+  }
+
+  // Distance from a point to the nearest road edge (negative = on the road)
+  function roadEdgeDist(x, z){
+    let best = Infinity;
+    for(const s of roadSegs){
+      const abx = s.x1 - s.x0, abz = s.z1 - s.z0;
+      const ab2 = abx * abx + abz * abz || 1;
+      let t = ((x - s.x0) * abx + (z - s.z0) * abz) / ab2;
+      t = t < 0 ? 0 : t > 1 ? 1 : t;
+      const dx = x - (s.x0 + abx * t), dz = z - (s.z0 + abz * t);
+      const d = Math.sqrt(dx * dx + dz * dz) - s.hw;
+      if(d < best) best = d;
+    }
+    return best;
+  }
+
+  // ── City buildings ──
+  const bMats = [0x2a2a3a, 0x3a3a4a, 0x222238, 0x1c2433, 0x33283d, 0x262b40]
+    .map(c => new THREE.MeshLambertMaterial({ color: c }));
+  const roofMat = new THREE.MeshLambertMaterial({ color: 0x333344 });
+  for(const c of FD_CITIES){
+    for(let bi = -2; bi < 2; bi++){
+      for(let bj = 0; bj < 3; bj++){
+        const cx = c.x + (bi + 0.5) * BLOCK;
+        const cz = c.z - CITY_HALF_D + (bj + 0.5) * BLOCK;
+        if(roadEdgeDist(cx, cz) < 12) continue;     // highway cuts through this block
+        const count = 1 + (Math.random() < 0.5 ? 1 : 0);
+        for(let k = 0; k < count; k++){
+          const bw = 22 + Math.random() * 28, bd = 22 + Math.random() * 28;
+          const jx = cx + (Math.random() - 0.5) * (BLOCK - bw - 16);
+          const jz = cz + (Math.random() - 0.5) * (BLOCK - bd - 16);
+          const centerDist = Math.hypot(jx - c.x, jz - c.z);
+          const bh = 8 + 26 * Math.exp(-centerDist / 160) + Math.random() * 9;
+          const bld = new THREE.Mesh(new THREE.BoxGeometry(bw, bh, bd),
+            bMats[Math.floor(Math.random() * bMats.length)]);
+          bld.position.set(jx, bh / 2, jz); bld.castShadow = true;
+          bld.userData.trk = true; scene.add(bld);
+          const roof = new THREE.Mesh(new THREE.BoxGeometry(bw + 0.6, 0.4, bd + 0.6), roofMat);
+          roof.position.set(jx, bh + 0.2, jz); roof.userData.trk = true; scene.add(roof);
+        }
+      }
+    }
+    // Landmark tower with a coloured beacon — visible from across the island
+    const tx = c.x - 45, tz = c.z + 45;
+    const tower = new THREE.Mesh(new THREE.BoxGeometry(20, 78, 20),
+      new THREE.MeshLambertMaterial({ color: 0x1b1b2c }));
+    tower.position.set(tx, 39, tz); tower.castShadow = true; tower.userData.trk = true; scene.add(tower);
+    const beacon = new THREE.Mesh(new THREE.BoxGeometry(23, 5, 23),
+      new THREE.MeshLambertMaterial({ color: c.beacon, emissive: c.beacon, emissiveIntensity: 0.8 }));
+    beacon.position.set(tx, 80.5, tz); beacon.userData.trk = true; scene.add(beacon);
+  }
+
+  // ── Trees (instanced — cheap even at a few hundred) ──
+  const TREES = 300;
+  const trunkGeo = new THREE.CylinderGeometry(0.22, 0.34, 1.8, 5);
+  const coneGeo = new THREE.ConeGeometry(1.6, 3.8, 6);
+  const trunkMesh = new THREE.InstancedMesh(trunkGeo, new THREE.MeshLambertMaterial({ color: 0x4a2810 }), TREES);
+  const coneMesh = new THREE.InstancedMesh(coneGeo, new THREE.MeshLambertMaterial({ color: 0x1e4a1e }), TREES);
+  const m4 = new THREE.Matrix4(), q = new THREE.Quaternion(), sv = new THREE.Vector3(), pv = new THREE.Vector3();
+  let placedTrees = 0, attempts = 0;
+  while(placedTrees < TREES && attempts < TREES * 14){
+    attempts++;
+    const th = Math.random() * Math.PI * 2, r = Math.sqrt(Math.random()) * (ISLAND_R - 70);
+    const x = Math.cos(th) * r, z = Math.sin(th) * r;
+    if(r < LAKE_R + 40) continue;
+    if(FD_CITIES.some(c => Math.abs(x - c.x) < CITY_HALF_W + 40 && Math.abs(z - c.z) < CITY_HALF_D + 40)) continue;
+    if(roadEdgeDist(x, z) < 9) continue;
+    const s = 0.8 + Math.random() * 1.1;
+    q.setFromAxisAngle(new THREE.Vector3(0, 1, 0), Math.random() * Math.PI * 2);
+    sv.set(s, s, s);
+    pv.set(x, 0.9 * s, z); m4.compose(pv, q, sv); trunkMesh.setMatrixAt(placedTrees, m4);
+    pv.set(x, (1.8 + 1.7) * s, z); m4.compose(pv, q, sv); coneMesh.setMatrixAt(placedTrees, m4);
+    placedTrees++;
+  }
+  trunkMesh.count = placedTrees; coneMesh.count = placedTrees;
+  trunkMesh.instanceMatrix.needsUpdate = true; coneMesh.instanceMatrix.needsUpdate = true;
+  trunkMesh.userData.trk = true; coneMesh.userData.trk = true;
+  scene.add(trunkMesh); scene.add(coneMesh);
+
+  // ── Sky + fog ──
+  const sky = 0x16263e;
+  scene.background = new THREE.Color(sky);
+  scene.fog = new THREE.Fog(sky, 320, 980);
+
+  // ── Spawn points: one per city, on a central horizontal street ──
+  const spawnPoints = FD_CITIES.map(c => ({
+    x: c.x - 90, z: c.z - CITY_HALF_D + BLOCK, hdg: Math.PI / 2, city: c.name,
+  }));
+
+  fdWorld = { islandR: ISLAND_R, waterR: WATER_R, lakeR: LAKE_R, roadSegs, mapRoads, spawnPoints, cities: FD_CITIES, roadEdgeDist };
+  return fdWorld;
+}

--- a/games/turborace/scripts/freedrive.js
+++ b/games/turborace/scripts/freedrive.js
@@ -1,0 +1,412 @@
+'use strict';
+import { THREE } from './three.js';
+import { CARS } from './data/cars.js';
+import { state, scene, dc, keys, mmctx } from './state.js';
+import { Car, resolveCarCollisions } from './car.js';
+import { buildFreeDriveWorld, getFreeDriveWorld } from './freedrive-world.js';
+import { FreeDriveNetwork } from './freedrive-net.js';
+import { setupLights } from './lighting.js';
+import { updateCamera } from './camera.js';
+import { drawDash } from './hud.js';
+import { initAudio, startMusic, updateAudio } from './audio.js';
+import {
+  isTouchControlsVisibleInState, updateTouchControlsVisibility,
+  isTouchControlsEnabled, touchState, getGyroSteering, getTouchSliderSteer
+} from './touch-controls.js';
+import { buildCarChipRow, refreshCarChipColors, disposeCarCardPreviews } from './menu.js';
+import { clearGhostVisual } from './ghost.js';
+import { getArcadeUser } from './user.js';
+import { hexNumToCss, cssToHexNum } from './editor.js';
+import { notify } from './notify.js';
+
+// ═══════════════════════════════════════════════════════
+//  FREE DRIVE MODE
+//  Open-world island cruising — solo or together with
+//  everyone else on the shared island channel.
+// ═══════════════════════════════════════════════════════
+
+const FD_WORLD_ID = 'island-v1';
+
+// Remote drivers: id → {car, tagEl, name, snap, hasPos}
+let fdRemote = {};
+let _firstRosterSync = false;
+
+// ── Dead-reckoning blend factors (same model as VS mode) ──
+const _DR_BLEND_POS = 12, _DR_BLEND_HDG = 15, _DR_BLEND_SPD = 8, _DR_SNAP_DIST = 25;
+
+// ═══════════════════════════════════════════════════════
+//  MENU SCREEN
+// ═══════════════════════════════════════════════════════
+function _setFdStatus(msg){
+  const el = document.getElementById('fdStatusMsg');
+  if(el) el.textContent = msg;
+}
+
+function _syncFdColorPicker(){
+  const cp = document.getElementById('fdColor');
+  if(!cp) return;
+  const def = CARS[state.selCar ?? 0]?.hex || '#ffffff';
+  cp.value = state.carColor != null ? hexNumToCss(state.carColor) : def;
+}
+
+export function showFreeDriveMenu(){
+  document.querySelectorAll('.screen,#results').forEach(s => s.style.display = 'none');
+  document.getElementById('sFreeDrive').style.display = 'flex';
+  state.gState = 'fdMenu';
+  updateTouchControlsVisibility(state.gState);
+  if(state.selCar == null) state.selCar = 0;
+  buildCarChipRow('fdCarRow', () => { _syncFdColorPicker(); });
+  _syncFdColorPicker();
+  const tgl = document.getElementById('fdOnlineToggle');
+  if(tgl) tgl.checked = state.fdOnline;
+  const lbl = document.getElementById('fdMyNameLabel');
+  if(lbl) lbl.textContent = getArcadeUser().name || 'Anonymous';
+  _setFdStatus('');
+}
+
+export function onFdColorInput(css){
+  state.carColor = cssToHexNum(css);
+  refreshCarChipColors('fdCarRow');
+}
+
+// ═══════════════════════════════════════════════════════
+//  SESSION START / END
+// ═══════════════════════════════════════════════════════
+export async function startFreeDrive(){
+  disposeCarCardPreviews();
+  _teardownSession();
+  for(const ctrl of state.aiControllers) if(ctrl.destroy) ctrl.destroy();
+  for(const c of state.allCars) scene.remove(c.mesh);
+  state.allCars = []; state.aiCars = []; state.aiControllers = []; state.pCar = null;
+  clearGhostVisual();
+  document.querySelectorAll('.screen,#results').forEach(s => s.style.display = 'none');
+
+  const world = buildFreeDriveWorld();
+  setupLights();
+
+  const sp = world.spawnPoints[Math.floor(Math.random() * world.spawnPoints.length)];
+  const pos = new THREE.Vector3(sp.x + (Math.random() - 0.5) * 18, 0, sp.z + (Math.random() - 0.5) * 5);
+  const car = new Car(CARS[state.selCar ?? 0], pos, sp.hdg, true, scene, state.carColor);
+  state.pCar = car; state.allCars = [car];
+
+  state.fdMode = true; state.raceTime = 0; state.fdPosTimer = 0;
+  state.fdCleanup = _quitCleanup;
+
+  // HUD: speed + gear + island map — no laps, checkpoints or positions
+  document.getElementById('hud').style.display = 'block';
+  document.getElementById('raceTop').style.display = 'none';
+  document.getElementById('pos').style.display = 'none';
+  document.getElementById('speedBox').style.display = 'block';
+  document.getElementById('gearBox').style.display = 'block';
+  document.getElementById('camLabel').textContent = '[ C ] COCKPIT VIEW';
+  document.getElementById('hint').style.display = isTouchControlsEnabled() ? 'none' : 'block';
+  state.camMode = 'chase'; dc.style.display = 'none';
+  _buildStaticMinimap(world);
+
+  state.gState = 'freedrive';
+  updateTouchControlsVisibility(state.gState);
+  initAudio(); startMusic();
+  notify(`Free Drive — spawned in ${sp.city}. Explore the island!`);
+  _updateOnlineHudTag();
+
+  if(state.fdOnline) await _joinIsland();
+}
+
+// Respawn on the nearest city spawn point (pause-menu RESTART).
+export function fdRespawn(){
+  const world = getFreeDriveWorld();
+  const car = state.pCar;
+  if(!world || !car) return;
+  let best = world.spawnPoints[0], bd = Infinity;
+  for(const sp of world.spawnPoints){
+    const d = (car.pos.x - sp.x) ** 2 + (car.pos.z - sp.z) ** 2;
+    if(d < bd){ bd = d; best = sp; }
+  }
+  car.pos.set(best.x + (Math.random() - 0.5) * 18, car.groundY(), best.z);
+  car.hdg = best.hdg; car.spd = 0; car.revSpd = 0; car.isReversing = false;
+  car.mesh.position.copy(car.pos); car.mesh.rotation.y = car.hdg;
+  state.gState = 'freedrive';
+  updateTouchControlsVisibility(state.gState);
+  initAudio(); startMusic();
+  notify(`Respawned in ${best.city}.`);
+}
+
+// Tear down network + remote cars (keeps the local car — showMain removes it).
+function _teardownSession(){
+  if(state.fdNetwork){ state.fdNetwork.leave().catch(() => {}); state.fdNetwork = null; }
+  for(const id of Object.keys(fdRemote)) _removeRemote(id);
+  fdRemote = {};
+  _firstRosterSync = false;
+}
+
+// Registered as state.fdCleanup — called by showMain when leaving the mode.
+function _quitCleanup(){
+  _teardownSession();
+  state.fdMode = false; state.fdCleanup = null;
+  document.getElementById('raceTop').style.display = '';
+  document.getElementById('pos').style.display = '';
+  const tag = document.getElementById('fdOnlineTag');
+  if(tag) tag.style.display = 'none';
+}
+
+// ═══════════════════════════════════════════════════════
+//  NETWORK
+// ═══════════════════════════════════════════════════════
+async function _joinIsland(){
+  const user = getArcadeUser();
+  const net = new FreeDriveNetwork();
+  state.fdNetwork = net;
+  net.onRoster = _onRoster;
+  net.onPos = _onPos;
+  try {
+    await net.join(FD_WORLD_ID, user.name || 'Anonymous', state.selCar ?? 0, state.carColor);
+  } catch(e) {
+    if(state.fdNetwork === net) state.fdNetwork = null;
+    notify('Island online unavailable — driving solo. (' + e.message + ')');
+    _updateOnlineHudTag();
+    return;
+  }
+  // User may have quit to the menu while we were connecting
+  if(state.gState !== 'freedrive' && state.gState !== 'paused'){
+    net.leave().catch(() => {});
+    if(state.fdNetwork === net) state.fdNetwork = null;
+    return;
+  }
+  _updateOnlineHudTag();
+}
+
+function _onRoster(players){
+  if(!state.fdNetwork) return;
+  const myId = state.fdNetwork.myId;
+  const seen = new Set();
+  for(const p of players){
+    if(!p.id || p.id === myId) continue;
+    seen.add(p.id);
+    if(!fdRemote[p.id]){
+      _addRemote(p);
+      if(_firstRosterSync) notify(`${p.name || 'A driver'} joined the island`);
+    }
+  }
+  for(const id of Object.keys(fdRemote)){
+    if(!seen.has(id)){
+      notify(`${fdRemote[id].name} left the island`);
+      _removeRemote(id);
+    }
+  }
+  _firstRosterSync = true;
+  _updateOnlineHudTag();
+}
+
+function _addRemote(p){
+  const car = new Car(CARS[p.carIdx] || CARS[0], new THREE.Vector3(0, 0, 0), 0, false, scene, p.color ?? null);
+  car.mesh.visible = false;   // hidden until the first position packet arrives
+  const tagEl = document.createElement('div');
+  tagEl.style.cssText = 'display:none;position:fixed;pointer-events:none;z-index:60;transform:translate(-50%,-100%);background:rgba(5,5,20,.85);border:1px solid #4af;border-radius:4px;padding:2px 8px;color:#4af;font-family:Orbitron,monospace;font-size:.65rem;white-space:nowrap;';
+  tagEl.textContent = p.name || 'Driver';
+  document.body.appendChild(tagEl);
+  fdRemote[p.id] = { car, tagEl, name: p.name || 'Driver', snap: null, hasPos: false };
+}
+
+function _removeRemote(id){
+  const r = fdRemote[id];
+  if(!r) return;
+  scene.remove(r.car.mesh);
+  if(r.tagEl.parentNode) r.tagEl.parentNode.removeChild(r.tagEl);
+  delete fdRemote[id];
+}
+
+function _onPos(p){
+  const r = fdRemote[p.id];
+  if(!r) return;
+  r.snap = { x: p.x, z: p.z, hdg: p.hdg, spd: p.spd, rxT: performance.now() / 1000 };
+  if(!r.hasPos){
+    r.hasPos = true;
+    r.car.pos.x = p.x; r.car.pos.z = p.z; r.car.hdg = p.hdg; r.car.spd = p.spd;
+    r.car.mesh.visible = true;
+  }
+}
+
+function _updateOnlineHudTag(){
+  const el = document.getElementById('fdOnlineTag');
+  if(!el) return;
+  if(!state.fdMode){ el.style.display = 'none'; return; }
+  el.style.display = 'block';
+  if(state.fdNetwork){
+    const n = 1 + Object.keys(fdRemote).length;
+    el.textContent = `🏝 ISLAND ONLINE · ${n} DRIVER${n > 1 ? 'S' : ''}`;
+    el.style.color = '#4f9';
+  } else {
+    el.textContent = '🏝 ISLAND · SOLO DRIVE';
+    el.style.color = '#789';
+  }
+}
+
+function _broadcastPos(dt){
+  if(!state.fdNetwork || !state.pCar) return;
+  state.fdPosTimer -= dt;
+  if(state.fdPosTimer > 0) return;
+  state.fdPosTimer = 0.1;   // 10 Hz — dead-reckoning fills the gaps
+  const c = state.pCar;
+  state.fdNetwork.sendPos(
+    Math.round(c.pos.x * 100) / 100,
+    Math.round(c.pos.z * 100) / 100,
+    Math.round(c.hdg * 1000) / 1000,
+    Math.round((c.isReversing ? -c.revSpd : c.spd) * 10) / 10
+  );
+}
+
+function _updateRemoteCars(dt){
+  const now = performance.now() / 1000;
+  for(const r of Object.values(fdRemote)){
+    const car = r.car, snap = r.snap;
+    if(!snap || !r.hasPos) continue;
+
+    // Stale feed (tab hidden / paused on their end): coast to a stop
+    if(now - snap.rxT > 1.5) car.spd *= Math.max(0, 1 - 2 * dt);
+
+    car.pos.x += Math.sin(car.hdg) * car.spd * dt;
+    car.pos.z += Math.cos(car.hdg) * car.spd * dt;
+
+    const ex = snap.x - car.pos.x, ez = snap.z - car.pos.z;
+    const dist = Math.sqrt(ex * ex + ez * ez);
+    if(dist > _DR_SNAP_DIST){
+      car.pos.x = snap.x; car.pos.z = snap.z;
+      car.hdg = snap.hdg; car.spd = snap.spd;
+    } else {
+      const pb = Math.min(1, _DR_BLEND_POS * dt);
+      car.pos.x += ex * pb; car.pos.z += ez * pb;
+      let dh = snap.hdg - car.hdg;
+      if(dh > Math.PI) dh -= Math.PI * 2;
+      if(dh < -Math.PI) dh += Math.PI * 2;
+      car.hdg += dh * Math.min(1, _DR_BLEND_HDG * dt);
+      car.spd += (snap.spd - car.spd) * Math.min(1, _DR_BLEND_SPD * dt);
+    }
+    car.pos.y = car.groundY();
+    car.mesh.position.copy(car.pos);
+    car.mesh.rotation.y = car.hdg;
+  }
+}
+
+function _updateTags(){
+  for(const r of Object.values(fdRemote)){
+    if(!r.hasPos || !state.activeCam){ r.tagEl.style.display = 'none'; continue; }
+    const p = r.car.mesh.position.clone().add(new THREE.Vector3(0, 2.7, 0)).project(state.activeCam);
+    if(p.z > -1 && p.z < 1){
+      r.tagEl.style.display = 'block';
+      r.tagEl.style.left = `${(p.x * 0.5 + 0.5) * window.innerWidth}px`;
+      r.tagEl.style.top = `${(-p.y * 0.5 + 0.5) * window.innerHeight}px`;
+    } else r.tagEl.style.display = 'none';
+  }
+}
+
+// ═══════════════════════════════════════════════════════
+//  PER-FRAME UPDATE (called from the game loop)
+// ═══════════════════════════════════════════════════════
+export function updateFreeDrive(dt){
+  const world = getFreeDriveWorld();
+  const car = state.pCar;
+  if(!world || !car) return;
+  state.raceTime += dt;
+
+  const autoTouchThrottle = isTouchControlsVisibleInState(state.gState)
+    && ('ontouchstart' in window || navigator.maxTouchPoints > 0)
+    && !touchState.brake;
+  const thr = (keys['ArrowUp'] || keys['KeyW'] || touchState.throttle || autoTouchThrottle) ? 1 : 0;
+  const brk = (keys['ArrowDown'] || keys['KeyS'] || touchState.brake) ? 1 : 0;
+  const left = (keys['ArrowLeft'] || keys['KeyA'] || touchState.left);
+  const right = (keys['ArrowRight'] || keys['KeyD'] || touchState.right);
+  const keySteer = left && !right ? 1 : right && !left ? -1 : 0;
+  const gyroSteer = getGyroSteering();
+  const sliderSteer = getTouchSliderSteer();
+  const str = Math.abs(gyroSteer) > 0.01 ? gyroSteer : Math.abs(sliderSteer) > 0.01 ? sliderSteer : keySteer;
+
+  // Off the road network everything behaves like gravel (caps around 80 km/h).
+  // The Rally Storm is the off-road specialist: full steering and ~130 km/h on dirt.
+  const offroad = world.roadEdgeDist(car.pos.x, car.pos.z) > 1.5;
+  const isRally = car.data.id === 2;
+  car.onGravel = offroad && !isRally;
+  car.update({ thr, brk, str }, dt);
+  if(offroad && isRally && car.spd > 36) car.spd = Math.max(36, car.spd - 14 * dt);
+  _applyWorldBounds(car, world);
+
+  _updateRemoteCars(dt);
+  _broadcastPos(dt);
+  resolveCarCollisions([car, ...Object.values(fdRemote).filter(r => r.hasPos).map(r => r.car)]);
+
+  updateAudio(thr, brk, dt, car, keys);
+  updateCamera();
+  document.getElementById('speedNum').textContent = Math.round((car.isReversing ? car.revSpd : car.spd) * 3.6);
+  document.getElementById('gearNum').textContent = car.gear === 0 ? 'R' : car.gear;
+  drawDash();
+  _drawFdMinimap(world);
+  _updateTags();
+}
+
+function _applyWorldBounds(car, world){
+  const d = Math.hypot(car.pos.x, car.pos.z);
+  if(d > world.waterR){
+    const f = world.waterR / d;
+    car.pos.x *= f; car.pos.z *= f;
+    car.spd *= 0.8; if(car.isReversing) car.revSpd *= 0.7;
+  } else if(d < world.lakeR + 6 && d > 0.01){
+    const f = (world.lakeR + 6) / d;
+    car.pos.x *= f; car.pos.z *= f;
+    car.spd *= 0.8; if(car.isReversing) car.revSpd *= 0.7;
+  }
+  car.mesh.position.copy(car.pos);
+}
+
+// ═══════════════════════════════════════════════════════
+//  ISLAND MINIMAP
+// ═══════════════════════════════════════════════════════
+let _mapCanvas = null, _mapScale = 1;
+
+function _buildStaticMinimap(world){
+  const S = 150, half = S / 2;
+  _mapCanvas = document.createElement('canvas');
+  _mapCanvas.width = S; _mapCanvas.height = S;
+  _mapScale = half / (world.waterR + 60);
+  const ctx = _mapCanvas.getContext('2d');
+  const toM = (x, z) => [half + x * _mapScale, half + z * _mapScale];
+  ctx.fillStyle = 'rgba(4,10,24,.85)'; ctx.fillRect(0, 0, S, S);
+  ctx.beginPath(); ctx.arc(half, half, (world.islandR + 95) * _mapScale, 0, Math.PI * 2);
+  ctx.fillStyle = '#54492f'; ctx.fill();
+  ctx.beginPath(); ctx.arc(half, half, world.islandR * _mapScale, 0, Math.PI * 2);
+  ctx.fillStyle = '#15301b'; ctx.fill();
+  ctx.beginPath(); ctx.arc(half, half, world.lakeR * _mapScale, 0, Math.PI * 2);
+  ctx.fillStyle = '#10334d'; ctx.fill();
+  const styles = { highway: ['#ffb347', 2.4], country: ['#7ddb8a', 1.6], lane: ['#55996b', 1.0], street: ['#4a8cff', 1.0] };
+  for(const r of world.mapRoads){
+    const [col, w] = styles[r.type] || ['#888', 1];
+    ctx.strokeStyle = col; ctx.lineWidth = w; ctx.beginPath();
+    r.pts.forEach(([x, z], i) => { const [mx, mz] = toM(x, z); i ? ctx.lineTo(mx, mz) : ctx.moveTo(mx, mz); });
+    if(r.closed) ctx.closePath();
+    ctx.stroke();
+  }
+  for(const c of world.cities){
+    const [mx, mz] = toM(c.x, c.z);
+    ctx.fillStyle = '#' + c.beacon.toString(16).padStart(6, '0');
+    ctx.beginPath(); ctx.arc(mx, mz, 2.6, 0, Math.PI * 2); ctx.fill();
+  }
+}
+
+function _drawFdMinimap(){
+  if(!_mapCanvas || !state.pCar) return;
+  const ctx = mmctx, S = 150, half = S / 2;
+  ctx.clearRect(0, 0, S, S);
+  ctx.drawImage(_mapCanvas, 0, 0);
+  for(const r of Object.values(fdRemote)){
+    if(!r.hasPos) continue;
+    ctx.beginPath();
+    ctx.arc(half + r.car.pos.x * _mapScale, half + r.car.pos.z * _mapScale, 3, 0, Math.PI * 2);
+    ctx.fillStyle = '#44aaff'; ctx.fill();
+  }
+  const px = half + state.pCar.pos.x * _mapScale, pz = half + state.pCar.pos.z * _mapScale;
+  const hdg = state.pCar.hdg;
+  ctx.beginPath(); ctx.arc(px, pz, 4, 0, Math.PI * 2);
+  ctx.fillStyle = '#ffd700'; ctx.fill();
+  ctx.strokeStyle = '#fff'; ctx.lineWidth = 1.2; ctx.stroke();
+  ctx.beginPath(); ctx.moveTo(px, pz);
+  ctx.lineTo(px + Math.sin(hdg) * 8, pz + Math.cos(hdg) * 8);
+  ctx.stroke();
+}

--- a/games/turborace/scripts/game.js
+++ b/games/turborace/scripts/game.js
@@ -57,6 +57,7 @@ import {
 } from './leaderboard.js';
 import { resetEditorCameraToTrack as camResetEditorCam } from './camera.js';
 import { loadArcadeUser } from './user.js';
+import { showFreeDriveMenu, startFreeDrive, onFdColorInput, updateFreeDrive } from './freedrive.js';
 
 'use strict';
 
@@ -65,24 +66,24 @@ import { loadArcadeUser } from './user.js';
 // ═══════════════════════════════════════════════════════
 document.addEventListener('keydown',e=>{
   keys[e.code]=true;
-  if(e.code==='KeyC'&&(state.gState==='racing'||state.gState==='cooldown'))toggleCam();
+  if(e.code==='KeyC'&&(state.gState==='racing'||state.gState==='cooldown'||state.gState==='freedrive'))toggleCam();
   if(e.code==='Escape'){
     const leaderboardModal=document.getElementById('leaderboardModal');
     if(leaderboardModal&&leaderboardModal.style.display==='flex'){ closeTrackLeaderboardModal(); return; }
-    if(state.gState==='racing'||state.gState==='cooldown')pauseRace();
+    if(state.gState==='racing'||state.gState==='cooldown'||state.gState==='freedrive')pauseRace();
     else if(state.gState==='paused')resumeRace();
   }
 });
 document.addEventListener('keyup',e=>{ keys[e.code]=false; });
 document.addEventListener('pointermove',e=>{
-  if((state.gState==='racing'||state.gState==='cooldown'||state.gState==='finished'||state.gState==='countdown')&&e.buttons===2){
+  if((state.gState==='racing'||state.gState==='cooldown'||state.gState==='finished'||state.gState==='countdown'||state.gState==='freedrive')&&e.buttons===2){
     raceCamOrbit.yaw-=e.movementX*0.004;
     raceCamOrbit.pitch=Math.max(-0.55,Math.min(0.75,raceCamOrbit.pitch-e.movementY*0.003));
     raceCamOrbit.lastInput=performance.now();
   }
 });
 document.addEventListener('wheel',e=>{
-  if(state.gState==='racing'||state.gState==='cooldown'||state.gState==='countdown'||state.gState==='finished'){
+  if(state.gState==='racing'||state.gState==='cooldown'||state.gState==='countdown'||state.gState==='finished'||state.gState==='freedrive'){
     raceCamOrbit.distance=Math.max(4,Math.min(40,raceCamOrbit.distance*(1+Math.sign(e.deltaY)*0.08)));
   }
 },{passive:true});
@@ -235,6 +236,8 @@ function updateFrame(dt){
     updateAudio(0,0,dt,state.pCar,keys); updateCamera();
     updateGhostReplay();
     if(document.getElementById('results').style.display==='flex') updateResultsUI();
+  }else if(state.gState==='freedrive'){
+    updateFreeDrive(dt);
   }else if(state.gState==='editorPreview'){
     updateEditorPreviewCamera(dt);
   }else if(state.gState==='editor'){
@@ -275,6 +278,11 @@ document.getElementById('settingsCloseBtn').addEventListener('click',closeSettin
 document.getElementById('introStartBtn').addEventListener('click',function(){tryStartMenuMusic();showMain();});
 document.getElementById('gameStartBtn').addEventListener('click',function(){tryStartMenuMusic();showTrkSel();});
 document.getElementById('vsModeBtn').addEventListener('click',function(){tryStartMenuMusic();showVsLobby();});
+document.getElementById('freeDriveBtn').addEventListener('click',function(){tryStartMenuMusic();showFreeDriveMenu();});
+document.getElementById('fdBackBtn').addEventListener('click',showMain);
+document.getElementById('fdStartBtn').addEventListener('click',function(){tryStartMenuMusic();void startFreeDrive();});
+document.getElementById('fdColor').addEventListener('input',e=>onFdColorInput(e.target.value));
+document.getElementById('fdOnlineToggle').addEventListener('change',e=>{ state.fdOnline=e.target.checked; });
 document.getElementById('trackEditorBtn').addEventListener('click',function(){tryStartMenuMusic();showTrackEditor();});
 document.getElementById('mainSettingsBtn').addEventListener('click',function(){tryStartMenuMusic();showSettings();});
 document.getElementById('backToSelectionBtn').addEventListener('click',()=>{ window.location.href='../index.html'; });

--- a/games/turborace/scripts/menu.js
+++ b/games/turborace/scripts/menu.js
@@ -67,6 +67,7 @@ export function showMain(){
   state.allCars=[]; state.aiCars=[]; state.pCar=null;
   state.vsMode=false;
   if(state.vsNetwork){ state.vsNetwork.leave().catch(()=>{}); state.vsNetwork=null; }
+  if(state.fdCleanup) state.fdCleanup();
 }
 
 // ═══════════════════════════════════════════════════════
@@ -93,7 +94,7 @@ function ensureCarCardPreviewRenderer(){
 }
 
 function renderCarCardPreviews(ts){
-  if((state.gState!=='carSel'&&state.gState!=='vsLobby')||!state.carCardPreviews.length){ state.carCardPreviewRaf=0; return; }
+  if((state.gState!=='carSel'&&state.gState!=='vsLobby'&&state.gState!=='fdMenu')||!state.carCardPreviews.length){ state.carCardPreviewRaf=0; return; }
   const now=ts||performance.now();
   const dt=Math.min(0.05,Math.max(0.001,(now-state.carCardPreviewLastTime||16)/1000));
   state.carCardPreviewLastTime=now;
@@ -543,9 +544,9 @@ export async function vsLoadOnlineTracks() {
   if (btn) { btn.disabled = false; btn.textContent = '✓ ONLINE TRACKS LOADED'; }
 }
 
-// ── Inline car selector ───────────────────────────────────────────────────────
+// ── Inline car selector (shared by VS lobby and Free Drive) ──────────────────
 
-function _buildVsCarRow(containerId, onSelect) {
+export function buildCarChipRow(containerId, onSelect) {
   const container = document.getElementById(containerId);
   if (!container) return;
 
@@ -586,18 +587,18 @@ function _buildVsCarRow(containerId, onSelect) {
       container.querySelectorAll('.vsCarChip').forEach(x => x.classList.remove('sel'));
       d.classList.add('sel'); state.selCar = i;
       state.carCardPreviews.forEach(item => { item.selected = item.host === d; });
-      _refreshVsCarColors(containerId);
+      refreshCarChipColors(containerId);
       startCarCardPreviews();
       onSelect(i);
     };
     container.appendChild(d);
   });
-  _refreshVsCarColors(containerId);
+  refreshCarChipColors(containerId);
   startCarCardPreviews();
 }
 
-// VS car chips: selected chip shows the chosen colour, others stay default.
-function _refreshVsCarColors(containerId) {
+// Car chips: selected chip shows the chosen colour, others stay default.
+export function refreshCarChipColors(containerId) {
   state.carCardPreviews.filter(p => p._vsContainer === containerId).forEach(p => {
     _recolorPreviewModel(p, (p.selected && state.carColor != null) ? state.carColor : null);
   });
@@ -609,10 +610,10 @@ export function onVsColorInput(css) {
   if (state.vsIsHost) {
     const me = _vsRoster.find(e => e.id === state.vsNetwork?.myId);
     if (me) { me.color = state.carColor; _hostSyncRoster(); }
-    _refreshVsCarColors('vsHostCarRow');
+    refreshCarChipColors('vsHostCarRow');
   } else {
     state.vsNetwork?.sendGuestReady(state.selCar ?? 0, state.carColor);
-    _refreshVsCarColors('vsGuestCarRow');
+    refreshCarChipColors('vsGuestCarRow');
   }
   startCarCardPreviews();
 }
@@ -647,12 +648,12 @@ function _showVsRoomPanel(isHost) {
       onlineBtn.textContent = _vsShowOnline ? '✓ ONLINE TRACKS LOADED' : 'LOAD ONLINE TRACKS';
     }
     _buildVsTrkCards();
-    _buildVsCarRow('vsHostCarRow', carIdx => {
+    buildCarChipRow('vsHostCarRow', carIdx => {
       const me = _vsRoster.find(e => e.id === state.vsNetwork?.myId);
       if (me) { me.carIdx = carIdx; me.color = state.carColor; _hostSyncRoster(); }
     });
   } else {
-    _buildVsCarRow('vsGuestCarRow', carIdx => {
+    buildCarChipRow('vsGuestCarRow', carIdx => {
       state.vsNetwork?.sendGuestReady(carIdx, state.carColor);
     });
   }

--- a/games/turborace/scripts/race.js
+++ b/games/turborace/scripts/race.js
@@ -213,7 +213,7 @@ export function pauseRace(){
 }
 
 export function resumeRace(){
-  state.gState=_prePauseState==='cooldown'?'cooldown':'racing';
+  state.gState=_prePauseState==='cooldown'?'cooldown':_prePauseState==='freedrive'?'freedrive':'racing';
   document.getElementById('pauseMenu').style.display='none';
   document.getElementById('settingsModal').style.display='none';
   updateTouchControlsVisibility(state.gState);
@@ -331,6 +331,11 @@ export function restartRace(){
   document.getElementById('settingsModal').style.display='none';
   releaseAllTouchControls();
   document.getElementById('results').style.display='none';
+  if(state.fdMode){
+    // Free Drive: "restart" = respawn at the nearest city
+    import('./freedrive.js').then(m=>m.fdRespawn());
+    return;
+  }
   if(state.vsMode){
     // Return everyone to the VS lobby so they can pick a new track/car
     import('./menu.js').then(m=>m.vsReturnToLobby());

--- a/games/turborace/scripts/state.js
+++ b/games/turborace/scripts/state.js
@@ -86,4 +86,11 @@ export const state = {
     // Broadcast throttle
     vsPosSendTimer: 0,
     vsPosSendInterval: 0.033, // 30 Hz
+
+    // ── Free Drive (open-world island) ──────────────────────────────────────
+    fdMode: false,           // true while free-driving on the island
+    fdOnline: true,          // menu toggle: share the island with other players
+    fdNetwork: null,         // FreeDriveNetwork instance (null = solo)
+    fdPosTimer: 0,           // broadcast throttle
+    fdCleanup: null,         // set by freedrive.js; called by showMain on exit
 };

--- a/games/turborace/scripts/touch-controls.js
+++ b/games/turborace/scripts/touch-controls.js
@@ -167,7 +167,7 @@ export function getGyroVisualSteer(){
 export function isTouchControlsEnabled(){ return touchControlsEnabled; }
 
 export function isTouchControlsVisibleInState(state){
-  return touchControlsEnabled&&(state==='racing'||state==='cooldown');
+  return touchControlsEnabled&&(state==='racing'||state==='cooldown'||state==='freedrive');
 }
 
 export function updateTouchControlsVisibility(gState){

--- a/games/turborace/scripts/version.js
+++ b/games/turborace/scripts/version.js
@@ -1,1 +1,1 @@
-export const TURBORACE_VERSION = 'v0.131';
+export const TURBORACE_VERSION = 'v0.132';


### PR DESCRIPTION
## Summary
- New Free Drive game mode with open-world island exploration (Aurora Heights, Neon Bay, Solace Springs)
- Drop-in multiplayer via Supabase presence channel with 10 Hz position broadcasts and dead-reckoning smoothing
- Island features three city tiers with street grids, landmarks, varied road sizes, lake, beaches, and instanced trees
- Off-tarmac gravel physics with Rally Storm exception for higher dirt top speed
- Full mode integration: shared car picker, online toggle, island minimap, speed/gear HUD, pause/restart functionality
- Touch controls, gyro and camera orbit support

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxXEuqL2vx7PeL5JCVwCLi)_