### PR TITLE
Add CURE tool, CITY spawner, and road scenery generator to drive map editor

### DIFF
--- a/games/drive-map-editor/editor.js
+++ b/games/drive-map-editor/editor.js
@@ -2,15 +2,12 @@
 
 // ════════════════════════════════════════════════════════════════
 //  DRIVE MAP EDITOR
-//  Node-based road network editor. Nodes are junctions/dead-ends;
-//  roads connect pairs of nodes and each carries its own width,
-//  type, and optional bezier control points.
 // ════════════════════════════════════════════════════════════════
 
 const STORAGE_KEY = 'drive_maps_v1';
-const HIT_NODE    = 14;   // px — pointer hit radius for nodes
-const HIT_ASSET   = 12;   // px
-const NODE_R      = 8;    // display radius (base)
+const HIT_NODE    = 14;
+const HIT_ASSET   = 12;
+const NODE_R      = 8;
 
 const ROAD_TYPES = {
   highway: { col: '#28283a', dash: '#48485a', label: 'Highway', defW: 22 },
@@ -46,6 +43,12 @@ let wptDrag = null;    // { roadId, ptIdx } — bezier handle drag
 
 // Brush settings
 let brushType = 'tree', brushCount = 1, brushSpacing = 20;
+
+// City spawner settings
+let citySize = 3, cityBlockSize = 80, cityRoadType = 'street';
+
+// Road scenery settings
+let sceneryDensity = 3, sceneryOffset = 8, sceneryMix = 'mixed';
 
 // Snap
 let snapSize = 0;
@@ -110,7 +113,6 @@ function drawGrid() {
     const [, sy] = w2s(0, wz);
     ctx.beginPath(); ctx.moveTo(0, sy); ctx.lineTo(canvas.width, sy); ctx.stroke();
   }
-  // Origin cross
   const [ox, oy] = w2s(0, 0);
   ctx.strokeStyle = 'rgba(255,255,255,.08)';
   ctx.lineWidth = 1;
@@ -127,12 +129,10 @@ function drawRoadPath(pts) {
     const [x1, y1] = w2s(pts[1].x, pts[1].z);
     ctx.lineTo(x1, y1);
   } else if (pts.length === 3) {
-    // Single control point → quadratic bezier
     const [cx, cy] = w2s(pts[1].x, pts[1].z);
     const [x2, y2] = w2s(pts[2].x, pts[2].z);
     ctx.quadraticCurveTo(cx, cy, x2, y2);
   } else {
-    // Multiple waypoints → polyline (Catmull-Rom could replace this)
     for (let i = 1; i < pts.length; i++) {
       const [xi, yi] = w2s(pts[i].x, pts[i].z);
       ctx.lineTo(xi, yi);
@@ -149,7 +149,6 @@ function drawRoads() {
     const isSel  = road.id === selRoad;
     const isHov  = road.id === hoverRoad && !isSel;
 
-    // Selection / hover glow
     if (isSel || isHov) {
       ctx.save();
       ctx.strokeStyle = isSel ? 'rgba(255,85,0,.5)' : 'rgba(255,215,0,.35)';
@@ -159,13 +158,11 @@ function drawRoads() {
       ctx.restore();
     }
 
-    // Road surface
     ctx.strokeStyle = rStyle.col;
     ctx.lineWidth   = rw;
     ctx.lineCap = ctx.lineJoin = 'round';
     drawRoadPath(pts); ctx.stroke();
 
-    // Center line (only when large enough to see)
     if (rw > 12) {
       ctx.strokeStyle = rStyle.dash;
       ctx.lineWidth   = Math.max(1, rw * 0.07);
@@ -174,20 +171,17 @@ function drawRoads() {
       ctx.setLineDash([]);
     }
 
-    // Waypoint handles on selected road
     if (isSel) drawWaypointHandles(road, pts);
   }
 }
 
 function drawWaypointHandles(road, pts) {
-  // Existing waypoint handles
   for (let i = 1; i < pts.length - 1; i++) {
     const [sx, sy] = w2s(pts[i].x, pts[i].z);
     ctx.beginPath(); ctx.arc(sx, sy, 6, 0, Math.PI * 2);
     ctx.fillStyle = '#ffd700'; ctx.fill();
     ctx.strokeStyle = '#050a14'; ctx.lineWidth = 1.5; ctx.stroke();
   }
-  // Mid-point handle when no waypoints (invites the user to curve the road)
   if (road.waypoints.length === 0 && pts.length === 2) {
     const mx = (pts[0].x + pts[1].x) / 2, mz = (pts[0].z + pts[1].z) / 2;
     const [sx, sy] = w2s(mx, mz);
@@ -206,24 +200,32 @@ function drawNodes() {
     const [sx, sy] = w2s(node.x, node.z);
     const r = NODE_R + (conns > 2 ? 2 : 0);
 
-    // Glow ring
     if (isSel || isHov || isConn) {
       ctx.beginPath(); ctx.arc(sx, sy, r + 6, 0, Math.PI * 2);
       ctx.fillStyle = isConn ? 'rgba(255,85,0,.3)' : isSel ? 'rgba(255,215,0,.28)' : 'rgba(100,200,255,.2)';
       ctx.fill();
     }
 
+    // Cure tool: highlight orphans with a pulsing ring
+    if (tool === 'cure' && conns === 0) {
+      ctx.beginPath(); ctx.arc(sx, sy, r + 9, 0, Math.PI * 2);
+      ctx.strokeStyle = 'rgba(255,80,80,.55)';
+      ctx.lineWidth = 2;
+      ctx.setLineDash([3, 3]);
+      ctx.stroke();
+      ctx.setLineDash([]);
+    }
+
     ctx.beginPath(); ctx.arc(sx, sy, r, 0, Math.PI * 2);
     ctx.fillStyle = isConn ? '#ff5500' :
                     isSel   ? '#ffd700' :
                     isHov   ? '#9de'    :
-                    conns === 0 ? '#f55' :  // orphan
-                    conns === 1 ? '#4af' :  // dead end
-                                 '#7df';   // intersection
+                    conns === 0 ? '#f55' :
+                    conns === 1 ? '#4af' :
+                                 '#7df';
     ctx.fill();
     ctx.strokeStyle = '#050a14'; ctx.lineWidth = 2; ctx.stroke();
 
-    // Connection count label for multi-way intersections
     if (conns >= 3 && zoom > 1.1) {
       ctx.fillStyle = '#050a14';
       ctx.font = 'bold 8px Orbitron,monospace';
@@ -258,6 +260,9 @@ function drawAssets() {
 }
 
 function drawOverlay() {
+  // City grid preview
+  if (tool === 'city' && map) drawCityPreview(snp(mouseWX), snp(mouseWZ));
+
   // Dashed preview line when drawing a road
   if (tool === 'road' && connectFrom >= 0) {
     const from = getNode(connectFrom);
@@ -274,11 +279,37 @@ function drawOverlay() {
     }
   }
   // Snap cursor indicator
-  if (snapSize > 0 && (tool === 'node' || (tool === 'road' && connectFrom < 0))) {
+  if (snapSize > 0 && (tool === 'node' || (tool === 'road' && connectFrom < 0) || tool === 'city')) {
     const [sx, sy] = w2s(snp(mouseWX), snp(mouseWZ));
     ctx.beginPath(); ctx.arc(sx, sy, 5, 0, Math.PI * 2);
     ctx.strokeStyle = 'rgba(255,255,100,.5)'; ctx.lineWidth = 1.5; ctx.stroke();
   }
+}
+
+function drawCityPreview(wx, wz) {
+  const blocks = citySize;
+  const bs     = cityBlockSize;
+  const half   = blocks / 2;
+  ctx.save();
+  ctx.strokeStyle = 'rgba(100,200,255,.3)';
+  ctx.lineWidth   = Math.max(1.5, bs * zoom * 0.05);
+  ctx.lineCap = ctx.lineJoin = 'round';
+  ctx.setLineDash([6, 6]);
+  for (let r = 0; r <= blocks; r++) {
+    const [x0, y0] = w2s(wx - half * bs,             wz + (r - half) * bs);
+    const [x1, y1] = w2s(wx + (blocks - half) * bs,  wz + (r - half) * bs);
+    ctx.beginPath(); ctx.moveTo(x0, y0); ctx.lineTo(x1, y1); ctx.stroke();
+  }
+  for (let c = 0; c <= blocks; c++) {
+    const [x0, y0] = w2s(wx + (c - half) * bs, wz - half * bs);
+    const [x1, y1] = w2s(wx + (c - half) * bs, wz + (blocks - half) * bs);
+    ctx.beginPath(); ctx.moveTo(x0, y0); ctx.lineTo(x1, y1); ctx.stroke();
+  }
+  ctx.setLineDash([]);
+  const [cx, cy] = w2s(wx, wz);
+  ctx.beginPath(); ctx.arc(cx, cy, 5, 0, Math.PI * 2);
+  ctx.fillStyle = 'rgba(100,200,255,.5)'; ctx.fill();
+  ctx.restore();
 }
 
 // ── Hit testing ────────────────────────────────────────────────
@@ -318,12 +349,10 @@ function hitWaypointHandle(sx, sy) {
   if (!road) return null;
   const pts = roadPts(road);
   if (!pts || pts.length < 2) return null;
-  // Existing waypoint handles
   for (let i = 1; i < pts.length - 1; i++) {
     const [hx, hy] = w2s(pts[i].x, pts[i].z);
     if (Math.hypot(sx - hx, sy - hy) < 12) return { roadId: road.id, ptIdx: i - 1 };
   }
-  // Mid-point create-handle when no waypoints
   if (road.waypoints.length === 0 && pts.length === 2) {
     const mx = (pts[0].x + pts[1].x) / 2, mz = (pts[0].z + pts[1].z) / 2;
     const [hx, hy] = w2s(mx, mz);
@@ -361,7 +390,6 @@ canvas.addEventListener('pointerdown', e => {
   if (!map) return;
 
   if (tool === 'select') {
-    // Bezier handle has highest priority
     const wph = hitWaypointHandle(sx, sy);
     if (wph) { wptDrag = wph; return; }
 
@@ -398,7 +426,6 @@ canvas.addEventListener('pointerdown', e => {
         finishRoad(connectFrom, nHit);
         connectFrom = -1;
       } else if (nHit < 0) {
-        // Place a new node and immediately connect
         const newId = nextNid;
         addNode(snp(wx), snp(wz));
         finishRoad(connectFrom, newId);
@@ -419,6 +446,12 @@ canvas.addEventListener('pointerdown', e => {
   } else if (tool === 'brush') {
     paintAssets(wx, wz);
     drag = { kind: 'brush' };
+
+  } else if (tool === 'cure') {
+    cureElement(sx, sy);
+
+  } else if (tool === 'city') {
+    spawnCity(snp(wx), snp(wz));
   }
 });
 
@@ -460,7 +493,7 @@ canvas.addEventListener('pointermove', e => {
   }
 
   // Hover updates
-  if (tool !== 'brush') {
+  if (tool !== 'brush' && tool !== 'city') {
     hoverNode  = hitNode(sx, sy);
     hoverAsset = hoverNode < 0 ? hitAsset(sx, sy) : -1;
     hoverRoad  = hoverNode < 0 && hoverAsset < 0 ? hitRoad(sx, sy) : -1;
@@ -636,6 +669,202 @@ function paintAssets(wx, wz) {
   }
 }
 
+// ── Cure tool ──────────────────────────────────────────────────
+function cureElement(sx, sy) {
+  const nHit = hitNode(sx, sy);
+  if (nHit >= 0) {
+    const conns = roadConnections(nHit);
+    if (conns === 0) {
+      deleteNode(nHit);
+      notify('ORPHAN REMOVED');
+    } else {
+      notify('NODE HAS ' + conns + ' CONNECTION(S)');
+    }
+    return;
+  }
+  const rHit = hitRoad(sx, sy);
+  if (rHit >= 0) {
+    cureRoad(rHit);
+  }
+}
+
+function cureRoad(roadId) {
+  const road = getRoad(roadId);
+  if (!road) return;
+  const a = getNode(road.nodeA), b = getNode(road.nodeB);
+  if (!a || !b) return;
+  if (road.waypoints.length > 0) {
+    road.waypoints = [];
+    notify('ROAD STRAIGHTENED');
+    return;
+  }
+  const mx = (a.x + b.x) / 2, mz = (a.z + b.z) / 2;
+  const dx = b.x - a.x, dz = b.z - a.z;
+  const len = Math.hypot(dx, dz);
+  if (len < 1) return;
+  // Alternate curve side based on road id for variety
+  const side   = ((road.id % 2) === 0) ? 1 : -1;
+  const offset = len * 0.18 * side;
+  road.waypoints = [{ x: mx + (-dz / len) * offset, z: mz + (dx / len) * offset }];
+  notify('ROAD CURVED');
+}
+
+function cureAllOrphans() {
+  if (!map) return;
+  const orphans = map.nodes.filter(n => roadConnections(n.id) === 0);
+  if (orphans.length === 0) { notify('NO ORPHANS FOUND'); return; }
+  orphans.forEach(n => deleteNode(n.id));
+  if (selNode >= 0 && !getNode(selNode)) { selNode = -1; syncSelectedUI(); }
+  notify('REMOVED ' + orphans.length + ' ORPHAN(S)');
+}
+
+function straightenAllRoads() {
+  if (!map) return;
+  let count = 0;
+  map.roads.forEach(r => { if (r.waypoints.length > 0) { r.waypoints = []; count++; } });
+  notify(count > 0 ? 'STRAIGHTENED ' + count + ' ROAD(S)' : 'ROADS ALREADY STRAIGHT');
+}
+
+// ── City spawner ───────────────────────────────────────────────
+function spawnCity(wx, wz) {
+  if (!map) return;
+  const blocks = citySize;
+  const bs     = cityBlockSize;
+  const half   = blocks / 2;
+  const rw     = ROAD_TYPES[cityRoadType]?.defW || 12;
+
+  // Build node grid
+  const grid = [];
+  for (let r = 0; r <= blocks; r++) {
+    grid[r] = [];
+    for (let c = 0; c <= blocks; c++) {
+      const node = { id: nextNid++, x: wx + (c - half) * bs, z: wz + (r - half) * bs };
+      map.nodes.push(node);
+      grid[r][c] = node.id;
+    }
+  }
+
+  // Horizontal roads
+  for (let r = 0; r <= blocks; r++) {
+    for (let c = 0; c < blocks; c++) {
+      map.roads.push({ id: nextRid++, nodeA: grid[r][c], nodeB: grid[r][c + 1],
+        width: rw, type: cityRoadType, waypoints: [] });
+    }
+  }
+  // Vertical roads
+  for (let r = 0; r < blocks; r++) {
+    for (let c = 0; c <= blocks; c++) {
+      map.roads.push({ id: nextRid++, nodeA: grid[r][c], nodeB: grid[r + 1][c],
+        width: rw, type: cityRoadType, waypoints: [] });
+    }
+  }
+
+  notify('CITY SPAWNED (' + blocks + '\xd7' + blocks + ')');
+}
+
+// ── Road scenery generation ────────────────────────────────────
+function bezierSample(pts, t) {
+  if (pts.length === 2) {
+    return { x: pts[0].x + (pts[1].x - pts[0].x) * t,
+             z: pts[0].z + (pts[1].z - pts[0].z) * t };
+  }
+  if (pts.length === 3) {
+    const u = 1 - t;
+    return { x: u*u*pts[0].x + 2*u*t*pts[1].x + t*t*pts[2].x,
+             z: u*u*pts[0].z + 2*u*t*pts[1].z + t*t*pts[2].z };
+  }
+  // Polyline fallback
+  let total = 0;
+  for (let i = 1; i < pts.length; i++)
+    total += Math.hypot(pts[i].x - pts[i-1].x, pts[i].z - pts[i-1].z);
+  const target = t * total;
+  let accum = 0;
+  for (let i = 1; i < pts.length; i++) {
+    const seg = Math.hypot(pts[i].x - pts[i-1].x, pts[i].z - pts[i-1].z);
+    if (accum + seg >= target || i === pts.length - 1) {
+      const st = seg > 0 ? Math.min(1, (target - accum) / seg) : 0;
+      return { x: pts[i-1].x + (pts[i].x - pts[i-1].x) * st,
+               z: pts[i-1].z + (pts[i].z - pts[i-1].z) * st };
+    }
+    accum += seg;
+  }
+  return pts[pts.length - 1];
+}
+
+function bezierTangent(pts, t) {
+  const eps = 0.001;
+  const a = bezierSample(pts, Math.max(0, t - eps));
+  const b = bezierSample(pts, Math.min(1, t + eps));
+  const dx = b.x - a.x, dz = b.z - a.z;
+  const len = Math.hypot(dx, dz) || 1;
+  return { x: dx / len, z: dz / len };
+}
+
+function roadApproxLength(road) {
+  const pts = roadPts(road);
+  if (!pts || pts.length < 2) return 0;
+  if (pts.length === 2) return Math.hypot(pts[1].x - pts[0].x, pts[1].z - pts[0].z);
+  let len = 0;
+  const steps = 20;
+  for (let i = 0; i < steps; i++) {
+    const a = bezierSample(pts, i / steps);
+    const b = bezierSample(pts, (i + 1) / steps);
+    len += Math.hypot(b.x - a.x, b.z - a.z);
+  }
+  return len;
+}
+
+function getSceneryPalette(mix) {
+  switch (mix) {
+    case 'trees':  return ['tree', 'tree', 'tree', 'tree'];
+    case 'dense':  return ['tree', 'tree', 'building', 'park', 'stand', 'tree'];
+    default:       return ['tree', 'tree', 'tree', 'building', 'tree'];
+  }
+}
+
+function generateRoadScenery() {
+  if (!map) return;
+  const palette  = getSceneryPalette(sceneryMix);
+  const spacing  = Math.max(10, 100 / sceneryDensity);
+  let   count    = 0;
+  let   seed     = 0;
+
+  for (const road of map.roads) {
+    const pts    = roadPts(road);
+    if (!pts)    continue;
+    const len    = roadApproxLength(road);
+    if (len < 1) continue;
+    const steps  = Math.max(2, Math.ceil(len / spacing));
+    const sideOff = road.width / 2 + sceneryOffset;
+
+    for (let i = 0; i <= steps; i++) {
+      const t   = i / steps;
+      const pos = bezierSample(pts, t);
+      const tan = bezierTangent(pts, t);
+      const px  = -tan.z, pz = tan.x; // perpendicular
+
+      for (const side of [-1, 1]) {
+        const ax = pos.x + px * sideOff * side;
+        const az = pos.z + pz * sideOff * side;
+        if (map.assets.some(a => Math.hypot(a.x - ax, a.z - az) < spacing * 0.6)) continue;
+        const type = palette[(seed++) % palette.length];
+        map.assets.push({ type, x: ax, z: az, generated: true });
+        count++;
+      }
+    }
+  }
+  notify(count > 0 ? 'SCENERY: ' + count + ' ASSETS PLACED' : 'NO ROADS TO DECORATE');
+}
+
+function clearRoadScenery() {
+  if (!map) return;
+  const before = map.assets.length;
+  map.assets = map.assets.filter(a => !a.generated);
+  const removed = before - map.assets.length;
+  if (selAsset >= map.assets.length) { selAsset = -1; syncSelectedUI(); }
+  notify(removed > 0 ? 'CLEARED ' + removed + ' SCENERY ASSET(S)' : 'NO GENERATED SCENERY');
+}
+
 // ── UI helpers ─────────────────────────────────────────────────
 let _notifTimer = 0;
 function notify(msg) {
@@ -716,10 +945,12 @@ function setTool(t) {
   tool = t; connectFrom = -1;
   document.querySelectorAll('.toolBtn').forEach(b => b.classList.toggle('active', b.dataset.tool === t));
   canvas.style.cursor =
-    t === 'node'  ? 'cell'         :
-    t === 'road'  ? 'crosshair'    :
-    t === 'erase' ? 'not-allowed'  :
-    t === 'brush' ? 'copy'         : 'default';
+    t === 'node'  ? 'cell'        :
+    t === 'road'  ? 'crosshair'   :
+    t === 'erase' ? 'not-allowed' :
+    t === 'brush' ? 'copy'        :
+    t === 'cure'  ? 'help'        :
+    t === 'city'  ? 'crosshair'   : 'default';
 }
 
 function syncBrushUI() {
@@ -832,6 +1063,38 @@ function bindUI() {
     el.addEventListener('click', () => { brushType = el.dataset.asset; setTool('brush'); syncBrushUI(); });
   });
 
+  // Cure tool
+  document.getElementById('btnCureOrphans').addEventListener('click', cureAllOrphans);
+  document.getElementById('btnStraightenAll').addEventListener('click', straightenAllRoads);
+
+  // City spawner
+  document.getElementById('citySize').addEventListener('input', e => {
+    citySize = +e.target.value;
+    document.getElementById('citySizeVal').textContent = citySize + '\xd7' + citySize;
+  });
+  document.getElementById('cityBlockSize').addEventListener('input', e => {
+    cityBlockSize = +e.target.value;
+    document.getElementById('cityBlockSizeVal').textContent = e.target.value;
+  });
+  document.getElementById('cityRoadType').addEventListener('change', e => {
+    cityRoadType = e.target.value;
+  });
+
+  // Road scenery
+  document.getElementById('sceneryDensity').addEventListener('input', e => {
+    sceneryDensity = +e.target.value;
+    document.getElementById('sceneryDensityVal').textContent = e.target.value;
+  });
+  document.getElementById('sceneryOffset').addEventListener('input', e => {
+    sceneryOffset = +e.target.value;
+    document.getElementById('sceneryOffsetVal').textContent = e.target.value;
+  });
+  document.getElementById('sceneryMix').addEventListener('change', e => {
+    sceneryMix = e.target.value;
+  });
+  document.getElementById('btnGenScenery').addEventListener('click', generateRoadScenery);
+  document.getElementById('btnClearScenery').addEventListener('click', clearRoadScenery);
+
   // Snap
   document.getElementById('snapToggle').addEventListener('change', e => {
     snapSize = e.target.checked ? 20 : 0;
@@ -846,6 +1109,8 @@ function bindUI() {
       case 'KeyR': setTool('road');    break;
       case 'KeyE': setTool('erase');   break;
       case 'KeyB': setTool('brush');   break;
+      case 'KeyC': setTool('cure');    break;
+      case 'KeyY': setTool('city');    break;
       case 'KeyG':
         snapSize = snapSize > 0 ? 0 : 20;
         document.getElementById('snapToggle').checked = snapSize > 0;

--- a/games/drive-map-editor/index.html
+++ b/games/drive-map-editor/index.html
@@ -18,12 +18,14 @@
     <button class="toolBtn"        data-tool="road"   title="Draw Road (R)">&#9135; ROAD</button>
     <button class="toolBtn"        data-tool="erase"  title="Erase (E)">&#10007; ERASE</button>
     <button class="toolBtn"        data-tool="brush"  title="Paint Assets (B)">&#9998; BRUSH</button>
+    <button class="toolBtn"        data-tool="cure"   title="Cure / Cleanup (C)">&#10010; CURE</button>
+    <button class="toolBtn"        data-tool="city"   title="Spawn City Grid (Y)">&#8962; CITY</button>
   </div>
 
   <div class="toolSep"></div>
 
   <div class="toolGroup" style="font-size:11px;color:#4a5870;letter-spacing:1px;">
-    S·N·R·E·B keys&nbsp;·&nbsp;Del deletes&nbsp;·&nbsp;G toggles snap&nbsp;·&nbsp;Scroll zooms&nbsp;·&nbsp;Right-drag pans
+    S·N·R·E·B·C·Y keys&nbsp;·&nbsp;Del deletes&nbsp;·&nbsp;G toggles snap&nbsp;·&nbsp;Scroll zooms&nbsp;·&nbsp;Right-drag pans
   </div>
 
   <div id="topRight">
@@ -85,7 +87,7 @@
       </div>
     </div>
 
-    <!-- New road defaults (used when drawing roads) -->
+    <!-- New road defaults -->
     <div class="editorSection">
       <div class="editorLabel">New Road Defaults</div>
       <div class="editorGrid2">
@@ -103,7 +105,7 @@
           <input id="newRoadWidth" type="number" min="4" max="40" value="12">
         </label>
       </div>
-      <div class="editorHint">These defaults apply to newly drawn roads. You can change each road's properties individually after selecting it.</div>
+      <div class="editorHint">Defaults for newly drawn roads. Change each road individually after selecting.</div>
     </div>
 
     <!-- Selected element: Node -->
@@ -198,6 +200,67 @@
       </label>
     </div>
 
+    <!-- Cure tool -->
+    <div class="editorSection">
+      <div class="editorLabel">&#10010; Cure Tool <span class="toolKeyHint">C</span></div>
+      <div class="editorHint" style="margin-bottom:10px;">Click an orphan node (red) to remove it. Click any road to auto-curve or straighten it. Orphan nodes are highlighted with a dashed ring.</div>
+      <div class="editorRow">
+        <button class="btn btn-s" id="btnCureOrphans">REMOVE ORPHANS</button>
+        <button class="btn btn-s" id="btnStraightenAll">STRAIGHTEN ALL</button>
+      </div>
+    </div>
+
+    <!-- City spawner -->
+    <div class="editorSection">
+      <div class="editorLabel">&#8962; City Spawner <span class="toolKeyHint">Y</span></div>
+      <div class="editorGrid2">
+        <label class="editorField">
+          <span>Grid Size <strong id="citySizeVal">3&times;3</strong></span>
+          <input id="citySize" type="range" min="2" max="8" step="1" value="3">
+        </label>
+        <label class="editorField">
+          <span>Block <strong id="cityBlockSizeVal">80</strong>m</span>
+          <input id="cityBlockSize" type="range" min="30" max="200" step="10" value="80">
+        </label>
+      </div>
+      <label class="editorField">
+        <span>Road Type</span>
+        <select id="cityRoadType">
+          <option value="street" selected>Street</option>
+          <option value="highway">Highway</option>
+          <option value="country">Country</option>
+          <option value="lane">Lane</option>
+        </select>
+      </label>
+      <div class="editorHint">Switch to CITY tool then click the canvas to place a city grid. A live preview follows your cursor.</div>
+    </div>
+
+    <!-- Road scenery -->
+    <div class="editorSection">
+      <div class="editorLabel">Road Scenery</div>
+      <label class="editorField">
+        <span>Density <strong id="sceneryDensityVal">3</strong> per 100m</span>
+        <input id="sceneryDensity" type="range" min="1" max="10" step="1" value="3">
+      </label>
+      <label class="editorField">
+        <span>Side Offset <strong id="sceneryOffsetVal">8</strong>m</span>
+        <input id="sceneryOffset" type="range" min="2" max="30" step="1" value="8">
+      </label>
+      <label class="editorField">
+        <span>Asset Mix</span>
+        <select id="sceneryMix">
+          <option value="trees">Trees Only</option>
+          <option value="mixed" selected>Trees &amp; Buildings</option>
+          <option value="dense">Dense (All Types)</option>
+        </select>
+      </label>
+      <div class="editorRow">
+        <button class="btn btn-p" id="btnGenScenery">GENERATE</button>
+        <button class="btn btn-danger" id="btnClearScenery">CLEAR</button>
+      </div>
+      <div class="editorHint">Auto-places assets along all roads respecting road width. CLEAR only removes auto-generated scenery, not hand-placed assets.</div>
+    </div>
+
     <!-- Grid snap -->
     <div class="editorSection">
       <div class="editorLabel">Canvas</div>
@@ -230,7 +293,7 @@
   <div id="canvasWrap">
     <canvas id="editorCanvas"></canvas>
     <div id="canvasHint">
-      SELECT drag nodes &amp; roads &nbsp;·&nbsp; NODE click to place &nbsp;·&nbsp; ROAD click two nodes &nbsp;·&nbsp; ERASE click to delete &nbsp;·&nbsp; BRUSH click to paint
+      SELECT drag nodes &amp; roads &nbsp;·&nbsp; NODE click to place &nbsp;·&nbsp; ROAD click two nodes &nbsp;·&nbsp; ERASE click to delete &nbsp;·&nbsp; BRUSH click to paint &nbsp;·&nbsp; CURE click to fix &nbsp;·&nbsp; CITY click to spawn grid
     </div>
     <!-- Node color legend -->
     <div id="legend">

--- a/games/drive-map-editor/styles.css
+++ b/games/drive-map-editor/styles.css
@@ -340,6 +340,20 @@ body {
 }
 .leg-node { display: inline-block; width: 10px; height: 10px; border-radius: 50%; margin-right: 5px; vertical-align: middle; }
 
+/* Tool key hint badge */
+.toolKeyHint {
+  display: inline-block;
+  padding: 1px 5px;
+  border-radius: 4px;
+  background: rgba(68,170,255,.15);
+  border: 1px solid rgba(68,170,255,.3);
+  color: #44aaff;
+  font-size: 9px;
+  letter-spacing: 1px;
+  vertical-align: middle;
+  margin-left: 4px;
+}
+
 /* ── Responsive ──────────────────────────────────────────────── */
 @media (max-width: 900px) {
   #main { grid-template-columns: 1fr; grid-template-rows: auto 1fr; }


### PR DESCRIPTION
## Summary
- Add CURE tool, CITY spawner, and road scenery generator to drive map editor
- Merge pull request #310 from rcktgrl/claude/wizardly-dijkstra-sfnznp
- Add Drive Map Editor — node-based road network tool
- Merge pull request #309 from rcktgrl/claude/ecstatic-clarke-fpv27k
- F3 free drive: irregular island, asymmetric layout, race circuit
- Merge pull request #308 from rcktgrl/claude/lucid-newton-0ild0j
- ai-trainer: add SAC as a selectable algorithm alongside PPO
- Merge pull request #307 from rcktgrl/claude/bold-shannon-4e01fd
- ai-trainer: replace hand-written WebGPU backend with TensorFlow.js (WebGL)
- Merge pull request #306 from rcktgrl/claude/quirky-pascal-xmk80u
- F³: add Free Drive mode — open-world island with drop-in multiplayer

---
_Generated by [Claude Code](https://claude.ai/code/session_011pJsDep32DKVhQ7Jt1Hnw4)_