### PR TITLE
Add map selection menu to Free Drive

### DIFF
--- a/games/turborace/index.html
+++ b/games/turborace/index.html
@@ -317,10 +317,21 @@
   </div>
 </div>
 
+<!-- FREE DRIVE MAP SELECT -->
+<div class="screen" id="sFdMapSel" style="display:none">
+  <h2>🏝️ Free Drive — Select Map</h2>
+  <div id="fdMapCards" class="trackCards" style="display:flex;gap:20px;flex-wrap:wrap;justify-content:center;margin-bottom:24px;"></div>
+  <div class="menuActions menuActions-inline">
+    <button id="fdMapBackBtn" class="btn btn-s">BACK</button>
+    <button id="fdMapLoadOnlineBtn" class="btn btn-s">LOAD ONLINE TRACKS</button>
+    <button id="fdMapNextBtn" class="btn btn-p" disabled>NEXT</button>
+  </div>
+</div>
+
 <!-- FREE DRIVE SETUP -->
 <div class="screen" id="sFreeDrive" style="display:none">
   <h2>🏝️ Free Drive</h2>
-  <div class="sub">Open-world island · three cities · cruise together</div>
+  <div class="sub" id="fdModeSub">Open-world island · three cities · cruise together</div>
   <div id="fdStatusMsg" style="color:#fa4;font-size:.8rem;min-height:1.2em;text-align:center;width:100%;max-width:640px;"></div>
   <div style="display:flex;align-items:center;gap:8px;margin-bottom:14px;">
     <span style="color:#556;font-size:.75rem;font-family:Orbitron,monospace;letter-spacing:1px;">DRIVING AS</span>

--- a/games/turborace/scripts/freedrive.js
+++ b/games/turborace/scripts/freedrive.js
@@ -16,7 +16,8 @@ import {
 import { buildCarChipRow, refreshCarChipColors, disposeCarCardPreviews } from './menu.js';
 import { clearGhostVisual } from './ghost.js';
 import { getArcadeUser } from './user.js';
-import { hexNumToCss, cssToHexNum } from './editor.js';
+import { hexNumToCss, cssToHexNum, getTrackById } from './editor.js';
+import { buildTrack } from './track-gen.js';
 import { notify } from './notify.js';
 
 // ═══════════════════════════════════════════════════════
@@ -62,6 +63,15 @@ export function showFreeDriveMenu(){
   const lbl = document.getElementById('fdMyNameLabel');
   if(lbl) lbl.textContent = getArcadeUser().name || 'Anonymous';
   _setFdStatus('');
+  const subEl = document.getElementById('fdModeSub');
+  if(subEl){
+    if(!state.fdSelMap || state.fdSelMap === 'island'){
+      subEl.textContent = 'Open-world island · three cities · cruise together';
+    } else {
+      const trk = getTrackById(state.fdSelMap);
+      subEl.textContent = trk ? `${trk.name} · race track · drive freely` : 'Race track · drive freely';
+    }
+  }
 }
 
 export function onFdColorInput(css){
@@ -78,21 +88,48 @@ export async function startFreeDrive(){
   for(const ctrl of state.aiControllers) if(ctrl.destroy) ctrl.destroy();
   for(const c of state.allCars) scene.remove(c.mesh);
   state.allCars = []; state.aiCars = []; state.aiControllers = []; state.pCar = null;
+  state.fdTrackData = null;
   clearGhostVisual();
   document.querySelectorAll('.screen,#results').forEach(s => s.style.display = 'none');
 
-  const world = buildFreeDriveWorld();
-  setupLights();
+  const selMap = state.fdSelMap || 'island';
+  let spawnPos, spawnHdg, notifyMsg, fdWorldId;
 
-  const sp = world.spawnPoints[Math.floor(Math.random() * world.spawnPoints.length)];
-  const pos = new THREE.Vector3(sp.x + (Math.random() - 0.5) * 18, 0, sp.z + (Math.random() - 0.5) * 5);
-  const car = new Car(CARS[state.selCar ?? 0], pos, sp.hdg, true, scene, state.carColor);
+  if(selMap === 'island'){
+    const world = buildFreeDriveWorld();
+    setupLights();
+    const sp = world.spawnPoints[Math.floor(Math.random() * world.spawnPoints.length)];
+    spawnPos = new THREE.Vector3(sp.x + (Math.random() - 0.5) * 18, 0, sp.z + (Math.random() - 0.5) * 5);
+    spawnHdg = sp.hdg;
+    notifyMsg = `Free Drive — spawned in ${sp.city}. Explore the island!`;
+    fdWorldId = FD_WORLD_ID;
+    _buildStaticMinimap(world);
+  } else {
+    const trackData = getTrackById(selMap);
+    if(!trackData){
+      notify('Map not found — falling back to island.');
+      state.fdSelMap = 'island';
+      return startFreeDrive();
+    }
+    buildTrack(trackData);
+    state.fdTrackData = trackData;
+    setupLights();
+    const sp0 = state.trkPts[0] || new THREE.Vector3(0, 0, 0);
+    const sp1 = state.trkPts[1] || new THREE.Vector3(0, 0, 5);
+    spawnPos = new THREE.Vector3(sp0.x + (Math.random() - 0.5) * 8, sp0.y, sp0.z + (Math.random() - 0.5) * 4);
+    spawnHdg = Math.atan2(sp1.x - sp0.x, sp1.z - sp0.z);
+    notifyMsg = `Free Drive — ${trackData.name}. Drive freely!`;
+    fdWorldId = `track-fd-${String(selMap).replace(/[^a-z0-9_-]/gi, '-')}`;
+    _buildTrackMinimap(trackData);
+  }
+
+  const car = new Car(CARS[state.selCar ?? 0], spawnPos, spawnHdg, true, scene, state.carColor);
   state.pCar = car; state.allCars = [car];
 
   state.fdMode = true; state.raceTime = 0; state.fdPosTimer = 0;
   state.fdCleanup = _quitCleanup;
 
-  // HUD: speed + gear + island map — no laps, checkpoints or positions
+  // HUD: speed + gear + minimap — no laps, checkpoints or positions
   document.getElementById('hud').style.display = 'block';
   document.getElementById('raceTop').style.display = 'none';
   document.getElementById('pos').style.display = 'none';
@@ -101,22 +138,35 @@ export async function startFreeDrive(){
   document.getElementById('camLabel').textContent = '[ C ] COCKPIT VIEW';
   document.getElementById('hint').style.display = isTouchControlsEnabled() ? 'none' : 'block';
   state.camMode = 'chase'; dc.style.display = 'none';
-  _buildStaticMinimap(world);
 
   state.gState = 'freedrive';
   updateTouchControlsVisibility(state.gState);
   initAudio(); startMusic();
-  notify(`Free Drive — spawned in ${sp.city}. Explore the island!`);
+  notify(notifyMsg);
   _updateOnlineHudTag();
 
-  if(state.fdOnline) await _joinIsland();
+  if(state.fdOnline) await _joinIsland(fdWorldId);
 }
 
-// Respawn on the nearest city spawn point (pause-menu RESTART).
+// Respawn on the nearest spawn point (pause-menu RESTART).
 export function fdRespawn(){
-  const world = getFreeDriveWorld();
   const car = state.pCar;
-  if(!world || !car) return;
+  if(!car) return;
+  if(state.fdTrackData){
+    const sp0 = state.trkPts[0] || new THREE.Vector3(0, 0, 0);
+    const sp1 = state.trkPts[1] || new THREE.Vector3(0, 0, 5);
+    car.pos.set(sp0.x + (Math.random() - 0.5) * 8, sp0.y, sp0.z + (Math.random() - 0.5) * 4);
+    car.hdg = Math.atan2(sp1.x - sp0.x, sp1.z - sp0.z);
+    car.spd = 0; car.revSpd = 0; car.isReversing = false;
+    car.mesh.position.copy(car.pos); car.mesh.rotation.y = car.hdg;
+    state.gState = 'freedrive';
+    updateTouchControlsVisibility(state.gState);
+    initAudio(); startMusic();
+    notify('Respawned at start/finish.');
+    return;
+  }
+  const world = getFreeDriveWorld();
+  if(!world) return;
   let best = world.spawnPoints[0], bd = Infinity;
   for(const sp of world.spawnPoints){
     const d = (car.pos.x - sp.x) ** 2 + (car.pos.z - sp.z) ** 2;
@@ -142,7 +192,7 @@ function _teardownSession(){
 // Registered as state.fdCleanup — called by showMain when leaving the mode.
 function _quitCleanup(){
   _teardownSession();
-  state.fdMode = false; state.fdCleanup = null;
+  state.fdMode = false; state.fdCleanup = null; state.fdTrackData = null;
   document.getElementById('raceTop').style.display = '';
   document.getElementById('pos').style.display = '';
   const tag = document.getElementById('fdOnlineTag');
@@ -152,17 +202,17 @@ function _quitCleanup(){
 // ═══════════════════════════════════════════════════════
 //  NETWORK
 // ═══════════════════════════════════════════════════════
-async function _joinIsland(){
+async function _joinIsland(worldId){
   const user = getArcadeUser();
   const net = new FreeDriveNetwork();
   state.fdNetwork = net;
   net.onRoster = _onRoster;
   net.onPos = _onPos;
   try {
-    await net.join(FD_WORLD_ID, user.name || 'Anonymous', state.selCar ?? 0, state.carColor);
+    await net.join(worldId, user.name || 'Anonymous', state.selCar ?? 0, state.carColor);
   } catch(e) {
     if(state.fdNetwork === net) state.fdNetwork = null;
-    notify('Island online unavailable — driving solo. (' + e.message + ')');
+    notify('Online unavailable — driving solo. (' + e.message + ')');
     _updateOnlineHudTag();
     return;
   }
@@ -231,12 +281,13 @@ function _updateOnlineHudTag(){
   if(!el) return;
   if(!state.fdMode){ el.style.display = 'none'; return; }
   el.style.display = 'block';
+  const label = state.fdTrackData ? (state.fdTrackData.name || 'TRACK') : 'ISLAND';
   if(state.fdNetwork){
     const n = 1 + Object.keys(fdRemote).length;
-    el.textContent = `🏝 ISLAND ONLINE · ${n} DRIVER${n > 1 ? 'S' : ''}`;
+    el.textContent = `🏁 ${label.toUpperCase()} ONLINE · ${n} DRIVER${n > 1 ? 'S' : ''}`;
     el.style.color = '#4f9';
   } else {
-    el.textContent = '🏝 ISLAND · SOLO DRIVE';
+    el.textContent = `🏁 ${label.toUpperCase()} · SOLO DRIVE`;
     el.style.color = '#789';
   }
 }
@@ -303,9 +354,10 @@ function _updateTags(){
 //  PER-FRAME UPDATE (called from the game loop)
 // ═══════════════════════════════════════════════════════
 export function updateFreeDrive(dt){
-  const world = getFreeDriveWorld();
   const car = state.pCar;
-  if(!world || !car) return;
+  if(!car) return;
+  const world = state.fdTrackData ? null : getFreeDriveWorld();
+  if(!state.fdTrackData && !world) return;
   state.raceTime += dt;
 
   const autoTouchThrottle = isTouchControlsVisibleInState(state.gState)
@@ -320,13 +372,17 @@ export function updateFreeDrive(dt){
   const sliderSteer = getTouchSliderSteer();
   const str = Math.abs(gyroSteer) > 0.01 ? gyroSteer : Math.abs(sliderSteer) > 0.01 ? sliderSteer : keySteer;
 
-  // Off-road: Rally Storm (green) drives freely. All other cars get reduced thrust
-  // (set via onGravel) — slower acceleration but no hard speed cap.
-  const offroad = world.roadEdgeDist(car.pos.x, car.pos.z) > 1.5;
-  const isRally = car.data.id === 2;
-  car.onGravel = offroad && !isRally;
+  if(world){
+    // Island: off-road check — Rally Storm drives freely, others slow down
+    const offroad = world.roadEdgeDist(car.pos.x, car.pos.z) > 1.5;
+    const isRally = car.data.id === 2;
+    car.onGravel = offroad && !isRally;
+  } else {
+    // Track: use gravel zones baked into the track (same as race mode)
+    car.checkGravel();
+  }
   car.update({ thr, brk, str }, dt);
-  _applyWorldBounds(car, world);
+  if(world) _applyWorldBounds(car, world);
 
   _updateRemoteCars(dt);
   _broadcastPos(dt);
@@ -356,14 +412,15 @@ function _applyWorldBounds(car, world){
 }
 
 // ═══════════════════════════════════════════════════════
-//  ISLAND MINIMAP
+//  MINIMAP (shared by island and track modes)
 // ═══════════════════════════════════════════════════════
-let _mapCanvas = null, _mapScale = 1;
+let _mapCanvas = null, _mapScale = 1, _mapCenterX = 0, _mapCenterZ = 0;
 
 function _buildStaticMinimap(world){
   const S = 150, half = S / 2;
   _mapCanvas = document.createElement('canvas');
   _mapCanvas.width = S; _mapCanvas.height = S;
+  _mapCenterX = 0; _mapCenterZ = 0;
   _mapScale = half / (world.waterR + 60);
   const ctx = _mapCanvas.getContext('2d');
   const toM = (x, z) => [half + x * _mapScale, half + z * _mapScale];
@@ -397,6 +454,43 @@ function _buildStaticMinimap(world){
   }
 }
 
+function _buildTrackMinimap(trackData){
+  const S = 150, half = S / 2;
+  _mapCanvas = document.createElement('canvas');
+  _mapCanvas.width = S; _mapCanvas.height = S;
+  const xs = trackData.wp.map(p => p[0]), zs = trackData.wp.map(p => p[2]);
+  const minX = Math.min(...xs), maxX = Math.max(...xs);
+  const minZ = Math.min(...zs), maxZ = Math.max(...zs);
+  _mapCenterX = (minX + maxX) / 2; _mapCenterZ = (minZ + maxZ) / 2;
+  const rangeX = maxX - minX || 1, rangeZ = maxZ - minZ || 1;
+  _mapScale = (half - 12) / Math.max(rangeX / 2, rangeZ / 2);
+  const toM = (x, z) => [half + (x - _mapCenterX) * _mapScale, half + (z - _mapCenterZ) * _mapScale];
+  // Catmull-Rom curve
+  const n = trackData.wp.length;
+  const curve = [];
+  for(let s = 0; s < n; s++){
+    const p0 = trackData.wp[(s - 1 + n) % n], p1 = trackData.wp[s], p2 = trackData.wp[(s + 1) % n], p3 = trackData.wp[(s + 2) % n];
+    for(let i = 0; i < 8; i++){
+      const t = i / 8, t2 = t * t, t3 = t2 * t;
+      curve.push([
+        0.5 * ((2 * p1[0]) + (-p0[0] + p2[0]) * t + (2 * p0[0] - 5 * p1[0] + 4 * p2[0] - p3[0]) * t2 + (-p0[0] + 3 * p1[0] - 3 * p2[0] + p3[0]) * t3),
+        0.5 * ((2 * p1[2]) + (-p0[2] + p2[2]) * t + (2 * p0[2] - 5 * p1[2] + 4 * p2[2] - p3[2]) * t2 + (-p0[2] + 3 * p1[2] - 3 * p2[2] + p3[2]) * t3)
+      ]);
+    }
+  }
+  const ctx = _mapCanvas.getContext('2d');
+  ctx.fillStyle = 'rgba(4,10,24,.85)'; ctx.fillRect(0, 0, S, S);
+  const col = trackData.previewColor || '#4488ff';
+  ctx.strokeStyle = col + '33'; ctx.lineWidth = Math.max(2, trackData.rw * _mapScale * 1.4);
+  ctx.lineCap = 'round'; ctx.lineJoin = 'round';
+  ctx.beginPath(); curve.forEach(([x, z], i) => { const [mx, mz] = toM(x, z); i ? ctx.lineTo(mx, mz) : ctx.moveTo(mx, mz); }); ctx.closePath(); ctx.stroke();
+  ctx.strokeStyle = col; ctx.lineWidth = 1.5;
+  ctx.beginPath(); curve.forEach(([x, z], i) => { const [mx, mz] = toM(x, z); i ? ctx.lineTo(mx, mz) : ctx.moveTo(mx, mz); }); ctx.closePath(); ctx.stroke();
+  const [sfx, sfz] = toM(trackData.wp[0][0], trackData.wp[0][2]);
+  ctx.strokeStyle = '#fff'; ctx.lineWidth = 2; ctx.setLineDash([2, 2]);
+  ctx.beginPath(); ctx.moveTo(sfx - 5, sfz); ctx.lineTo(sfx + 5, sfz); ctx.stroke(); ctx.setLineDash([]);
+}
+
 function _drawFdMinimap(){
   if(!_mapCanvas || !state.pCar) return;
   const ctx = mmctx, S = 150, half = S / 2;
@@ -405,10 +499,11 @@ function _drawFdMinimap(){
   for(const r of Object.values(fdRemote)){
     if(!r.hasPos) continue;
     ctx.beginPath();
-    ctx.arc(half + r.car.pos.x * _mapScale, half + r.car.pos.z * _mapScale, 3, 0, Math.PI * 2);
+    ctx.arc(half + (r.car.pos.x - _mapCenterX) * _mapScale, half + (r.car.pos.z - _mapCenterZ) * _mapScale, 3, 0, Math.PI * 2);
     ctx.fillStyle = '#44aaff'; ctx.fill();
   }
-  const px = half + state.pCar.pos.x * _mapScale, pz = half + state.pCar.pos.z * _mapScale;
+  const px = half + (state.pCar.pos.x - _mapCenterX) * _mapScale;
+  const pz = half + (state.pCar.pos.z - _mapCenterZ) * _mapScale;
   const hdg = state.pCar.hdg;
   ctx.beginPath(); ctx.arc(px, pz, 4, 0, Math.PI * 2);
   ctx.fillStyle = '#ffd700'; ctx.fill();

--- a/games/turborace/scripts/game.js
+++ b/games/turborace/scripts/game.js
@@ -50,7 +50,8 @@ import {
   showDiffSel, showOnlineTrkSel, showSettings, closeSettings,
   showVsLobby, vsCreateRoom, vsJoinRoom, vsStartRace, vsLeaveLobby,
   vsCopyCode, vsCopyInviteLink, vsLoadOnlineTracks,
-  onCarColorInput, resetCarColor, onVsColorInput
+  onCarColorInput, resetCarColor, onVsColorInput,
+  showFdMapSel, showFdMapOnlineTracks
 } from './menu.js';
 import {
   closeTrackLeaderboardModal
@@ -278,8 +279,11 @@ document.getElementById('settingsCloseBtn').addEventListener('click',closeSettin
 document.getElementById('introStartBtn').addEventListener('click',function(){tryStartMenuMusic();showMain();});
 document.getElementById('gameStartBtn').addEventListener('click',function(){tryStartMenuMusic();showTrkSel();});
 document.getElementById('vsModeBtn').addEventListener('click',function(){tryStartMenuMusic();showVsLobby();});
-document.getElementById('freeDriveBtn').addEventListener('click',function(){tryStartMenuMusic();showFreeDriveMenu();});
-document.getElementById('fdBackBtn').addEventListener('click',showMain);
+document.getElementById('freeDriveBtn').addEventListener('click',function(){tryStartMenuMusic();void showFdMapSel();});
+document.getElementById('fdMapBackBtn').addEventListener('click',showMain);
+document.getElementById('fdMapLoadOnlineBtn').addEventListener('click',function(){void showFdMapOnlineTracks();});
+document.getElementById('fdMapNextBtn').addEventListener('click',showFreeDriveMenu);
+document.getElementById('fdBackBtn').addEventListener('click',function(){void showFdMapSel();});
 document.getElementById('fdStartBtn').addEventListener('click',function(){tryStartMenuMusic();void startFreeDrive();});
 document.getElementById('fdColor').addEventListener('input',e=>onFdColorInput(e.target.value));
 document.getElementById('fdOnlineToggle').addEventListener('change',e=>{ state.fdOnline=e.target.checked; });

--- a/games/turborace/scripts/menu.js
+++ b/games/turborace/scripts/menu.js
@@ -376,6 +376,101 @@ export async function showOnlineTrkSel(){
 }
 
 // ═══════════════════════════════════════════════════════
+//  FREE DRIVE MAP SELECTION
+// ═══════════════════════════════════════════════════════
+
+function _drawIslandPreview(canvas) {
+  const W = canvas.width, H = canvas.height, cx = W / 2, cy = H / 2;
+  const ctx = canvas.getContext('2d');
+  ctx.fillStyle = '#10334d'; ctx.fillRect(0, 0, W, H);
+  const r = Math.min(W, H) * 0.36;
+  const pts = 14;
+  function islandPath(scl) {
+    ctx.beginPath();
+    for (let i = 0; i <= pts; i++) {
+      const a = (i / pts) * Math.PI * 2;
+      const noise = 0.78 + 0.22 * Math.sin(a * 3.7 + 1.2) + 0.12 * Math.cos(a * 7.1 + 0.8);
+      const x = cx + Math.cos(a) * r * scl * noise;
+      const y = cy + Math.sin(a) * r * scl * noise;
+      i === 0 ? ctx.moveTo(x, y) : ctx.lineTo(x, y);
+    }
+    ctx.closePath();
+  }
+  islandPath(1.0); ctx.fillStyle = '#54492f'; ctx.fill();
+  islandPath(0.93); ctx.fillStyle = '#15301b'; ctx.fill();
+  ctx.beginPath(); ctx.arc(cx, cy, r * 0.13, 0, Math.PI * 2); ctx.fillStyle = '#10334d'; ctx.fill();
+  const cities = [{ a: -0.5, d: 0.52, col: '#ffd700' }, { a: 2.0, d: 0.54, col: '#ff6644' }, { a: 1.0, d: 0.48, col: '#44aaff' }];
+  for (const c of cities) {
+    ctx.beginPath(); ctx.arc(cx + Math.cos(c.a) * r * c.d, cy + Math.sin(c.a) * r * c.d, 4, 0, Math.PI * 2);
+    ctx.fillStyle = c.col; ctx.fill();
+  }
+  ctx.font = 'bold 10px Orbitron, monospace'; ctx.fillStyle = '#2ecc88'; ctx.textAlign = 'center';
+  ctx.fillText('ISLAND', cx, H - 10); ctx.textAlign = 'left';
+}
+
+function _buildFdMapCards(tracks) {
+  const COLORS = ['#4488ff', '#44cc66', '#ffaa22', '#ff4488', '#22ddaa', '#dd66ff', '#66bbff'];
+  const container = document.getElementById('fdMapCards');
+  container.innerHTML = '';
+
+  // Island card (always first)
+  const islandCard = document.createElement('div');
+  islandCard.className = 'tcard' + (state.fdSelMap === 'island' ? ' sel' : '');
+  const islandCanvas = document.createElement('canvas'); islandCanvas.width = 280; islandCanvas.height = 230; islandCanvas.style.borderRadius = '6px';
+  const islandH3 = document.createElement('h3'); islandH3.textContent = 'Island';
+  const islandP = document.createElement('p'); islandP.textContent = 'Open-world island · three cities · cruise freely';
+  islandCard.appendChild(islandCanvas); islandCard.appendChild(islandH3); islandCard.appendChild(islandP);
+  islandCard.onclick = () => {
+    container.querySelectorAll('.tcard').forEach(x => x.classList.remove('sel'));
+    islandCard.classList.add('sel'); state.fdSelMap = 'island';
+    document.getElementById('fdMapNextBtn').disabled = false;
+  };
+  container.appendChild(islandCard);
+  _drawIslandPreview(islandCanvas);
+
+  tracks.forEach((t, i) => {
+    const card = document.createElement('div'); card.className = 'tcard' + (String(state.fdSelMap) === String(t.id) ? ' sel' : '');
+    const canvas = document.createElement('canvas'); canvas.width = 280; canvas.height = 230; canvas.style.borderRadius = '6px';
+    const h3 = document.createElement('h3'); h3.textContent = t.name;
+    const p = document.createElement('p'); p.textContent = t.desc + ' · ' + t.rw + 'm wide' + (t.builtin ? '' : ' · Custom');
+    card.appendChild(canvas); card.appendChild(h3); card.appendChild(p);
+    card.onclick = () => {
+      container.querySelectorAll('.tcard').forEach(x => x.classList.remove('sel'));
+      card.classList.add('sel'); state.fdSelMap = t.id;
+      document.getElementById('fdMapNextBtn').disabled = false;
+    };
+    container.appendChild(card);
+    drawTrackPreview(canvas, t, t.previewColor || COLORS[i % COLORS.length]);
+  });
+
+  if (!state.fdSelMap) {
+    state.fdSelMap = 'island';
+    islandCard.classList.add('sel');
+    document.getElementById('fdMapNextBtn').disabled = false;
+  }
+}
+
+export async function showFdMapSel() {
+  await loadTracksFromFolder().catch(() => {});
+  document.querySelectorAll('.screen').forEach(s => s.style.display = 'none');
+  document.getElementById('sFdMapSel').style.display = 'flex';
+  state.gState = 'fdMapSel';
+  updateTouchControlsVisibility(state.gState);
+  document.getElementById('fdMapNextBtn').disabled = (state.fdSelMap == null);
+  _buildFdMapCards(state.folderTracks);
+}
+
+export async function showFdMapOnlineTracks() {
+  loadEditorTracks();
+  const container = document.getElementById('fdMapCards');
+  const loadingEl = document.createElement('p'); loadingEl.textContent = 'Loading online tracks…'; loadingEl.style.color = '#778'; loadingEl.style.width = '100%'; loadingEl.style.textAlign = 'center';
+  container.innerHTML = ''; container.appendChild(loadingEl);
+  await syncEditorTracksFromCloud().catch(() => {});
+  const allOnline = state.editorTracks.filter(t => !state.folderTracks.some(f => String(f.id) === String(t.id)));
+  _buildFdMapCards([...state.folderTracks, ...allOnline]);
+}
+
+// ═══════════════════════════════════════════════════════
 //  VS MODE LOBBY
 // ═══════════════════════════════════════════════════════
 

--- a/games/turborace/scripts/state.js
+++ b/games/turborace/scripts/state.js
@@ -87,10 +87,12 @@ export const state = {
     vsPosSendTimer: 0,
     vsPosSendInterval: 0.033, // 30 Hz
 
-    // ── Free Drive (open-world island) ──────────────────────────────────────
-    fdMode: false,           // true while free-driving on the island
-    fdOnline: true,          // menu toggle: share the island with other players
+    // ── Free Drive (open-world island or race track) ────────────────────────
+    fdMode: false,           // true while free-driving
+    fdOnline: true,          // menu toggle: share the world with other players
     fdNetwork: null,         // FreeDriveNetwork instance (null = solo)
     fdPosTimer: 0,           // broadcast throttle
     fdCleanup: null,         // set by freedrive.js; called by showMain on exit
+    fdSelMap: 'island',      // 'island' or a track ID string
+    fdTrackData: null,       // null for island mode, track data object for track mode
 };


### PR DESCRIPTION
## Summary
- Add map selection menu to Free Drive using the same track database

This PR introduces a map selection menu for the Free Drive mode, allowing players to choose from available tracks in the track database.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S4U6JMctBGrtxjuzpECwHc)_