### PR TITLE
Add custom free-ride map features: scenery, roads, buildings, traffic

### DIFF
--- a/games/drive-map-editor/editor.js
+++ b/games/drive-map-editor/editor.js
@@ -51,6 +51,9 @@ let citySize = 3, cityBlockSize = 80, cityRoadType = 'street';
 // Road scenery settings
 let sceneryDensity = 3, sceneryOffset = 8, sceneryMix = 'mixed';
 
+// Curvy road settings
+let curvyEnabled = false, curvyAmount = 3;
+
 // Snap
 let snapSize = 0;
 
@@ -698,6 +701,20 @@ function finishRoad(aId, bId) {
     type:   typeEl?.value  || 'street',
     waypoints: [],
   };
+  if (curvyEnabled) {
+    const a = getNode(aId), b = getNode(bId);
+    if (a && b) {
+      const mx = (a.x + b.x) / 2, mz = (a.z + b.z) / 2;
+      const dx = b.x - a.x, dz = b.z - a.z;
+      const len = Math.hypot(dx, dz);
+      if (len > 1) {
+        const maxOff = len * 0.08 * curvyAmount;
+        const side = Math.random() < 0.5 ? 1 : -1;
+        const offDist = maxOff * (0.4 + Math.random() * 0.6) * side;
+        road.waypoints = [{ x: mx + (-dz / len) * offDist, z: mz + (dx / len) * offDist }];
+      }
+    }
+  }
   map.roads.push(road);
   selRoad = road.id; selNode = selAsset = -1;
   syncSelectedUI();
@@ -817,7 +834,41 @@ function spawnCity(wx, wz) {
     }
   }
 
-  notify('CITY SPAWNED (' + blocks + '\xd7' + blocks + ')');
+  // Auto-place buildings and parks in each block
+  let seed = ((wx * 1234 + wz * 5678) | 0) || 1;
+  function rng() {
+    seed = (Math.imul(seed + 1, 1664525) + 1013904223) | 0;
+    return ((seed >>> 0) & 0xffff) / 0xffff;
+  }
+  const inset = rw / 2 + 5;
+  const usable = bs - inset * 2;
+  let assetCount = 0;
+  for (let r = 0; r < blocks; r++) {
+    for (let c = 0; c < blocks; c++) {
+      const bx = wx + (c - half + 0.5) * bs;
+      const bz = wz + (r - half + 0.5) * bs;
+      if (rng() < 0.22 && usable > 12) {
+        map.assets.push({ type: 'park', x: bx, z: bz, generated: true });
+        assetCount++;
+        for (let ti = 0; ti < 3; ti++) {
+          const ang = (ti / 3) * Math.PI * 2 + rng() * 0.5;
+          const rad = Math.max(4, usable * 0.22);
+          map.assets.push({ type: 'tree', x: bx + Math.cos(ang) * rad, z: bz + Math.sin(ang) * rad, generated: true });
+          assetCount++;
+        }
+      } else if (usable > 10) {
+        const num = 2 + Math.floor(rng() * 3);
+        for (let b = 0; b < num; b++) {
+          const bldX = bx + (rng() - 0.5) * usable;
+          const bldZ = bz + (rng() - 0.5) * usable;
+          map.assets.push({ type: 'building', x: bldX, z: bldZ, generated: true, tall: true });
+          assetCount++;
+        }
+      }
+    }
+  }
+
+  notify('CITY SPAWNED ' + blocks + '\xd7' + blocks + ' + ' + assetCount + ' ASSETS');
 }
 
 // ── Road scenery generation ────────────────────────────────────
@@ -1154,6 +1205,16 @@ function bindUI() {
   });
   document.getElementById('btnGenScenery').addEventListener('click', generateRoadScenery);
   document.getElementById('btnClearScenery').addEventListener('click', clearRoadScenery);
+
+  // Curvy roads
+  document.getElementById('curvyToggle').addEventListener('change', e => {
+    curvyEnabled = e.target.checked;
+    document.getElementById('curvyAmountRow').style.display = curvyEnabled ? '' : 'none';
+  });
+  document.getElementById('curvyAmount').addEventListener('input', e => {
+    curvyAmount = +e.target.value;
+    document.getElementById('curvyAmountVal').textContent = e.target.value;
+  });
 
   // Snap
   document.getElementById('snapToggle').addEventListener('change', e => {

--- a/games/drive-map-editor/index.html
+++ b/games/drive-map-editor/index.html
@@ -105,6 +105,14 @@
           <input id="newRoadWidth" type="number" min="4" max="40" value="12">
         </label>
       </div>
+      <label class="toggleRow">
+        <span>Curvy Roads (auto-curve new roads)</span>
+        <input type="checkbox" id="curvyToggle">
+      </label>
+      <label class="editorField" id="curvyAmountRow" style="display:none">
+        <span>Curve Amount <strong id="curvyAmountVal">3</strong></span>
+        <input id="curvyAmount" type="range" min="1" max="5" step="1" value="3">
+      </label>
       <div class="editorHint">Defaults for newly drawn roads. Change each road individually after selecting.</div>
     </div>
 

--- a/games/turborace/index.html
+++ b/games/turborace/index.html
@@ -349,6 +349,16 @@
     <span class="toggleLbl">ONLINE — JOIN OTHER DRIVERS ON THE ISLAND</span>
     <input type="checkbox" id="fdOnlineToggle" checked>
   </label>
+  <div id="fdTrafficSection" style="display:none;width:100%;max-width:700px;">
+    <label class="toggleRow" for="fdTrafficToggle" style="margin-top:10px;">
+      <span class="toggleLbl">AI TRAFFIC — SLOW CARS DRIVING THE ROADS</span>
+      <input type="checkbox" id="fdTrafficToggle">
+    </label>
+    <label class="toggleRow" for="fdTrafficCollisionsToggle" id="fdTrafficCollisionsRow" style="margin-top:6px;display:none;">
+      <span class="toggleLbl">ENABLE COLLISIONS WITH TRAFFIC</span>
+      <input type="checkbox" id="fdTrafficCollisionsToggle">
+    </label>
+  </div>
   <p style="color:#667;font-size:.78rem;max-width:640px;text-align:center;line-height:1.5;margin-top:12px;">
     One shared island, no room codes — everyone with Online enabled drives together.
     Three cities linked by highways, a winding coastal road and narrow country lanes.

--- a/games/turborace/scripts/freedrive-custommap.js
+++ b/games/turborace/scripts/freedrive-custommap.js
@@ -17,6 +17,12 @@ const ROAD_COLORS_3D = {
   lane:    0x201e18,
 };
 
+function _assetHash(i) {
+  let h = (i + 1) * 2654435769;
+  h ^= (h >>> 15); h = Math.imul(h, 0x85ebca6b); h ^= (h >>> 13);
+  return ((h >>> 0) & 0xffff) / 0xffff;
+}
+
 let _dmWorld = null;
 let _dmSyncOk = true;
 
@@ -123,19 +129,64 @@ export function buildDriveMap(mapData) {
     mesh.receiveShadow = true; mesh.userData.trk = true; scene.add(mesh);
   }
 
-  // Assets (skip auto-generated ones to keep performance reasonable)
+  // Assets — render all (including auto-generated scenery)
   (mapData.assets || []).forEach((asset, i) => {
-    if (asset.generated) return;
+    const t = _assetHash(i);
+    const t2 = _assetHash(i + 1000);
     let mesh = null;
     if (asset.type === 'tree') {
-      const h = 6 + (i % 5) * 2;
-      mesh = new THREE.Mesh(new THREE.ConeGeometry(2.5, h, 6),
-        new THREE.MeshLambertMaterial({ color: 0x2d7a2d }));
-      mesh.position.set(asset.x, h / 2, asset.z);
+      const h = 5 + t * 9;
+      const grn = 0x1a5c1a + Math.floor(t2 * 0x305010);
+      const trunk = new THREE.Mesh(
+        new THREE.CylinderGeometry(0.3, 0.5, h * 0.35, 5),
+        new THREE.MeshLambertMaterial({ color: 0x5c3a1a })
+      );
+      trunk.position.y = h * 0.175;
+      const crown = new THREE.Mesh(
+        new THREE.ConeGeometry(2 + t2 * 1.5, h * 0.75, 6),
+        new THREE.MeshLambertMaterial({ color: grn })
+      );
+      crown.position.y = h * 0.55;
+      mesh = new THREE.Group();
+      mesh.add(trunk); mesh.add(crown);
+      mesh.position.set(asset.x, 0, asset.z);
     } else if (asset.type === 'building') {
-      const h = 8 + (i % 7) * 3;
-      mesh = new THREE.Mesh(new THREE.BoxGeometry(8, h, 8),
-        new THREE.MeshLambertMaterial({ color: 0x55557a }));
+      const isTall = asset.tall;
+      const h = isTall ? 18 + t * 32 : 8 + t * 14;
+      const w = 7 + t2 * 6, d = 7 + _assetHash(i + 2000) * 6;
+      const col = 0x303050 + Math.floor(t * 0x202020);
+      const emv = 0x060612 + Math.floor(t2 * 0x0a0a08);
+      mesh = new THREE.Mesh(
+        new THREE.BoxGeometry(w, h, d),
+        new THREE.MeshLambertMaterial({ color: col, emissive: emv })
+      );
+      mesh.position.set(asset.x, h / 2, asset.z);
+    } else if (asset.type === 'park') {
+      const g = new THREE.Group();
+      const ground = new THREE.Mesh(
+        new THREE.BoxGeometry(16, 0.12, 16),
+        new THREE.MeshLambertMaterial({ color: 0x2d7a2d })
+      );
+      ground.position.y = 0.06;
+      g.add(ground);
+      for (let ti = 0; ti < 4; ti++) {
+        const th = _assetHash(i * 13 + ti);
+        const ang = (ti / 4) * Math.PI * 2;
+        const tr = new THREE.Mesh(
+          new THREE.ConeGeometry(1.2 + th * 0.8, 4 + th * 4, 5),
+          new THREE.MeshLambertMaterial({ color: 0x1e6b1e })
+        );
+        tr.position.set(Math.cos(ang) * 5.5, 2 + th * 2, Math.sin(ang) * 5.5);
+        g.add(tr);
+      }
+      mesh = g;
+      mesh.position.set(asset.x, 0, asset.z);
+    } else if (asset.type === 'stand') {
+      const h = 4 + t * 3;
+      mesh = new THREE.Mesh(
+        new THREE.BoxGeometry(16, h, 5),
+        new THREE.MeshLambertMaterial({ color: 0x8a4a3a })
+      );
       mesh.position.set(asset.x, h / 2, asset.z);
     }
     if (mesh) { mesh.castShadow = true; mesh.userData.trk = true; scene.add(mesh); }

--- a/games/turborace/scripts/freedrive-traffic.js
+++ b/games/turborace/scripts/freedrive-traffic.js
@@ -1,0 +1,236 @@
+'use strict';
+import { THREE } from './three.js';
+import { scene } from './state.js';
+
+// ═══════════════════════════════════════════════════════
+//  CUSTOM MAP AI TRAFFIC
+//  Simple road-following traffic cars for free-ride maps.
+//  Cars pick a random road, follow it to the end, then
+//  randomly choose a connected road at each intersection.
+// ═══════════════════════════════════════════════════════
+
+const TRAFFIC_COUNT   = 8;
+const TRAFFIC_SPD_MIN = 4.0;  // m/s (~14 km/h)
+const TRAFFIC_SPD_MAX = 7.5;  // m/s (~27 km/h)
+const LOOKAHEAD       = 8;    // pts to look ahead for steering
+const STEER_RATE      = 3.2;  // rad/s heading blend rate
+const SAMPLE_STEPS    = 16;   // pts sampled per road segment
+
+// Traffic car colors
+const TRAFFIC_COLORS = [0xcc3322, 0x2255cc, 0xddaa22, 0x33aa55, 0x9933bb, 0xdd6622, 0x228899, 0xcccccc];
+
+let _agents = [];
+let _graph  = null; // nodeId → [{ roadId, otherNodeId }]
+let _roads  = null; // roadId → { pts, len, nodeA, nodeB }
+
+// ── Path helpers ─────────────────────────────────────────────────
+
+function _sampleRoad(road, nodeMap) {
+  const a = nodeMap.get(road.nodeA), b = nodeMap.get(road.nodeB);
+  if (!a || !b) return null;
+  const raw = [{ x: a.x, z: a.z }, ...(road.waypoints || []), { x: b.x, z: b.z }];
+  const result = [];
+  const segs = raw.length - 1;
+  for (let i = 0; i <= segs * SAMPLE_STEPS; i++) {
+    const t = i / (segs * SAMPLE_STEPS);
+    const seg = Math.min(Math.floor(t * segs), segs - 1);
+    const f = t * segs - seg;
+    const p0 = raw[seg], p1 = raw[seg + 1];
+    result.push({ x: p0.x + (p1.x - p0.x) * f, z: p0.z + (p1.z - p0.z) * f });
+  }
+  return result;
+}
+
+function _roadLen(pts) {
+  let len = 0;
+  for (let i = 1; i < pts.length; i++)
+    len += Math.hypot(pts[i].x - pts[i - 1].x, pts[i].z - pts[i - 1].z);
+  return len;
+}
+
+// ── Build road graph ─────────────────────────────────────────────
+
+function _buildGraph(mapData) {
+  const nodeMap = new Map();
+  for (const n of (mapData.nodes || [])) nodeMap.set(n.id, n);
+
+  _graph = new Map();
+  _roads = new Map();
+
+  for (const road of (mapData.roads || [])) {
+    const pts = _sampleRoad(road, nodeMap);
+    if (!pts || pts.length < 2) continue;
+    _roads.set(road.id, { pts, len: _roadLen(pts), nodeA: road.nodeA, nodeB: road.nodeB });
+
+    if (!_graph.has(road.nodeA)) _graph.set(road.nodeA, []);
+    if (!_graph.has(road.nodeB)) _graph.set(road.nodeB, []);
+    _graph.get(road.nodeA).push({ roadId: road.id, otherNodeId: road.nodeB });
+    _graph.get(road.nodeB).push({ roadId: road.id, otherNodeId: road.nodeA });
+  }
+}
+
+// ── Simple traffic car mesh ───────────────────────────────────────
+
+function _makeCarMesh(color) {
+  const g = new THREE.Group();
+  const body = new THREE.Mesh(
+    new THREE.BoxGeometry(2.0, 0.9, 4.0),
+    new THREE.MeshLambertMaterial({ color })
+  );
+  body.position.y = 0.55;
+  const roof = new THREE.Mesh(
+    new THREE.BoxGeometry(1.6, 0.65, 2.2),
+    new THREE.MeshLambertMaterial({ color })
+  );
+  roof.position.set(0, 1.32, 0.1);
+  const wMat = new THREE.MeshLambertMaterial({ color: 0x222222 });
+  const wGeo = new THREE.CylinderGeometry(0.38, 0.38, 0.22, 8);
+  const wOff = [[0.95, 0.38, 1.4], [-0.95, 0.38, 1.4], [0.95, 0.38, -1.4], [-0.95, 0.38, -1.4]];
+  for (const [wx, wy, wz] of wOff) {
+    const w = new THREE.Mesh(wGeo, wMat);
+    w.rotation.z = Math.PI / 2; w.position.set(wx, wy, wz);
+    g.add(w);
+  }
+  g.add(body); g.add(roof);
+  g.castShadow = true;
+  g.userData.trk = true;
+  return g;
+}
+
+// ── Spawn helpers ─────────────────────────────────────────────────
+
+function _randomRoadEntry() {
+  const roadIds = [..._roads.keys()];
+  if (!roadIds.length) return null;
+  const roadId = roadIds[Math.floor(Math.random() * roadIds.length)];
+  const rd = _roads.get(roadId);
+  const forward = Math.random() < 0.5;
+  const ptIdx = Math.floor(Math.random() * rd.pts.length);
+  return { roadId, forward, ptIdx };
+}
+
+// ── Build / destroy ───────────────────────────────────────────────
+
+export function buildTraffic(mapData) {
+  destroyTraffic();
+  _buildGraph(mapData);
+  if (!_roads.size) return;
+
+  for (let i = 0; i < TRAFFIC_COUNT; i++) {
+    const entry = _randomRoadEntry();
+    if (!entry) continue;
+    const rd = _roads.get(entry.roadId);
+    const pt = rd.pts[entry.ptIdx];
+    const speed = TRAFFIC_SPD_MIN + Math.random() * (TRAFFIC_SPD_MAX - TRAFFIC_SPD_MIN);
+    const color = TRAFFIC_COLORS[i % TRAFFIC_COLORS.length];
+    const mesh = _makeCarMesh(color);
+
+    // Compute initial heading from road direction
+    const nextIdx = Math.min(entry.ptIdx + 1, rd.pts.length - 1);
+    const prevIdx = Math.max(entry.ptIdx - 1, 0);
+    const np = rd.pts[nextIdx], pp = rd.pts[prevIdx];
+    const hdg = Math.atan2(np.x - pp.x, np.z - pp.z);
+
+    mesh.position.set(pt.x, 0, pt.z);
+    mesh.rotation.y = hdg;
+    scene.add(mesh);
+
+    _agents.push({ mesh, roadId: entry.roadId, ptIdx: entry.ptIdx, forward: entry.forward, speed, hdg, prevRoadId: -1 });
+  }
+}
+
+export function destroyTraffic() {
+  for (const a of _agents) scene.remove(a.mesh);
+  _agents = [];
+  _graph  = null;
+  _roads  = null;
+}
+
+// ── Per-frame update ──────────────────────────────────────────────
+
+export function updateTraffic(dt, playerCar, enableCollisions) {
+  if (!_agents.length || !_roads) return;
+
+  for (const a of _agents) {
+    const rd = _roads.get(a.roadId);
+    if (!rd) continue;
+    const pts = rd.pts;
+
+    // Advance along road
+    const dist = a.speed * dt;
+    let rem = dist;
+    while (rem > 0) {
+      const next = a.forward ? a.ptIdx + 1 : a.ptIdx - 1;
+      if (next < 0 || next >= pts.length) {
+        // Reached end of road — pick next road
+        const endNode = a.forward ? rd.nodeB : rd.nodeA;
+        const conns = _graph ? (_graph.get(endNode) || []) : [];
+        const choices = conns.filter(e => e.roadId !== a.prevRoadId || conns.length === 1);
+        if (!choices.length) {
+          // Dead end — reverse
+          a.forward = !a.forward;
+          break;
+        }
+        const pick = choices[Math.floor(Math.random() * choices.length)];
+        a.prevRoadId = a.roadId;
+        a.roadId = pick.roadId;
+        const newRd = _roads.get(pick.roadId);
+        if (!newRd) break;
+        a.forward = (newRd.nodeA === endNode);
+        a.ptIdx   = a.forward ? 0 : newRd.pts.length - 1;
+        break;
+      }
+      const cur  = pts[a.ptIdx];
+      const nxt  = pts[next];
+      const segD = Math.hypot(nxt.x - cur.x, nxt.z - cur.z);
+      if (rem >= segD) { rem -= segD; a.ptIdx = next; }
+      else { break; }
+    }
+
+    // Steer toward lookahead point
+    const targetIdx = a.forward
+      ? Math.min(a.ptIdx + LOOKAHEAD, pts.length - 1)
+      : Math.max(a.ptIdx - LOOKAHEAD, 0);
+    const tp = pts[targetIdx];
+    const cur = pts[a.ptIdx];
+    const desiredHdg = Math.atan2(tp.x - cur.x, tp.z - cur.z);
+
+    let dh = desiredHdg - a.hdg;
+    if (dh >  Math.PI) dh -= Math.PI * 2;
+    if (dh < -Math.PI) dh += Math.PI * 2;
+    a.hdg += Math.sign(dh) * Math.min(Math.abs(dh), STEER_RATE * dt);
+
+    // Move car
+    const p = pts[a.ptIdx];
+    a.mesh.position.set(p.x, 0, p.z);
+    a.mesh.rotation.y = a.hdg;
+  }
+
+  // Collision with player car
+  if (enableCollisions && playerCar) {
+    const px = playerCar.pos.x, pz = playerCar.pos.z;
+    for (const a of _agents) {
+      const tp = a.mesh.position;
+      const dx = px - tp.x, dz = pz - tp.z;
+      const d  = Math.sqrt(dx * dx + dz * dz);
+      if (d < 3.5 && d > 0.01) {
+        const overlap = 3.5 - d;
+        const nx = dx / d, nz = dz / d;
+        playerCar.pos.x += nx * overlap * 0.6;
+        playerCar.pos.z += nz * overlap * 0.6;
+        playerCar.spd    *= 0.6;
+        if (playerCar.isReversing) playerCar.revSpd *= 0.6;
+        playerCar.mesh.position.copy(playerCar.pos);
+        // Nudge traffic car slightly
+        tp.x -= nx * overlap * 0.4;
+        tp.z -= nz * overlap * 0.4;
+      }
+    }
+  }
+
+  // Show on minimap — handled externally via getTrafficPositions()
+}
+
+export function getTrafficPositions() {
+  return _agents.map(a => ({ x: a.mesh.position.x, z: a.mesh.position.z }));
+}

--- a/games/turborace/scripts/freedrive.js
+++ b/games/turborace/scripts/freedrive.js
@@ -21,6 +21,7 @@ import { buildTrack } from './track-gen.js';
 import {
   buildDriveMap, getDriveMapWorld, applyDriveMapBounds, buildDriveMapMinimap,
 } from './freedrive-custommap.js';
+import { buildTraffic, destroyTraffic, updateTraffic, getTrafficPositions } from './freedrive-traffic.js';
 import { notify } from './notify.js';
 
 // ═══════════════════════════════════════════════════════
@@ -63,6 +64,16 @@ export function showFreeDriveMenu(){
   _syncFdColorPicker();
   const tgl = document.getElementById('fdOnlineToggle');
   if(tgl) tgl.checked = state.fdOnline;
+  const trafficSec = document.getElementById('fdTrafficSection');
+  if(trafficSec) trafficSec.style.display = state.fdCustomMapData ? '' : 'none';
+  const trafficTgl = document.getElementById('fdTrafficToggle');
+  if(trafficTgl){
+    trafficTgl.checked = state.fdTrafficEnabled;
+    const collRow = document.getElementById('fdTrafficCollisionsRow');
+    if(collRow) collRow.style.display = state.fdTrafficEnabled ? '' : 'none';
+  }
+  const collTgl = document.getElementById('fdTrafficCollisionsToggle');
+  if(collTgl) collTgl.checked = state.fdTrafficCollisions;
   const lbl = document.getElementById('fdMyNameLabel');
   if(lbl) lbl.textContent = getArcadeUser().name || 'Anonymous';
   _setFdStatus('');
@@ -113,6 +124,7 @@ export async function startFreeDrive(){
     fdWorldId = `drivemap-fd-${String(mapData.id).replace(/[^a-z0-9_-]/gi, '-')}`;
     const mm = buildDriveMapMinimap(mapData);
     _mapCanvas = mm.canvas; _mapScale = mm.scale; _mapCenterX = mm.cx; _mapCenterZ = mm.cz;
+    if(state.fdTrafficEnabled) buildTraffic(mapData);
   } else if(selMap === 'island'){
     const world = buildFreeDriveWorld();
     setupLights();
@@ -224,6 +236,7 @@ function _teardownSession(){
 // Registered as state.fdCleanup — called by showMain when leaving the mode.
 function _quitCleanup(){
   _teardownSession();
+  destroyTraffic();
   state.fdMode = false; state.fdCleanup = null; state.fdTrackData = null; state.fdCustomMapData = null;
   document.getElementById('raceTop').style.display = '';
   document.getElementById('pos').style.display = '';
@@ -422,6 +435,9 @@ export function updateFreeDrive(dt){
   if(world) _applyWorldBounds(car, world);
   else if(state.fdCustomMapData) applyDriveMapBounds(car);
 
+  if(state.fdCustomMapData && state.fdTrafficEnabled)
+    updateTraffic(dt, car, state.fdTrafficCollisions);
+
   _updateRemoteCars(dt);
   _broadcastPos(dt);
   resolveCarCollisions([car, ...Object.values(fdRemote).filter(r => r.hasPos).map(r => r.car)]);
@@ -534,6 +550,13 @@ function _drawFdMinimap(){
   const ctx = mmctx, S = 150, half = S / 2;
   ctx.clearRect(0, 0, S, S);
   ctx.drawImage(_mapCanvas, 0, 0);
+  if(state.fdCustomMapData && state.fdTrafficEnabled){
+    for(const tp of getTrafficPositions()){
+      ctx.beginPath();
+      ctx.arc(half + (tp.x - _mapCenterX) * _mapScale, half + (tp.z - _mapCenterZ) * _mapScale, 2.5, 0, Math.PI * 2);
+      ctx.fillStyle = '#ff8833'; ctx.fill();
+    }
+  }
   for(const r of Object.values(fdRemote)){
     if(!r.hasPos) continue;
     ctx.beginPath();

--- a/games/turborace/scripts/game.js
+++ b/games/turborace/scripts/game.js
@@ -287,6 +287,12 @@ document.getElementById('fdBackBtn').addEventListener('click',function(){void sh
 document.getElementById('fdStartBtn').addEventListener('click',function(){tryStartMenuMusic();void startFreeDrive();});
 document.getElementById('fdColor').addEventListener('input',e=>onFdColorInput(e.target.value));
 document.getElementById('fdOnlineToggle').addEventListener('change',e=>{ state.fdOnline=e.target.checked; });
+document.getElementById('fdTrafficToggle').addEventListener('change',e=>{
+  state.fdTrafficEnabled=e.target.checked;
+  const collRow=document.getElementById('fdTrafficCollisionsRow');
+  if(collRow) collRow.style.display=e.target.checked?'':'none';
+});
+document.getElementById('fdTrafficCollisionsToggle').addEventListener('change',e=>{ state.fdTrafficCollisions=e.target.checked; });
 document.getElementById('trackEditorBtn').addEventListener('click',function(){tryStartMenuMusic();showTrackEditor();});
 document.getElementById('mainSettingsBtn').addEventListener('click',function(){tryStartMenuMusic();showSettings();});
 document.getElementById('backToSelectionBtn').addEventListener('click',()=>{ window.location.href='../index.html'; });

--- a/games/turborace/scripts/state.js
+++ b/games/turborace/scripts/state.js
@@ -97,4 +97,6 @@ export const state = {
     fdSelMap: 'island',      // 'island', a track ID, or a drive-map ID string
     fdTrackData: null,       // null for island/drivemap mode, track data object for track mode
     fdCustomMapData: null,   // null unless a drive-map-editor map is selected
+    fdTrafficEnabled: false, // AI traffic cars on custom maps
+    fdTrafficCollisions: false, // collide with AI traffic
 };


### PR DESCRIPTION
## Summary

- Fix scenery rendering on custom maps by removing generated-asset skip filter
- Improve asset rendering: trees with trunks, tall city buildings with emissive windows, parks with tree clusters
- Add Curvy Roads toggle + intensity slider in the editor road tool
- Add AI traffic system with 8 cars following road paths at configurable speeds
- Traffic system activates only on custom free-ride maps with toggle in setup menu

---
_Generated by [Claude Code](https://claude.ai/code/session_01PCn89Sv2gpdG9ZYFar8Co2)_