### PR TITLE
ai-trainer: remove ES + dynamic gamma, add toggleable PPO mods

### DIFF
--- a/games/ai-trainer/index.html
+++ b/games/ai-trainer/index.html
@@ -393,7 +393,6 @@
   <span class="hud-chip" id="hudBest">REWARD —</span>
   <span class="hud-chip" id="hudAvg">BEST LAP —</span>
   <span class="hud-chip" id="hudSigma" title="Policy exploration noise σ (steer/throttle) — shrinks as AI gets confident">σ —</span>
-  <span class="hud-chip" id="hudGamma" title="Discount factor γ — rises automatically when the reward stagnates (longer planning horizon), eases back on progress" style="color:#8af;">γ —</span>
   <span class="hud-chip" id="hudWasm" title="Gradient compute backend — GPU = TensorFlow.js on WebGL, WASM = compiled native code, JS = fallback" style="color:#888;font-size:.65rem;">…</span>
   <span class="hud-sep">│</span>
   <span class="hud-chip" id="hudTrack" style="color:#4af;">—</span>
@@ -414,41 +413,27 @@
 <div id="controls">
 
   <div class="ctrl-section">
-    <div class="ctrl-title live-title" id="liveTitle">⚡ LIVE — PPO</div>
+    <div class="ctrl-title live-title">⚡ LIVE — PPO</div>
     <div class="ctrl-row">
       <span class="ctrl-label">SPEED</span>
       <span class="ctrl-val" id="speedVal">1×</span>
       <input type="range" id="speedSlider" min="1" max="200" value="1" step="1">
     </div>
-    <div class="ctrl-row" id="lrRow">
+    <div class="ctrl-row">
       <span class="ctrl-label">LEARN RATE</span>
       <span class="ctrl-val" id="lrVal">3.0e-4</span>
       <input type="range" id="lrSlider" min="0.00002" max="0.001" value="0.0003" step="0.00002" style="accent-color:#c8f;">
     </div>
-    <div class="ctrl-row" id="entRow">
+    <div class="ctrl-row">
       <span class="ctrl-label">ENTROPY</span>
       <span class="ctrl-val" id="entVal">0.0030</span>
       <input type="range" id="entSlider" min="0" max="0.02" value="0.003" step="0.0005" style="accent-color:#c8f;">
-    </div>
-    <div class="ctrl-row" id="esLrRow" style="display:none" title="ES learning rate — how far the weights move along the rank-weighted noise direction each generation">
-      <span class="ctrl-label">ES LEARN RATE</span>
-      <span class="ctrl-val" id="esLrVal">0.020</span>
-      <input type="range" id="esLrSlider" min="0.002" max="0.1" value="0.02" step="0.002" style="accent-color:#c8f;">
-    </div>
-    <div class="ctrl-row" id="esSigmaRow" style="display:none" title="Parameter-noise σ — how different each car's perturbed brain is from the base network (applies from the next generation)">
-      <span class="ctrl-label">NOISE σ</span>
-      <span class="ctrl-val" id="esSigmaVal">0.10</span>
-      <input type="range" id="esSigmaSlider" min="0.02" max="0.4" value="0.1" step="0.01" style="accent-color:#c8f;">
     </div>
     <div class="ctrl-row">
       <span class="ctrl-label">EPISODE LEN</span>
       <span class="ctrl-val" id="epLenVal">60s</span>
       <input type="range" id="epLenSlider" min="15" max="120" value="60" step="5" style="accent-color:#4fa;">
     </div>
-    <label class="toggle-row" id="gammaRow" title="Adapt the discount γ to training progress — it rises a bit whenever the reward has stagnated for a long time (longer planning horizon), and eases back once the reward improves again">
-      <span>AUTO γ (HORIZON)</span>
-      <input type="checkbox" id="gammaToggle" checked>
-    </label>
     <label class="toggle-row" title="Spawn each episode at a random point on the track — much better state coverage">
       <span>RANDOM SPAWN</span>
       <input type="checkbox" id="spawnToggle" checked>
@@ -462,6 +447,31 @@
       <span class="ctrl-val" id="popVal">8</span>
       <input type="range" id="popSlider" min="1" max="32" value="8" step="1" style="accent-color:#4af;">
     </div>
+  </div>
+
+  <div class="ctrl-section">
+    <div class="ctrl-title live-title">🧬 PPO MODS (LIVE)</div>
+    <label class="toggle-row" title="Left↔right symmetry augmentation — every transition is also trained mirrored (steer flipped, sensors reflected). Doubles the training data per physics step.">
+      <span>MIRROR AUGMENT</span>
+      <input type="checkbox" id="mirrorToggle">
+    </label>
+    <label class="toggle-row" title="Stop the update's epochs early once the policy has moved a KL-threshold away from the collected data — saves wasted epochs and prevents destructive over-updates.">
+      <span>KL EARLY STOP</span>
+      <input type="checkbox" id="klToggle" checked>
+    </label>
+    <label class="toggle-row" title="Every 10 updates: recycle dead neurons (no influence — fresh random inputs, outputs zeroed) and split the most overtuned neuron into the most useless slot (half the outgoing weight each — output unchanged, pressure halved). Stabilizes top-heavy networks.">
+      <span>NEURON REPAIR</span>
+      <input type="checkbox" id="repairToggle">
+    </label>
+    <div class="ctrl-row" title="Fraction of actor weights that are 'defect' (dead) for each agent's own acting copy during its episode. The real network trains unmasked — the policy learns not to depend on any single connection.">
+      <span class="ctrl-label">FAILURE RATE</span>
+      <span class="ctrl-val" id="failVal">0%</span>
+      <input type="range" id="failSlider" min="0" max="0.15" value="0" step="0.01" style="accent-color:#f84;">
+    </div>
+    <div class="ctrl-actions">
+      <button class="btn" id="repairNowBtn" title="Run one neuron-repair pass right now">🔧 REPAIR NOW</button>
+    </div>
+    <div id="modsStatus" style="color:#667;font-size:.6rem;margin-top:6px;"></div>
   </div>
 
   <div class="ctrl-section" title="The trainer keeps a snapshot of the network whose recent episodes had the best AVERAGE return across all agents — judged by how well everyone does with it, not by one lucky run. EXPORT saves this snapshot.">
@@ -521,7 +531,7 @@
 <!-- ── Map selection menu (shown before the trainer) ─────────────────────── -->
 <div id="mapMenu">
   <div id="mapMenuTitle">🧠 AI TRAINER</div>
-  <div id="mapMenuSub">PPO / EVOLUTION TRAINING · SELECT A MAP TO TRAIN ON</div>
+  <div id="mapMenuSub">PPO REINFORCEMENT LEARNING · SELECT A MAP TO TRAIN ON</div>
   <div id="mapCards"></div>
   <div class="map-menu-actions">
     <button class="btn btn-big" id="mapBackBtn">← ARCADE</button>
@@ -560,8 +570,8 @@
           <span class="config-label">PARALLEL AGENTS</span>
           <span class="config-val" id="configAgentVal">8 agents</span>
         </div>
-        <input type="range" id="configAgentSlider" min="2" max="32" value="8" step="2" style="accent-color:#4af;">
-        <span style="color:#445;font-size:.58rem;">more agents = more diverse experience per update — EVOLUTION wants 16+ (its population size)</span>
+        <input type="range" id="configAgentSlider" min="2" max="32" value="8" step="1" style="accent-color:#4af;">
+        <span style="color:#445;font-size:.58rem;">more agents = more diverse experience per update (rounded to a multiple of the group size)</span>
       </div>
       <div class="config-row">
         <div style="display:flex;justify-content:space-between">
@@ -583,16 +593,16 @@
     <div class="config-panel">
       <div class="config-panel-title">📊 TRAINING</div>
       <div class="config-row">
-        <span class="config-label">ALGORITHM</span>
-        <div class="opt-group" id="configAlgoBtns"></div>
-        <span style="color:#445;font-size:.58rem;">PPO = gradient learning, smooth progress · EVOLUTION = forward passes only, near-zero update cost — wants many agents and a high speed multiplier</span>
+        <span class="config-label">AGENT GROUPS</span>
+        <div class="opt-group" id="configGroupBtns"></div>
+        <span style="color:#445;font-size:.58rem;">groups spawn together at the same spot; each agent's advantage is its return vs the group average (GRPO-style — replaces the critic). Raise AGENTS so several groups run in parallel.</span>
       </div>
-      <div class="config-row" id="configBackendRow">
+      <div class="config-row">
         <span class="config-label">COMPUTE BACKEND</span>
         <div class="opt-group" id="configBackendBtns"></div>
         <span style="color:#445;font-size:.58rem;">AUTO = multi-core WASM · GPU = TensorFlow.js on WebGL (stable everywhere, no WebGPU) · JS = plain fallback</span>
       </div>
-      <div class="config-row" id="configThreadRow">
+      <div class="config-row">
         <div style="display:flex;justify-content:space-between">
           <span class="config-label">GRADIENT THREADS</span>
           <span class="config-val" id="configThreadVal">4 threads</span>
@@ -600,12 +610,12 @@
         <input type="range" id="configThreadSlider" min="1" max="64" value="4" step="1" style="accent-color:#4fa;">
         <span style="color:#445;font-size:.58rem;">CPU worker count for WASM/JS backends — more than your core count wastes memory</span>
       </div>
-      <div class="config-row" id="configHorizonRow">
+      <div class="config-row">
         <span class="config-label">STEPS PER UPDATE (HORIZON)</span>
         <div class="opt-group" id="configHorizonBtns"></div>
         <span style="color:#445;font-size:.58rem;">more steps = better gradient estimate, slower update</span>
       </div>
-      <div class="config-row" id="configLrRow">
+      <div class="config-row">
         <div style="display:flex;justify-content:space-between">
           <span class="config-label">LEARNING RATE</span>
           <span class="config-val" id="configLrVal">3.0e-4</span>
@@ -613,29 +623,13 @@
         <input type="range" id="configLrSlider" min="0.00005" max="0.001" value="0.0003" step="0.00005" style="accent-color:#c8f;">
         <span style="color:#445;font-size:.58rem;">how fast the network learns — too high = unstable</span>
       </div>
-      <div class="config-row" id="configEntRow">
+      <div class="config-row">
         <div style="display:flex;justify-content:space-between">
           <span class="config-label">ENTROPY (EXPLORATION)</span>
           <span class="config-val" id="configEntVal">0.0030</span>
         </div>
         <input type="range" id="configEntSlider" min="0" max="0.02" value="0.003" step="0.0005" style="accent-color:#c8f;">
         <span style="color:#445;font-size:.58rem;">higher = more random actions early on, helps explore</span>
-      </div>
-      <div class="config-row" id="configEsLrRow" style="display:none">
-        <div style="display:flex;justify-content:space-between">
-          <span class="config-label">ES LEARNING RATE</span>
-          <span class="config-val" id="configEsLrVal">0.020</span>
-        </div>
-        <input type="range" id="configEsLrSlider" min="0.002" max="0.1" value="0.02" step="0.002" style="accent-color:#c8f;">
-        <span style="color:#445;font-size:.58rem;">step size along the rank-weighted noise direction each generation</span>
-      </div>
-      <div class="config-row" id="configEsSigmaRow" style="display:none">
-        <div style="display:flex;justify-content:space-between">
-          <span class="config-label">PARAMETER NOISE σ</span>
-          <span class="config-val" id="configEsSigmaVal">0.10</span>
-        </div>
-        <input type="range" id="configEsSigmaSlider" min="0.02" max="0.4" value="0.1" step="0.01" style="accent-color:#c8f;">
-        <span style="color:#445;font-size:.58rem;">how different each car's perturbed brain is — exploration lives here</span>
       </div>
     </div>
 
@@ -648,7 +642,7 @@
 </div>
 
 <!-- ── Hint ──────────────────────────────────────────────────────────────── -->
-<div id="hint">DRAG=PAN · SCROLL=ZOOM · SIM ON WORKER THREAD · RENDERING ON MAIN THREAD · PPO UPDATES ON MULTI-CORE WORKER POOL · ES UPDATES INLINE</div>
+<div id="hint">DRAG=PAN · SCROLL=ZOOM · SIM ON WORKER THREAD · RENDERING ON MAIN THREAD · PPO UPDATES ON MULTI-CORE WORKER POOL</div>
 
 <script type="module" src="./scripts/trainer-app.js"></script>
 </body>

--- a/games/ai-trainer/scripts/sim-worker.js
+++ b/games/ai-trainer/scripts/sim-worker.js
@@ -3,20 +3,29 @@
 import { Net, gauss, LOG_2PI, accumulatePPOGrads } from './nn-core.js';
 
 // ─────────────────────────────────────────────────────────────────────────────
-//  AI Trainer — Simulation Worker (PPO / ES)
+//  AI Trainer — Simulation Worker (PPO + optional mods)
 //
 //  Runs entirely off the main thread. No DOM, no Three.js.
-//  Two selectable algorithms (cfg.algo, restart required):
-//    · PPO — gradient-based: actor-critic MLPs with manual backprop, Adam,
-//      GAE(λ), clipped surrogate + entropy bonus. The discount γ adapts to
-//      training progress (rises when the reward stagnates — see adaptGamma).
-//    · ES  — evolution strategies (OpenAI-style, antithetic + rank shaping):
-//      each parallel car runs one episode with parameter-noise-perturbed
-//      weights; the update is a rank-weighted sum of the noise. Forward
-//      passes only — no critic, no backprop, no gradient workers, no GPU —
-//      so nearly all compute goes into the simulation itself.
-//  Both share the actor MLP (tanh hidden, linear output) and N parallel
-//  environments.
+//  Implements Proximal Policy Optimization with:
+//    · actor-critic MLPs (tanh hidden, linear output) with manual backprop
+//    · Adam optimizer
+//    · GAE(λ) advantage estimation
+//    · clipped surrogate objective + entropy bonus
+//    · N parallel environments sharing one policy
+//
+//  Optional PPO mods (cfg flags, see each section):
+//    · groupSize    — GRPO-style agent groups: members spawn together, the
+//                     advantage is each member's return relative to the group
+//                     average (no critic / GAE needed)
+//    · mirror       — left↔right symmetry augmentation: every transition is
+//                     also trained mirrored, doubling data per physics step
+//    · klStop       — stop update epochs early once the policy has moved a
+//                     KL-threshold away from the data (saves wasted epochs)
+//    · neuronRepair — periodically recycle dead hidden neurons and split
+//                     dominant ones into a useless slot (function-preserving)
+//    · failRate     — fraction of actor weights that are "defect" (zeroed)
+//                     for each agent's own acting copy during collection;
+//                     the real network trains unmasked
 //
 //  Observations include fixed centerline look-ahead probes (relative angle +
 //  slope at several distances ahead), so the policy can anticipate corners
@@ -46,15 +55,9 @@ let cfg = {
   episodeLen: 60,        // seconds before truncation
   randomSpawn: true,     // spawn each episode at a random centerline point
   actionRepeat: 2,       // physics ticks per agent decision (restart required)
-  // algorithm
-  algo: 'ppo',           // 'ppo' | 'es' — restart required
-  // ES hyperparameters (both live; σ applies from the next generation)
-  esSigma: 0.1,          // parameter-noise std
-  esLr: 0.02,            // ES learning rate (Adam on the rank-weighted noise sum)
   // PPO hyperparameters
   lr: 3e-4,
-  gamma: 0.99,           // base discount; the live value adapts when gammaAuto
-  gammaAuto: true,       // raise γ while the reward stagnates (live)
+  gamma: 0.99,
   lam: 0.95,
   clip: 0.2,
   entropyCoef: 0.003,
@@ -66,6 +69,13 @@ let cfg = {
   hiddenLayers: 1,       // restart required
   backend: 'auto',       // 'auto' | 'gpu' | 'wasm' | 'js' — restart required
   threads: 0,            // gradient worker count, 0 = auto (cores − 2, max 6)
+  // PPO mods
+  groupSize: 1,          // >1: GRPO-style agent groups (restart required)
+  mirror: false,         // left↔right symmetry augmentation (live)
+  klStop: true,          // KL-based early stop of update epochs (live)
+  klLimit: 0.025,        // KL movement allowed per update before stopping
+  neuronRepair: false,   // periodic dead-neuron recycle + dominant split (live)
+  failRate: 0,           // fraction of "defect" actor weights per agent (live)
   // reward shaping
   progressReward: 0.2,   // per metre of forward progress along the centerline
   gravelPenalty: 1.0,    // per second on gravel
@@ -521,18 +531,56 @@ function buildObs(car, out) {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-//  Agent — actor MLP shared by both algorithms; critic/logStd are PPO-only
+//  Mirror augmentation (cfg.mirror) — the track problem is left↔right
+//  symmetric, so every real transition has an equally valid mirror twin:
+//  reflect the observation, negate the steering. Trained alongside the
+//  original it doubles the data per physics step and bakes the symmetry
+//  into the policy instead of waiting for it to be learned twice.
+//
+//  Index map (must match the buildObs layout above):
+//    0..10   long rays    — symmetric fan → reverse
+//    11..17  edge rays    — symmetric fan → reverse
+//    18 speed · 20 |centerline dist| · 21 gravel · 22 reversing · 23 slope — keep
+//    19      heading error — negate
+//    24+2k   probe angle   — negate;  25+2k probe slope — keep
+//    36..39  memory cells  — keep (no spatial meaning; their actions are
+//            kept too, so the mirrored pair stays self-consistent)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function mirrorObsInto(src, dst) {
+  for (let k = 0; k <= 10; k++) dst[k] = src[10 - k];
+  for (let k = 11; k <= 17; k++) dst[k] = src[28 - k];
+  dst[18] = src[18];
+  dst[19] = -src[19];
+  dst[20] = src[20];
+  dst[21] = src[21];
+  dst[22] = src[22];
+  dst[23] = src[23];
+  for (let p = 0; p < PROBE_DISTS.length; p++) {
+    dst[24 + 2 * p] = -src[24 + 2 * p];
+    dst[25 + 2 * p] = src[25 + 2 * p];
+  }
+  for (let d = 0; d < MEM_DIM; d++) dst[MEM_OBS + d] = src[MEM_OBS + d];
+  return dst;
+}
+
+export function mirrorActInto(src, dst) {
+  dst[0] = -src[0];                                   // steer flips
+  for (let d = 1; d < ACT_DIM; d++) dst[d] = src[d];  // throttle + memory keep
+  return dst;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  PPO agent
 // ─────────────────────────────────────────────────────────────────────────────
 
 const ACT_DIM = 2 + MEM_DIM; // [steer, throttle/brake, 4 memory-cell deltas]
 
-let actor  = null;          // Net [OBS_DIM, h, ACT_DIM] → action means (ES: base θ)
-let critic = null;          // PPO: Net [OBS_DIM, h, 1] → state value
-let logStd = null;          // PPO: Float64Array(ACT_DIM), learnable
+let actor  = null;          // Net [OBS_DIM, h, ACT_DIM] → action means
+let critic = null;          // Net [OBS_DIM, h, 1] → state value
+let logStd = null;          // Float64Array(ACT_DIM), learnable
 let lsM = null, lsV = null; // Adam moments for logStd
 let lsT = 0;
-
-const isES = () => cfg.algo === 'es';
 
 function initAgent(modelOverride) {
   const h = cfg.hiddenSize, nl = Math.max(1, cfg.hiddenLayers | 0);
@@ -544,13 +592,8 @@ function initAgent(modelOverride) {
   lsM = new Float64Array(ACT_DIM);
   lsV = new Float64Array(ACT_DIM);
   lsT = 0;
-  if (modelOverride) {
+  if (modelOverride && modelOverride.algo === 'ppo') {
     try {
-      // The actor transfers freely between PPO and ES (same network shape);
-      // PPO's critic/logStd are restored only from a PPO export.
-      if (modelOverride.algo !== 'ppo' && modelOverride.algo !== 'es') {
-        throw new Error(`unsupported model type '${modelOverride.algo}'`);
-      }
       const mSizes = modelOverride.actor.sizes;
       if (modelOverride.obsDim !== OBS_DIM || mSizes[mSizes.length - 1] !== ACT_DIM) {
         throw new Error(`incompatible model: expects obs ${modelOverride.obsDim}/act ${mSizes[mSizes.length - 1]}, ` +
@@ -558,51 +601,15 @@ function initAgent(modelOverride) {
       }
       actor  = new Net(modelOverride.actor.sizes, 1);
       actor.loadFlat(modelOverride.actor.flat);
-      if (modelOverride.algo === 'ppo') {
-        critic = new Net(modelOverride.critic.sizes, 1);
-        critic.loadFlat(modelOverride.critic.flat);
-        logStd = Float64Array.from(modelOverride.logStd);
-        lsM = new Float64Array(ACT_DIM);
-        lsV = new Float64Array(ACT_DIM);
-        lsT = 0;
-      }
-      // es → ppo: the fresh critic/logStd above stay (value net retrains)
+      critic = new Net(modelOverride.critic.sizes, 1);
+      critic.loadFlat(modelOverride.critic.flat);
+      logStd = Float64Array.from(modelOverride.logStd);
+      lsM = new Float64Array(ACT_DIM);
+      lsV = new Float64Array(ACT_DIM);
+      lsT = 0;
     } catch (err) {
       postMessage({ type: 'error', message: 'Model import failed: ' + err.message });
     }
-  }
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-//  Adaptive discount γ (PPO) — the configured cfg.gamma is the BASE; the live
-//  value gammaNow drifts up toward GAMMA_MAX while the average return has
-//  stagnated for a while (a longer credit-assignment horizon often breaks a
-//  plateau, e.g. when the policy must brake NOW for a reward many seconds
-//  away), and eases back toward the base once the reward improves again.
-// ─────────────────────────────────────────────────────────────────────────────
-
-const GAMMA_MAX = 0.998;            // effective horizon cap ≈ 500 decisions
-const GAMMA_STAGNATION_UPDATES = 8; // updates without improvement per raise
-
-let gammaNow = cfg.gamma;
-let gammaBestAvg = -Infinity;       // best windowed avg return seen so far
-let gammaLastProgress = 0;          // iteration of the last improvement/raise
-
-function adaptGamma() {
-  if (!cfg.gammaAuto) { gammaNow = cfg.gamma; return; }
-  if (curAvg == null) return;       // not enough finished episodes yet
-  const thr = gammaBestAvg === -Infinity
-    ? -Infinity
-    : Math.max(0.5, Math.abs(gammaBestAvg) * 0.01);
-  if (curAvg > gammaBestAvg + thr) {
-    gammaBestAvg = curAvg;
-    gammaLastProgress = iteration;
-    // reward is moving again — ease back toward the configured base
-    gammaNow += (cfg.gamma - gammaNow) * 0.25;
-  } else if (iteration - gammaLastProgress >= GAMMA_STAGNATION_UPDATES) {
-    // long stagnation — push the horizon out a bit (γ: 0.990 → 0.992 → …)
-    gammaNow = Math.min(GAMMA_MAX, 1 - (1 - gammaNow) * 0.8);
-    gammaLastProgress = iteration;  // at most one raise per stagnation window
   }
 }
 
@@ -617,6 +624,171 @@ function logProb(act, mean) {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+//  Weight-failure mode (cfg.failRate) — each agent acts through its own copy
+//  of the actor in which a random fraction of weights is "defect" (zeroed).
+//  The defects last for the agent's current episode; the REAL network is
+//  trained unmasked (PPO's importance ratio absorbs the behavior mismatch,
+//  since the stored log-prob comes from the masked acting copy). Forces the
+//  policy not to rely on any single connection — like dropout, but in the
+//  world instead of the optimizer.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function rollFailMask(env) {
+  const P = actor.paramCount();
+  if (!env.failMask || env.failMask.length !== P) env.failMask = new Uint8Array(P);
+  else env.failMask.fill(0);
+  const p = Math.min(0.5, cfg.failRate);
+  for (let k = 0; k < P; k++) if (Math.random() < p) env.failMask[k] = 1;
+  applyFailMask(env);
+}
+
+// (Re)build the agent's acting copy from the CURRENT weights + its mask.
+function applyFailMask(env) {
+  const flat = actor.flatF64();
+  for (let k = 0; k < flat.length; k++) if (env.failMask[k]) flat[k] = 0;
+  if (!env.actNet || env.actNet.paramCount() !== flat.length) env.actNet = new Net(actor.sizes, 1);
+  env.actNet.loadFlat(flat);
+}
+
+// Weights changed (update / repair / restore) → defect copies must follow.
+function refreshFailNets() {
+  for (const env of envs) {
+    if (cfg.failRate > 0 && env.failMask) applyFailMask(env);
+    else env.actNet = null;
+  }
+}
+
+// The policy network an env ACTS with (true actor unless failure mode is on).
+function actingNet(env) {
+  if (cfg.failRate > 0) {
+    if (!env.actNet) rollFailMask(env);
+    return env.actNet;
+  }
+  return actor;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  Neuron repair (cfg.neuronRepair) — every REPAIR_EVERY updates:
+//   1. Score each hidden neuron by influence = std(activation) × ‖W_out‖₁,
+//      measured over a reservoir of recently seen observations.
+//   2. DEAD neurons (≈ no influence — constant output or unused downstream)
+//      are recycled ReDo-style: fresh random incoming weights, outgoing
+//      zeroed. Output is unchanged, but gradient can regrow the slot.
+//   3. The most OVERTUNED neuron (influence ≫ layer mean) is split into the
+//      most useless slot: the clone gets the same incoming weights and both
+//      get half the outgoing weights — the summed output is identical, so
+//      nothing breaks, but the dominant feature gains redundancy and its
+//      per-neuron gradient pressure halves. Stabilizes top-heavy networks.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const REPAIR_EVERY   = 10;    // updates between repair passes
+const REPAIR_RES_CAP = 256;   // observation reservoir size
+const DEAD_FRAC      = 0.05;  // dead if influence < 5 % of the layer mean
+const OVER_FRAC      = 3.0;   // overtuned if influence > 3× the layer mean
+const RECYCLE_CAP    = 0.25;  // recycle at most a quarter of a layer per pass
+
+let repairObs   = [];         // reservoir of Float64Array observations
+let repairSeen  = 0;          // total observations offered to the reservoir
+let repairStats = { recycled: 0, splits: 0 };
+let _repairPending = false;   // requested while an update was in flight
+
+function reservoirOffer(obs) {
+  repairSeen++;
+  if (repairObs.length < REPAIR_RES_CAP) {
+    repairObs.push(Float64Array.from(obs));
+  } else if (Math.random() < REPAIR_RES_CAP / repairSeen) {
+    repairObs[(Math.random() * REPAIR_RES_CAP) | 0] = Float64Array.from(obs);
+  }
+}
+
+function repairPass() {
+  if (repairObs.length < 32) return;  // not enough data to judge neurons
+
+  // activation statistics per hidden layer over the reservoir
+  const L = actor.W.length;            // weight-layer count; hidden layers L−1
+  const sums = [], sqs = [];
+  for (let l = 0; l < L - 1; l++) {
+    sums.push(new Float64Array(actor.sizes[l + 1]));
+    sqs.push(new Float64Array(actor.sizes[l + 1]));
+  }
+  const cache = {};
+  for (const o of repairObs) {
+    actor.forward(o, cache);
+    for (let l = 0; l < L - 1; l++) {
+      const a = cache.acts[l + 1];
+      for (let j = 0; j < a.length; j++) { sums[l][j] += a[j]; sqs[l][j] += a[j] * a[j]; }
+    }
+  }
+
+  for (let l = 0; l < L - 1; l++) {
+    const nH = actor.sizes[l + 1];           // neurons in this hidden layer
+    const nIn = actor.sizes[l], nOut = actor.sizes[l + 2];
+    const Win = actor.W[l], bIn = actor.b[l], Wout = actor.W[l + 1];
+
+    const score = new Float64Array(nH);
+    let mean = 0;
+    for (let j = 0; j < nH; j++) {
+      const m = sums[l][j] / repairObs.length;
+      const v = Math.max(0, sqs[l][j] / repairObs.length - m * m);
+      let outNorm = 0;
+      for (let o = 0; o < nOut; o++) outNorm += Math.abs(Wout[o * nH + j]);
+      score[j] = Math.sqrt(v) * outNorm;
+      mean += score[j] / nH;
+    }
+    if (!(mean > 0)) continue;  // layer entirely silent — nothing to rank
+
+    const zeroAdam = j => {
+      for (let i = 0; i < nIn; i++) {
+        actor.mW[l][j * nIn + i] = 0; actor.vW[l][j * nIn + i] = 0;
+      }
+      actor.mb[l][j] = 0; actor.vb[l][j] = 0;
+      for (let o = 0; o < nOut; o++) {
+        actor.mW[l + 1][o * nH + j] = 0; actor.vW[l + 1][o * nH + j] = 0;
+      }
+    };
+
+    // ── recycle dead neurons ──
+    const lim = Math.sqrt(6 / (nIn + nH));
+    let recycled = 0;
+    for (let j = 0; j < nH && recycled < Math.max(1, nH * RECYCLE_CAP); j++) {
+      if (score[j] >= mean * DEAD_FRAC) continue;
+      for (let i = 0; i < nIn; i++) Win[j * nIn + i] = (Math.random() * 2 - 1) * lim;
+      bIn[j] = 0;
+      for (let o = 0; o < nOut; o++) Wout[o * nH + j] = 0;
+      zeroAdam(j);
+      score[j] = mean;  // freshly recycled — don't pick it as the split target
+      recycled++;
+      repairStats.recycled++;
+    }
+
+    // ── split the most overtuned neuron into the most useless slot ──
+    let jMax = 0, jMin = 0;
+    for (let j = 1; j < nH; j++) {
+      if (score[j] > score[jMax]) jMax = j;
+      if (score[j] < score[jMin]) jMin = j;
+    }
+    if (jMax !== jMin && score[jMax] > mean * OVER_FRAC && score[jMin] < mean) {
+      for (let i = 0; i < nIn; i++) {
+        // tiny jitter so the twins don't stay numerically identical forever
+        Win[jMin * nIn + i] = Win[jMax * nIn + i] * (1 + (Math.random() * 2 - 1) * 0.01);
+      }
+      bIn[jMin] = bIn[jMax];
+      for (let o = 0; o < nOut; o++) {
+        const half = Wout[o * nH + jMax] * 0.5;
+        Wout[o * nH + jMax] = half;
+        Wout[o * nH + jMin] = half;
+      }
+      zeroAdam(jMax);
+      zeroAdam(jMin);
+      repairStats.splits++;
+    }
+  }
+
+  refreshFailNets();   // acting copies must see the repaired weights
+  sendTfWeights();     // keep the GPU backend's resident weights in sync
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 //  Environments
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -627,6 +799,8 @@ let agentSteps  = 0;        // transitions collected since last update
 let recentReturns = [];     // last completed episode returns
 let bestLap = Infinity;
 let lastLoss = { pi: 0, v: 0, ent: 0 };
+let lastEpochs = 0;         // epochs the last update actually ran (KL stop)
+let lastKl = 0;             // KL movement of the last update
 
 // ── Best-network snapshot ────────────────────────────────────────────────────
 // A network is judged by the AVERAGE return over the recent episodes of ALL
@@ -680,26 +854,91 @@ function makeEnv(i) {
     curAct: new Float64Array(ACT_DIM),
     // pending transition (written to buffer when the repeat window closes)
     pendObs: null, pendLogp: 0, pendVal: 0, rewAcc: 0,
-    // per-env rollout chain (PPO)
-    buf: { obs: [], act: [], logp: [], val: [], rew: [], done: [] },
-    // ES: per-env perturbed policy + episode result
-    esNet: null,    // Net with θ + σ·sign·ε loaded for this generation
-    esEps: null,    // Float64Array(paramCount) — shared with the antithetic twin
-    esSign: 1,
-    esDone: false,  // episode finished, waiting for the generation to close
-    esFit: 0,
+    // mirror twin of the pending transition (cfg.mirror)
+    pendObsM: null, pendActM: null, pendLogpM: 0, pendValM: 0,
+    // per-env rollout chains (M = mirrored twin; shares rew/done values)
+    buf:  { obs: [], act: [], logp: [], val: [], rew: [], done: [] },
+    bufM: { obs: [], act: [], logp: [], val: [], rew: [], done: [] },
+    // weight-failure mode
+    failMask: null, actNet: null,
+    // agent groups
+    gDone: false, gFit: 0,
   };
 }
 
-function resetEnv(env, i) {
-  const sp = spawnPose(i);
+function clearChains(env) {
+  for (const b of [env.buf, env.bufM]) {
+    b.obs.length = 0; b.act.length = 0; b.logp.length = 0;
+    b.val.length = 0; b.rew.length = 0; b.done.length = 0;
+  }
+}
+
+function resetEnv(env, i, pose = null) {
+  const sp = pose || spawnPose(i);
   env.car.reset(sp.pos, sp.hdg);
   env.prevS = carArc(env.car).s;
   env.lapAcc = 0; env.lapTime = 0;
   env.epTime = 0; env.epReturn = 0;
   env.offTrackTime = 0; env.noProgTime = 0; env.prevStuck = 0;
   env.repCount = 0;
-  env.pendObs = null; env.rewAcc = 0;
+  env.pendObs = null; env.pendObsM = null; env.rewAcc = 0;
+  env.gDone = false; env.gFit = 0;
+  // fresh episode → fresh defects
+  if (cfg.failRate > 0) rollFailMask(env);
+  else env.actNet = null;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  Agent groups (cfg.groupSize > 1) — GRPO-style baseline. Every group of G
+//  agents spawns at the SAME pose and runs the same shared policy with
+//  independent noise. When the whole group has finished, each member's
+//  advantage is its episode return relative to the group: the group average
+//  IS the baseline, so no critic / GAE is involved. Finished members park
+//  until the slowest one is done.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const groupOn = () => (cfg.groupSize | 0) > 1;
+
+// Episode-complete transitions waiting for the next group-mode update.
+let readyBatch = { OBS: [], ACT: [], LOGP: [], ADV: [], RET: [] };
+
+function groupMembers(g) {
+  const G = cfg.groupSize | 0;
+  return envs.slice(g * G, Math.min(envs.length, (g + 1) * G));
+}
+
+function respawnGroup(g) {
+  const members = groupMembers(g);
+  if (!members.length) return;
+  const pose = spawnPose(g * (cfg.groupSize | 0));
+  for (let m = 0; m < members.length; m++) {
+    resetEnv(members[m], 0, pose);
+    clearChains(members[m]);
+  }
+}
+
+// All members done → group-relative advantages → ready buffer → respawn.
+function finalizeGroup(g) {
+  const members = groupMembers(g);
+  const n = members.length;
+  let mean = 0;
+  for (const m of members) mean += m.gFit / n;
+  let varr = 0;
+  for (const m of members) varr += (m.gFit - mean) ** 2;
+  const std = Math.sqrt(varr / n) + 1e-6;
+  for (const m of members) {
+    const adv = (m.gFit - mean) / std;
+    for (const b of [m.buf, m.bufM]) {
+      for (let t = 0; t < b.obs.length; t++) {
+        readyBatch.OBS.push(b.obs[t]);
+        readyBatch.ACT.push(b.act[t]);
+        readyBatch.LOGP.push(b.logp[t]);
+        readyBatch.ADV.push(adv);
+        readyBatch.RET.push(m.gFit);  // unused for learning (vfCoef forced 0)
+      }
+    }
+  }
+  respawnGroup(g);
 }
 
 function initSim(modelOverride) {
@@ -711,84 +950,111 @@ function initSim(modelOverride) {
   simTime = 0;
   lastLoss = { pi: 0, v: 0, ent: 0 };
   best = null; curAvg = null; _loadBestPending = false;
-  gammaNow = cfg.gamma;
-  gammaBestAvg = -Infinity;
-  gammaLastProgress = 0;
-  if (isES()) esStartGeneration();
+  readyBatch = { OBS: [], ACT: [], LOGP: [], ADV: [], RET: [] };
+  repairObs = []; repairSeen = 0;
+  repairStats = { recycled: 0, splits: 0 };
+  _repairPending = false;
+  lastEpochs = 0; lastKl = 0;
+  if (groupOn()) {
+    const nGroups = Math.ceil(envs.length / (cfg.groupSize | 0));
+    for (let g = 0; g < nGroups; g++) respawnGroup(g);
+  } else if (cfg.failRate > 0) {
+    for (const env of envs) rollFailMask(env);
+  }
 }
 
 // Finalize the pending transition of an env into its rollout chain.
-function commitTransition(env, done) {
+// extra / extraM: bootstrap value added to this transition's reward only
+// (the mirrored twin bootstraps from the mirrored terminal observation).
+function commitTransition(env, done, extra = 0, extraM = 0) {
   if (!env.pendObs) return;
   env.buf.obs.push(env.pendObs);
   env.buf.act.push(Float64Array.from(env.curAct));
   env.buf.logp.push(env.pendLogp);
   env.buf.val.push(env.pendVal);
-  env.buf.rew.push(env.rewAcc);
+  env.buf.rew.push(env.rewAcc + extra);
   env.buf.done.push(done ? 1 : 0);
+  if (env.pendObsM) {
+    env.bufM.obs.push(env.pendObsM);
+    env.bufM.act.push(env.pendActM);
+    env.bufM.logp.push(env.pendLogpM);
+    env.bufM.val.push(env.pendValM);
+    env.bufM.rew.push(env.rewAcc + extraM);
+    env.bufM.done.push(done ? 1 : 0);
+  }
   env.pendObs = null;
+  env.pendObsM = null;
   env.rewAcc = 0;
   agentSteps++;
 }
 
 function terminateEnv(env, i, penalty, truncated) {
-  if (isES()) {
-    // fitness = undiscounted episode return; the car parks until every env
-    // in the generation has finished, then esUpdate() respawns them all
-    env.esFit = env.epReturn;
-    env.esDone = true;
-    recentReturns.push(env.epReturn);
-    if (recentReturns.length > 50) recentReturns.shift();
-    return;
-  }
   // per-tick rewards are already in epReturn; only the penalty/bootstrap
   // terms are added to the stored transition reward here
   if (penalty) env.rewAcc -= penalty;
-  if (truncated && env.pendObs) {
+  let boot = 0, bootM = 0;
+  if (truncated && env.pendObs && !groupOn()) {
     // bootstrap the value of the post-step state so truncation isn't
-    // mistaken for a real terminal
+    // mistaken for a real terminal (groups skip this — no critic there)
     const obs = new Float64Array(OBS_DIM);
     buildObs(env.car, obs);
-    env.rewAcc += gammaNow * critic.forward(obs)[0];
+    boot = cfg.gamma * critic.forward(obs)[0];
+    if (env.pendObsM) {
+      const obsM = mirrorObsInto(obs, new Float64Array(OBS_DIM));
+      bootM = cfg.gamma * critic.forward(obsM)[0];
+    }
   }
-  commitTransition(env, true);
+  commitTransition(env, true, boot, bootM);
   recentReturns.push(env.epReturn);
   if (recentReturns.length > 50) recentReturns.shift();
+  if (groupOn()) {
+    // park; the group respawns together once its last member finishes
+    env.gFit = env.epReturn;
+    env.gDone = true;
+    const g = (i / (cfg.groupSize | 0)) | 0;
+    if (groupMembers(g).every(m => m.gDone)) finalizeGroup(g);
+    return;
+  }
   resetEnv(env, i);
 }
 
 // One physics tick for every env (dt = FIXED_DT).
 function stepOnce(dt) {
-  // Back-pressure (PPO): if an update is in flight and the next batch is
-  // already twice the horizon, pause collection so batches can't grow
-  // without bound at high speed multipliers.
+  // Back-pressure: if an update is in flight and the next batch is already
+  // twice the horizon, pause collection so batches can't grow without bound
+  // at high speed multipliers.
   if (_ppoRunning && agentSteps >= cfg.horizon * cfg.numEnvs * 2) return;
 
   simTime += dt;
-  const es = isES();
   for (let i = 0; i < envs.length; i++) {
     const env = envs[i];
-    if (es && env.esDone) continue;  // parked until the generation closes
+    if (env.gDone) continue;  // parked until its group's last member finishes
     const car = env.car;
 
     // ── New agent decision at the start of each repeat window ──
     if (env.repCount <= 0) {
+      commitTransition(env, false); // finalize previous window (non-terminal)
       const obs = new Float64Array(OBS_DIM);
       buildObs(car, obs);
-      if (es) {
-        // deterministic perturbed policy — exploration is in parameter space
-        const mean = env.esNet.forward(obs);
-        for (let d = 0; d < ACT_DIM; d++) env.curAct[d] = mean[d];
-      } else {
-        commitTransition(env, false); // finalize previous window (non-terminal)
-        const mean = actor.forward(obs);
-        for (let d = 0; d < ACT_DIM; d++) {
-          env.curAct[d] = mean[d] + Math.exp(logStd[d]) * gauss();
-        }
-        env.pendObs  = obs;
-        env.pendLogp = logProb(env.curAct, mean);
-        env.pendVal  = critic.forward(obs)[0];
+      const pol = actingNet(env);   // true actor, or the defect-masked copy
+      const mean = pol.forward(obs);
+      for (let d = 0; d < ACT_DIM; d++) {
+        env.curAct[d] = mean[d] + Math.exp(logStd[d]) * gauss();
       }
+      env.pendObs  = obs;
+      env.pendLogp = logProb(env.curAct, mean);
+      env.pendVal  = groupOn() ? 0 : critic.forward(obs)[0];
+      if (cfg.mirror) {
+        // synthetic twin: mirrored observation + mirrored action, with its
+        // own behavior log-prob/value so PPO's ratio and GAE stay exact
+        const obsM = mirrorObsInto(obs, new Float64Array(OBS_DIM));
+        const actM = mirrorActInto(env.curAct, new Float64Array(ACT_DIM));
+        env.pendObsM  = obsM;
+        env.pendActM  = actM;
+        env.pendLogpM = logProb(actM, pol.forward(obsM));
+        env.pendValM  = groupOn() ? 0 : critic.forward(obsM)[0];
+      }
+      if (cfg.neuronRepair && (totalSteps & 31) === 0) reservoirOffer(obs);
       env.repCount = cfg.actionRepeat;
       // Memory write: rate-limited delta from the memory actions. Applied
       // after the observation snapshot, so the new value appears in the
@@ -864,13 +1130,15 @@ function stepOnce(dt) {
     }
   }
 
-  // ── Trigger updates ──
-  if (es) {
-    // a generation closes when every env has finished its episode; the ES
-    // update is O(params·N) — instant, so it runs synchronously
-    if (envs.length && envs.every(e => e.esDone)) {
-      esUpdate();
-      esStartGeneration();
+  // ── Trigger async PPO update when the rollout buffer is full ──
+  if (groupOn()) {
+    // group mode: only whole finished groups are trainable
+    if (readyBatch.OBS.length >= cfg.horizon * cfg.numEnvs && !_ppoRunning) {
+      _ppoRunning = true;
+      const batch = { ...readyBatch, N: readyBatch.OBS.length, grouped: true };
+      readyBatch = { OBS: [], ACT: [], LOGP: [], ADV: [], RET: [] };
+      agentSteps = 0;
+      _runPPO(batch);
     }
   } else if (agentSteps >= cfg.horizon * cfg.numEnvs && !_ppoRunning) {
     _ppoRunning = true;
@@ -878,74 +1146,6 @@ function stepOnce(dt) {
     agentSteps = 0;
     if (batch.N >= 8) _runPPO(batch); else _ppoRunning = false;
   }
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-//  Evolution strategies — OpenAI-ES with antithetic sampling + centered-rank
-//  fitness shaping, Adam on the estimated ascent direction. The entire
-//  update is a few hundred thousand multiply-adds; the expensive part of ES
-//  is the simulation, which this trainer runs anyway.
-// ─────────────────────────────────────────────────────────────────────────────
-
-let esSigmaUsed = 0.1;   // σ the current generation was drawn with (cfg.esSigma
-                         // is live and may change while episodes run)
-
-function esStartGeneration() {
-  const base = actor.flatF64();
-  const P = base.length;
-  esSigmaUsed = Math.max(0.005, cfg.esSigma);
-  for (let i = 0; i < envs.length; i++) {
-    const env = envs[i];
-    if (i % 2 === 0) {
-      // fresh noise; the next env mirrors it (antithetic pair)
-      const eps = new Float64Array(P);
-      for (let k = 0; k < P; k++) eps[k] = gauss();
-      env.esEps = eps;
-      env.esSign = 1;
-    } else {
-      env.esEps = envs[i - 1].esEps;
-      env.esSign = -1;
-    }
-    const w = new Float64Array(P);
-    const s = esSigmaUsed * env.esSign;
-    for (let k = 0; k < P; k++) w[k] = base[k] + s * env.esEps[k];
-    if (!env.esNet) env.esNet = new Net(actor.sizes, 1);
-    env.esNet.loadFlat(w);
-    env.esDone = false;
-    env.esFit = 0;
-    resetEnv(env, i);
-  }
-}
-
-function esUpdate() {
-  const n = envs.length;
-  // centered ranks in [−0.5, 0.5] — robust to the reward scale and to the
-  // huge fitness outliers a single lap bonus produces
-  const order = envs.map((_, i) => i).sort((a, b) => envs[a].esFit - envs[b].esFit);
-  const u = new Float64Array(n);
-  for (let r = 0; r < n; r++) u[order[r]] = n > 1 ? r / (n - 1) - 0.5 : 0;
-
-  const P = actor.paramCount();
-  const g = new Float64Array(P);
-  for (let i = 0; i < n; i++) {
-    const env = envs[i];
-    const w = u[i] * env.esSign;
-    if (!w) continue;
-    const eps = env.esEps;
-    for (let k = 0; k < P; k++) g[k] += w * eps[k];
-  }
-  // Adam minimizes, so feed it the NEGATED ascent estimate
-  const scale = -1 / (n * esSigmaUsed);
-  for (let k = 0; k < P; k++) g[k] *= scale;
-  actor.loadGradFlat(g);
-  actor.adamStep(cfg.esLr, 1);
-
-  iteration++;
-  let mean = 0, best = -Infinity;
-  for (const e of envs) { mean += e.esFit / n; if (e.esFit > best) best = e.esFit; }
-  lastLoss = { pi: mean, v: best, ent: 0 };  // repurposed: generation mean/best
-  if (_loadBestPending) { _loadBestPending = false; loadBestSnapshot(); }
-  else updateBestSnapshot();
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1100,22 +1300,18 @@ function _flushBatch() {
   for (const env of envs) { commitTransition(env, false); env.repCount = 0; }
 
   const OBS = [], ACT = [], LOGP = [], ADV = [], RET = [];
-  for (const env of envs) {
-    const b = env.buf, T = b.obs.length;
-    if (!T) continue;
-    let nextVal = 0;
-    if (!b.done[T - 1]) {
-      const obs = new Float64Array(OBS_DIM);
-      buildObs(env.car, obs);
-      nextVal = critic.forward(obs)[0];
-    }
+
+  // GAE over one rollout chain; nextVal bootstraps an unfinished tail.
+  const flushChain = (b, nextVal) => {
+    const T = b.obs.length;
+    if (!T) return;
     let gae = 0;
     const adv = new Float64Array(T);
     for (let t = T - 1; t >= 0; t--) {
       const nonTerm = 1 - b.done[t];
       const nextV = t === T - 1 ? nextVal : b.val[t + 1];
-      const delta = b.rew[t] + gammaNow * nextV * nonTerm - b.val[t];
-      gae = delta + gammaNow * cfg.lam * nonTerm * gae;
+      const delta = b.rew[t] + cfg.gamma * nextV * nonTerm - b.val[t];
+      gae = delta + cfg.gamma * cfg.lam * nonTerm * gae;
       adv[t] = gae;
     }
     for (let t = 0; t < T; t++) {
@@ -1124,6 +1320,22 @@ function _flushBatch() {
     }
     b.obs.length = 0; b.act.length = 0; b.logp.length = 0;
     b.val.length = 0; b.rew.length = 0; b.done.length = 0;
+  };
+
+  for (const env of envs) {
+    let nextVal = 0, nextValM = 0;
+    const open = env.buf.obs.length && !env.buf.done[env.buf.obs.length - 1];
+    if (open) {
+      const obs = new Float64Array(OBS_DIM);
+      buildObs(env.car, obs);
+      nextVal = critic.forward(obs)[0];
+      if (env.bufM.obs.length) {
+        const obsM = mirrorObsInto(obs, new Float64Array(OBS_DIM));
+        nextValM = critic.forward(obsM)[0];
+      }
+    }
+    flushChain(env.buf, nextVal);
+    flushChain(env.bufM, nextValM);
   }
   return { OBS, ACT, LOGP, ADV, RET, N: OBS.length };
 }
@@ -1179,33 +1391,22 @@ function updateBestSnapshot() {
   let avg = 0; for (const r of tail) avg += r; avg /= tail.length;
   curAvg = avg;
   if (!best || avg > best.avg) {
-    best = isES()
-      ? { algo: 'es', aFlat: actor.flatF64(), avg, iter: iteration }
-      : {
-        algo: 'ppo',
-        aFlat: actor.flatF64(), cFlat: critic.flatF64(),
-        logStd: Float64Array.from(logStd),
-        avg, iter: iteration,
-      };
+    best = {
+      aFlat: actor.flatF64(), cFlat: critic.flatF64(),
+      logStd: Float64Array.from(logStd),
+      avg, iter: iteration,
+    };
   }
 }
 
-// Restore the best snapshot. Only call between updates (weights must not
+// Restore the best snapshot. Only call between PPO updates (weights must not
 // change while gradient tasks are in flight).
 function loadBestSnapshot() {
   if (!best) return;
   actor.loadFlat(best.aFlat);
-  actor.resetAdam();
-  if (isES()) {
-    // exploration is parameter noise — nothing to re-open; abandon the
-    // running generation and re-perturb every env from the restored θ
-    recentReturns = [];
-    curAvg = null;
-    esStartGeneration();
-    return;
-  }
   critic.loadFlat(best.cFlat);
   logStd.set(best.logStd);
+  actor.resetAdam();
   critic.resetAdam();
   lsM.fill(0); lsV.fill(0); lsT = 0;
   // Re-open exploration a little: the abandoned direction was a dead end, so
@@ -1214,15 +1415,15 @@ function loadBestSnapshot() {
   // Drop rollouts and episode stats gathered under the abandoned policy —
   // stale transitions would train the restored weights toward it again.
   for (const env of envs) {
-    const b = env.buf;
-    b.obs.length = 0; b.act.length = 0; b.logp.length = 0;
-    b.val.length = 0; b.rew.length = 0; b.done.length = 0;
-    env.pendObs = null; env.rewAcc = 0; env.repCount = 0;
+    clearChains(env);
+    env.pendObs = null; env.pendObsM = null; env.rewAcc = 0; env.repCount = 0;
   }
+  readyBatch = { OBS: [], ACT: [], LOGP: [], ADV: [], RET: [] };
   agentSteps = 0;
   recentReturns = [];
   curAvg = null;
   sendTfWeights();  // keep the GPU backend's resident weights in sync
+  refreshFailNets();  // defect copies must act with the restored weights
 }
 
 async function _runPPO(batch) {
@@ -1236,9 +1437,30 @@ async function _runPPO(batch) {
   for (let k = 0; k < N; k++) ADV[k] = (ADV[k] - mean) / std;
 
   const idx = Array.from({ length: N }, (_, k) => k);
-  const hp = { clip: cfg.clip, entropyCoef: cfg.entropyCoef, vfCoef: cfg.vfCoef };
+  const hp = {
+    clip: cfg.clip, entropyCoef: cfg.entropyCoef,
+    // group mode has no critic to train — advantages came from the group
+    vfCoef: batch.grouped ? 0 : cfg.vfCoef,
+    klStop: !!cfg.klStop, klLimit: cfg.klLimit,
+  };
   let sumPi = 0, sumV = 0, sumEnt = 0, nMB = 0;
   let gpuDone = false;
+
+  // KL movement estimate (k3, always ≥ 0) of the live actor vs the stored
+  // behavior log-probs, on a fixed subsample. Used to stop epochs early once
+  // the policy has drifted klLimit past where it started this update.
+  const klSample = Math.min(512, N);
+  const klEstimate = () => {
+    let kl = 0;
+    for (let t = 0; t < klSample; t++) {
+      const s = ((t * 2654435761) >>> 0) % N;  // fixed quasi-random subsample
+      const d = Math.min(20, logProb(ACT[s], actor.forward(OBS[s])) - LOGP[s]);
+      kl += (Math.exp(d) - 1) - d;
+    }
+    return kl / klSample;
+  };
+  const kl0 = cfg.klStop ? klEstimate() : 0;
+  let epochsRan = 0;
 
   // ── GPU path: the COMPLETE update (all epochs, shuffling, Adam) runs on the
   //    TF.js worker; the new weights come back in one message ────────────────
@@ -1272,6 +1494,8 @@ async function _runPPO(batch) {
       critic.loadFlat(r.criticFlat);
       for (let d2 = 0; d2 < ACT_DIM; d2++) logStd[d2] = r.logStd[d2];
       lastLoss = r.loss;
+      lastEpochs = r.epochs || cfg.epochs;
+      lastKl = r.kl || 0;
       gpuDone = true;
     } catch (err) {
       _tfFail(String(err && err.message || err));
@@ -1360,13 +1584,26 @@ async function _runPPO(batch) {
 
       sumPi += mbPi / bs; sumV += mbV / bs; sumEnt += mbEnt / bs; nMB++;
     }
+
+    epochsRan = ep + 1;
+    if (cfg.klStop) {
+      const kl = klEstimate() - kl0;
+      lastKl = kl;
+      if (kl > cfg.klLimit) break;  // policy moved far enough — extra epochs
+                                    // would only overfit this batch
+    }
   }
+  if (!gpuDone) lastEpochs = epochsRan;
 
   if (nMB) lastLoss = { pi: sumPi / nMB, v: sumV / nMB, ent: sumEnt / nMB };
   iteration++;
   if (_loadBestPending) { _loadBestPending = false; loadBestSnapshot(); }
   else updateBestSnapshot();
-  adaptGamma();  // raise γ on long reward stagnation, ease back on progress
+  if (_repairPending || (cfg.neuronRepair && iteration % REPAIR_EVERY === 0)) {
+    _repairPending = false;
+    repairPass();
+  }
+  if (cfg.failRate > 0) refreshFailNets();  // defect copies track new weights
   _ppoRunning = false;
   if (_poolRebuild) { _poolRebuild = false; initGradPool(true); }
 }
@@ -1391,26 +1628,32 @@ function buildSnapshot() {
     const tail = recentReturns.slice(-20);
     avgReturn = tail.reduce((s, v) => s + v, 0) / tail.length;
   }
-  const es = isES();
   const snap = {
     type: 'frame',
     cars: carData,
-    algo: cfg.algo,
     iteration,
     totalSteps,
-    bufferFill: es
-      ? (envs.length ? envs.filter(e => e.esDone).length / envs.length : 0)
-      : Math.min(1, agentSteps / (cfg.horizon * cfg.numEnvs)),
+    bufferFill: Math.min(1, (groupOn() ? readyBatch.OBS.length : agentSteps) /
+                            (cfg.horizon * cfg.numEnvs)),
     phase: _ppoRunning ? 'updating' : 'collecting',
+    // PPO-mod status for the HUD
+    mods: {
+      groupSize: cfg.groupSize | 0,
+      mirror: !!cfg.mirror,
+      klStop: !!cfg.klStop,
+      epochs: lastEpochs,
+      epochsMax: cfg.epochs,
+      kl: lastKl,
+      repair: cfg.neuronRepair ? { ...repairStats } : null,
+      masked: cfg.failRate > 0 ? envs.filter(e => e.actNet).length : 0,
+    },
     gradThreads: gradPool ? gradPool.length : 0,
-    backend: es ? 'sim'
-           : gpuState === 'ready'  ? 'gpu'
+    backend: gpuState === 'ready'  ? 'gpu'
            : gpuState === 'init'   ? 'gpu-init'
            : gpuState === 'failed' ? 'gpu-failed'
            : (gradPool && gradPool.length && _wasmOk && cfg.backend !== 'js') ? 'wasm'
            : 'js',
-    backendInfo: es ? 'ES needs no gradient compute — all CPU goes into the simulation'
-               : gpuState === 'failed' ? gpuInfo
+    backendInfo: gpuState === 'failed' ? gpuInfo
                : gpuState === 'init'   ? gpuInfo
                : gpuState === 'ready'  ? gpuInfo
                : _wasmErr ? 'WASM unavailable: ' + _wasmErr
@@ -1419,9 +1662,7 @@ function buildSnapshot() {
     bestLap: Number.isFinite(bestLap) ? bestLap : null,
     episodes: recentReturns.length,
     loss: lastLoss,
-    sigma: es ? [cfg.esSigma, cfg.esSigma]
-         : logStd ? [Math.exp(logStd[0]), Math.exp(logStd[1])] : null,
-    gamma: es ? null : gammaNow,
+    sigma: logStd ? [Math.exp(logStd[0]), Math.exp(logStd[1])] : null,
     best: best ? { avg: best.avg, iter: best.iter, cur: curAvg } : null,
   };
   // actor weights for the visualiser — heavy, send ~once per second
@@ -1498,15 +1739,9 @@ self.onmessage = function (e) {
 
     running = false;
     stopLoop();
-    // ES does all its math inline — no gradient pool, no GPU worker
-    if (!isES()) initGradPool();
+    initGradPool();
     initSim(model || null);
-    if (isES()) {
-      if (tfWorker) { try { tfWorker.terminate(); } catch { /* dead */ } tfWorker = null; }
-      gpuState = 'off'; gpuInfo = '';
-    } else {
-      initGpu();
-    }
+    initGpu();
     postMessage({
       type: 'ready', obsDim: OBS_DIM, actorSizes: actor.sizes,
       numEnvs: cfg.numEnvs, gradThreads: gradPool ? gradPool.length : 0,
@@ -1538,13 +1773,26 @@ self.onmessage = function (e) {
 
   if (type === 'setConfig') {
     const prevThreads = desiredThreads();
+    const prevFail = cfg.failRate;
     Object.assign(cfg, e.data.config);
-    if (!cfg.gammaAuto) gammaNow = cfg.gamma;  // auto-γ off → pin to the base
     if (gradPool !== null && desiredThreads() !== prevThreads) {
       // resize the pool — deferred while an update has tasks in flight
       if (_ppoRunning) _poolRebuild = true;
       else initGradPool(true);
     }
+    // failure rate flipped — apply to the live agents right away
+    if (cfg.failRate > 0 && prevFail === 0 && envs.length) {
+      for (const env of envs) rollFailMask(env);
+    } else if (cfg.failRate === 0 && prevFail > 0) {
+      for (const env of envs) env.actNet = null;
+    }
+    return;
+  }
+
+  if (type === 'repairNow') {
+    // manual repair pass; deferred while gradient tasks hold the weights
+    if (_ppoRunning) _repairPending = true;
+    else repairPass();
     return;
   }
 
@@ -1566,28 +1814,25 @@ self.onmessage = function (e) {
     // weights may have drifted past their peak. { which: 'current' } forces
     // the live weights.
     const useBest = !!best && e.data.which !== 'current';
-    const common = {
-      version: 3,
-      obsDim: OBS_DIM,
-      actDim: ACT_DIM,
-      actor: { sizes: actor.sizes, flat: useBest ? Array.from(best.aFlat) : actor.flat() },
-      iteration: useBest ? best.iter : iteration,
-      totalSteps,
-      bestLap: Number.isFinite(bestLap) ? bestLap : null,
-      snapshot: useBest ? 'best-average' : 'current',
-      avgReturn: useBest ? best.avg : curAvg,
-    };
-    const model = isES()
-      ? { id: 'ai-trainer-es', name: 'AI Trainer ES Export', algo: 'es', ...common }
-      : {
+    postMessage({
+      type: 'modelExport',
+      model: {
         id: 'ai-trainer-ppo',
         name: 'AI Trainer PPO Export',
+        version: 3,
         algo: 'ppo',
-        ...common,
+        obsDim: OBS_DIM,
+        actDim: ACT_DIM,
+        actor:  { sizes: actor.sizes,  flat: useBest ? Array.from(best.aFlat) : actor.flat()  },
         critic: { sizes: critic.sizes, flat: useBest ? Array.from(best.cFlat) : critic.flat() },
         logStd: Array.from(useBest ? best.logStd : logStd),
-      };
-    postMessage({ type: 'modelExport', model });
+        iteration: useBest ? best.iter : iteration,
+        totalSteps,
+        bestLap: Number.isFinite(bestLap) ? bestLap : null,
+        snapshot: useBest ? 'best-average' : 'current',
+        avgReturn: useBest ? best.avg : curAvg,
+      },
+    });
     return;
   }
 };

--- a/games/ai-trainer/scripts/tf-worker.js
+++ b/games/ai-trainer/scripts/tf-worker.js
@@ -127,6 +127,29 @@ async function runUpdate(d) {
   const idx = new Int32Array(n);
   for (let k = 0; k < n; k++) idx[k] = k;
 
+  // KL movement (k3 estimator) of the live actor vs the stored behavior
+  // log-probs, on a fixed leading subsample — mirrors the CPU path's
+  // early-epoch-stop so both backends train identically.
+  const klSub = Math.min(512, n);
+  const klEstimate = async () => {
+    const t = tf.tidy(() => {
+      const obs  = tf.slice(obsT,  [0, 0], [klSub, -1]);
+      const act  = tf.slice(actT,  [0, 0], [klSub, -1]);
+      const logp = tf.slice(logpT, [0], [klSub]);
+      const mu = fwd(aVars, obs);
+      const z  = act.sub(mu).div(tf.exp(lsVar));
+      const lp = z.square().mul(-0.5).sub(lsVar).sub(0.5 * LOG_2PI).sum(1);
+      const dlt = tf.minimum(lp.sub(logp), 20);
+      return tf.exp(dlt).sub(1).sub(dlt).mean();
+    });
+    const v = (await t.data())[0];
+    t.dispose();
+    return v;
+  };
+  const klStop = !!(hp.klStop);
+  const kl0 = klStop ? await klEstimate() : 0;
+  let epochsRan = 0, lastKl = 0;
+
   try {
     for (let ep = 0; ep < d.epochs; ep++) {
       for (let k = n - 1; k > 0; k--) {  // Fisher-Yates shuffle
@@ -144,6 +167,11 @@ async function runUpdate(d) {
       }
       // yield so queued GPU work drains instead of piling up across epochs
       await new Promise(res => setTimeout(res, 0));
+      epochsRan = ep + 1;
+      if (klStop) {
+        lastKl = (await klEstimate()) - kl0;
+        if (lastKl > hp.klLimit) break;
+      }
     }
 
     // Loss scalars over the full batch with the final weights (for the HUD).
@@ -159,7 +187,8 @@ async function runUpdate(d) {
     const logStd     = new Float32Array(await lsVar.data());
     postMessage({
       type: 'updated', actorFlat, criticFlat, logStd,
-      loss: { pi, v, ent }, ms: performance.now() - t0,
+      loss: { pi, v, ent }, epochs: epochsRan, kl: lastKl,
+      ms: performance.now() - t0,
     }, [actorFlat.buffer, criticFlat.buffer, logStd.buffer]);
   } finally {
     tf.dispose([obsT, actT, logpT, advT, retT]);

--- a/games/ai-trainer/scripts/trainer-app.js
+++ b/games/ai-trainer/scripts/trainer-app.js
@@ -149,7 +149,6 @@ const ACT_DIM = 6;  // steer, throttle/brake + 4 memory-cell deltas
 
 // Full training config — architecture fields require restart, others are live
 const simCfg = {
-  algo: 'ppo',           // restart required — 'ppo' | 'es'
   hiddenLayers: 1,       // restart required
   hiddenSize: 64,        // restart required
   backend: 'auto',       // restart required — 'auto' | 'gpu' | 'wasm' | 'js'
@@ -158,12 +157,15 @@ const simCfg = {
   speedMult: 1,
   episodeLen: 60,
   randomSpawn: true,
-  lr: 3e-4,              // PPO only
-  entropyCoef: 0.003,    // PPO only
-  gammaAuto: true,       // PPO only — γ rises while the reward stagnates
-  horizon: 512,          // PPO only — restart required
-  esSigma: 0.1,          // ES only — parameter noise (live)
-  esLr: 0.02,            // ES only — learning rate (live)
+  lr: 3e-4,
+  entropyCoef: 0.003,
+  horizon: 512,          // restart required
+  // PPO mods
+  groupSize: 1,          // restart required — GRPO-style agent groups
+  mirror: false,         // live — left↔right symmetry augmentation
+  klStop: true,          // live — KL-based early stop of update epochs
+  neuronRepair: false,   // live — dead-neuron recycle + dominant split
+  failRate: 0,           // live — defect-weight fraction per agent
   progressReward: 0.2,
   gravelPenalty: 1.0,
   wallPenalty: 2.0,
@@ -227,7 +229,7 @@ function onMsg(e) {
     const blob = new Blob([JSON.stringify(d.model, null, 2)], { type: 'application/json' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
-    a.href = url; a.download = `ai-trainer-${d.model.algo || 'ppo'}-model.json`; a.click();
+    a.href = url; a.download = 'ai-trainer-ppo-model.json'; a.click();
     URL.revokeObjectURL(url);
   }
 }
@@ -254,7 +256,6 @@ function refreshHUD(d) {
   document.getElementById('hudAvg').textContent  = 'BEST LAP ' + fmtLap(bestLap);
   document.getElementById('hudTime').textContent = fmtSteps(totalSteps) + ' steps';
 
-  const es = d.algo === 'es';
   const bar = document.getElementById('genBar');
   const wrap = document.getElementById('genBarWrap');
   if (phase === 'updating') {
@@ -264,9 +265,7 @@ function refreshHUD(d) {
   } else {
     bar.style.width = (Math.min(1, bufferFill) * 100).toFixed(1) + '%';
     bar.style.background = 'linear-gradient(90deg, #4af, #4f4)';
-    wrap.title = es
-      ? 'Generation progress — fraction of cars that finished their episode'
-      : 'Collecting rollout — bar fills then policy updates';
+    wrap.title = 'Collecting rollout — bar fills then policy updates';
   }
   const threads = d.gradThreads || 0;
   const phaseEl = document.getElementById('hudPhase');
@@ -277,37 +276,24 @@ function refreshHUD(d) {
     phaseEl.textContent = '● COLLECTING';
     phaseEl.style.color = '#4f4';
   }
-  // Compute-backend badge: GPU / WASM / JS / SIM, tooltip carries failure reasons
+  // Compute-backend badge: GPU / WASM / JS, tooltip carries failure reasons
   const backendEl = document.getElementById('hudWasm');
   if (backendEl && d.backend) {
     const labels = {
       'gpu': 'GPU ✓', 'gpu-init': 'GPU …', 'gpu-failed': 'GPU ✗→CPU',
       'wasm': `WASM ×${threads}`, 'js': `JS ×${threads || 1}`,
-      'sim': 'SIM ONLY',
     };
     const colors = {
       'gpu': '#c9f', 'gpu-init': '#fa4', 'gpu-failed': '#f66',
-      'wasm': '#4fa', 'js': '#888', 'sim': '#4fa',
+      'wasm': '#4fa', 'js': '#888',
     };
     backendEl.textContent = labels[d.backend] || d.backend;
     backendEl.style.color = colors[d.backend] || '#888';
     backendEl.title = d.backendInfo || 'Gradient compute backend';
   }
 
-  const sigmaEl = document.getElementById('hudSigma');
   if (d.sigma) {
-    if (es) {
-      sigmaEl.textContent = 'σₚ ' + d.sigma[0].toFixed(2);
-      sigmaEl.title = 'Parameter-noise σ — how different each car’s perturbed brain is from the base network';
-    } else {
-      sigmaEl.textContent = 'σ ' + d.sigma.map(s => s.toFixed(2)).join('/');
-      sigmaEl.title = 'Policy exploration noise σ (steer/throttle) — shrinks as AI gets confident';
-    }
-  }
-  const gammaEl = document.getElementById('hudGamma');
-  if (gammaEl) {
-    gammaEl.style.display = es ? 'none' : '';
-    if (d.gamma != null) gammaEl.textContent = 'γ ' + d.gamma.toFixed(4);
+    document.getElementById('hudSigma').textContent = 'σ ' + d.sigma.map(s => s.toFixed(2)).join('/');
   }
 
   const bestEl = document.getElementById('bestStatus');
@@ -324,6 +310,20 @@ function refreshHUD(d) {
       bestEl.textContent = 'no snapshot yet — needs ~12 finished episodes';
       bestEl.style.color = '#667';
     }
+  }
+
+  const modsEl = document.getElementById('modsStatus');
+  if (modsEl && d.mods) {
+    const m = d.mods;
+    const parts = [];
+    if (m.groupSize > 1) parts.push(`groups ×${m.groupSize}`);
+    if (m.mirror) parts.push('mirror ×2');
+    if (m.klStop && m.epochsMax) {
+      parts.push(`epochs ${m.epochs || '—'}/${m.epochsMax} · KL ${m.kl.toFixed(3)}`);
+    }
+    if (m.repair) parts.push(`♻ ${m.repair.recycled} recycled · ${m.repair.splits} split`);
+    if (m.masked) parts.push(`⚡ ${m.masked} defect agents`);
+    modsEl.textContent = parts.length ? parts.join('  ·  ') : 'no mods active';
   }
 
   if (lastCars.length) {
@@ -397,34 +397,10 @@ function netParams(hiddenLayers, hiddenSize, outDim) {
 
 function updateConfigParamCount() {
   const l = simCfg.hiddenLayers, h = simCfg.hiddenSize;
-  const act = netParams(l, h, ACT_DIM);
-  const el = document.getElementById('configParamCount');
-  if (simCfg.algo === 'es') {
-    el.textContent = `${act.toLocaleString()} parameters (actor only — evolution needs no critic)`;
-  } else {
-    const crit = netParams(l, h, 1);
-    el.textContent =
-      `${(act + crit).toLocaleString()} total parameters  (actor ${act.toLocaleString()} · critic ${crit.toLocaleString()})`;
-  }
-}
-
-// Show/hide algorithm-specific controls (config menu + live sidebar + HUD).
-function updateAlgoUI() {
-  const es = simCfg.algo === 'es';
-  for (const [id, showInEs] of [
-    ['configBackendRow', false], ['configThreadRow', false],
-    ['configHorizonRow', false], ['configLrRow', false], ['configEntRow', false],
-    ['configEsLrRow', true], ['configEsSigmaRow', true],
-    ['lrRow', false], ['entRow', false], ['gammaRow', false],
-    ['esLrRow', true], ['esSigmaRow', true],
-  ]) {
-    document.getElementById(id).style.display = (es === showInEs) ? '' : 'none';
-  }
-  document.getElementById('liveTitle').textContent = es ? '⚡ LIVE — EVOLUTION' : '⚡ LIVE — PPO';
-  document.getElementById('hudGamma').style.display = es ? 'none' : '';
-  // imports can switch the algorithm outside the button group's own clicks
-  document.getElementById('configAlgoBtns').querySelectorAll('.opt-btn')
-    .forEach(el => el.classList.toggle('sel', el.dataset.val === simCfg.algo));
+  const act  = netParams(l, h, ACT_DIM);
+  const crit = netParams(l, h, 1);
+  document.getElementById('configParamCount').textContent =
+    `${(act + crit).toLocaleString()} total parameters  (actor ${act.toLocaleString()} · critic ${crit.toLocaleString()})`;
 }
 
 function makeOptBtnGroup(containerId, options, key, onChange) {
@@ -456,9 +432,9 @@ function wireConfigSlider(sliderId, valId, key, fmtFn) {
 }
 
 function initConfigMenu() {
-  makeOptBtnGroup('configAlgoBtns',
-    [{ label: 'PPO', val: 'ppo' }, { label: 'EVOLUTION', val: 'es' }],
-    'algo', () => { updateAlgoUI(); updateConfigParamCount(); });
+  makeOptBtnGroup('configGroupBtns',
+    [{ label: 'OFF', val: 1 }, { label: '×2', val: 2 }, { label: '×4', val: 4 }, { label: '×8', val: 8 }],
+    'groupSize');
 
   makeOptBtnGroup('configLayerBtns',
     [{ val: 1 }, { val: 2 }, { val: 3 }],
@@ -482,8 +458,6 @@ function initConfigMenu() {
   wireConfigSlider('configEpLenSlider',  'configEpLenVal',  'episodeLen', v => v + 's');
   wireConfigSlider('configLrSlider',     'configLrVal',     'lr',        v => v.toExponential(1));
   wireConfigSlider('configEntSlider',    'configEntVal',    'entropyCoef', v => v.toFixed(4));
-  wireConfigSlider('configEsLrSlider',   'configEsLrVal',   'esLr',      v => v.toFixed(3));
-  wireConfigSlider('configEsSigmaSlider','configEsSigmaVal','esSigma',   v => v.toFixed(2));
 
   const spawnTog = document.getElementById('configSpawnToggle');
   spawnTog.checked = simCfg.randomSpawn;
@@ -494,7 +468,6 @@ function initConfigMenu() {
   });
   document.getElementById('configStartBtn').addEventListener('click', startFromConfigMenu);
 
-  updateAlgoUI();
   updateConfigParamCount();
 }
 
@@ -508,6 +481,11 @@ function hideConfigMenu() {
 }
 
 function startFromConfigMenu() {
+  // groups need a whole number of groups — snap the agent count
+  const G = simCfg.groupSize | 0;
+  if (G > 1) {
+    simCfg.numEnvs = Math.max(G, Math.round(simCfg.numEnvs / G) * G);
+  }
   hideConfigMenu();
   sendInit();
   setTimeout(() => {
@@ -584,15 +562,24 @@ function initUI() {
   wireSlider('speedSlider',   'speedVal',   'speedMult',       v => v + '×');
   wireSlider('lrSlider',      'lrVal',      'lr',              v => v.toExponential(1));
   wireSlider('entSlider',     'entVal',     'entropyCoef',     v => v.toFixed(4));
-  wireSlider('esLrSlider',    'esLrVal',    'esLr',            v => v.toFixed(3));
-  wireSlider('esSigmaSlider', 'esSigmaVal', 'esSigma',         v => v.toFixed(2));
   wireSlider('epLenSlider',   'epLenVal',   'episodeLen',      v => v + 's');
+  wireSlider('failSlider',    'failVal',    'failRate',        v => Math.round(v * 100) + '%');
 
-  const gammaTog = document.getElementById('gammaToggle');
-  gammaTog.checked = simCfg.gammaAuto;
-  gammaTog.addEventListener('change', () => {
-    simCfg.gammaAuto = gammaTog.checked;
-    if (worker) worker.postMessage({ type: 'setConfig', config: { gammaAuto: gammaTog.checked } });
+  // live PPO-mod toggles
+  const wireToggle = (id, key) => {
+    const el = document.getElementById(id);
+    el.checked = simCfg[key];
+    el.addEventListener('change', () => {
+      simCfg[key] = el.checked;
+      if (worker) worker.postMessage({ type: 'setConfig', config: { [key]: el.checked } });
+    });
+  };
+  wireToggle('mirrorToggle', 'mirror');
+  wireToggle('klToggle', 'klStop');
+  wireToggle('repairToggle', 'neuronRepair');
+
+  document.getElementById('repairNowBtn').addEventListener('click', () => {
+    if (worker) worker.postMessage({ type: 'repairNow' });
   });
   wireSlider('progSlider',    'progVal',    'progressReward',  v => v.toFixed(2));
   wireSlider('gravelSlider',  'gravelVal',  'gravelPenalty',   v => v.toFixed(1));
@@ -634,13 +621,8 @@ function initUI() {
     if (!this.files[0]) return;
     try {
       const model = JSON.parse(await this.files[0].text());
-      const okPpo = model.algo === 'ppo' && model.actor && model.critic;
-      const okEs  = model.algo === 'es' && model.actor;
-      if (!okPpo && !okEs)
-        throw new Error('Not a PPO/ES trainer export — older genetic trainer exports are not compatible');
-      // the model carries its algorithm — switch the trainer to match
-      simCfg.algo = model.algo;
-      updateAlgoUI();
+      if (model.algo !== 'ppo' || !model.actor || !model.critic)
+        throw new Error('Not a PPO model — older genetic trainer exports are not compatible');
       const was = simRunning; simRunning = false;
       sendInit(model);
       setTimeout(() => { if (was) { worker.postMessage({ type: 'start' }); simRunning = true; } updateStartBtn(); }, 80);

--- a/games/ai-trainer/test/sim-smoke.mjs
+++ b/games/ai-trainer/test/sim-smoke.mjs
@@ -5,12 +5,11 @@
 //  Run:  node games/ai-trainer/test/sim-smoke.mjs
 //
 //  Drives the worker protocol on a synthetic circular track. Nested Workers
-//  don't exist in Node, so PPO's gradient pool fails over to the local
-//  single-thread path — exactly the trainer's worst-case fallback. Checks:
-//    1. ES: generations complete, stats are finite, export is actor-only.
-//    2. PPO: updates complete, adaptive γ is reported (regression).
-//    3. Adaptive γ: with every reward zeroed the average return stagnates by
-//       construction, so γ MUST rise above its base after enough updates.
+//  don't exist in Node, so the gradient pool fails over to the local
+//  single-thread path — exactly the trainer's worst-case fallback. Covers
+//  the PPO mods: mirror augmentation (unit-checked index map + live run),
+//  KL early stop (forced trigger), agent groups, neuron repair and the
+//  defect-weight failure rate.
 // ─────────────────────────────────────────────────────────────────────────────
 
 let failures = 0;
@@ -28,7 +27,7 @@ globalThis.postMessage = msg => {
   if (wakeup) { const w = wakeup; wakeup = null; w(); }
 };
 
-await import('../scripts/sim-worker.js');
+const sim = await import('../scripts/sim-worker.js');
 const handler = globalThis.self.onmessage;
 const send = msg => handler({ data: msg });
 
@@ -69,7 +68,7 @@ function makeTrack() {
 
 const carData = { accel: 12, maxSpd: 50, brake: 25, hdl: 1.0, aiSpd: 1.0 };
 
-async function runAlgo(label, config, runMs) {
+async function runConfig(label, config, runMs) {
   inbox.length = 0;
   send({ type: 'init', track: makeTrack(), carData, config });
   const ready = await waitFor(m => m.type === 'ready', 5000);
@@ -86,84 +85,168 @@ async function runAlgo(label, config, runMs) {
   return frame;
 }
 
-// ── 1. ES ────────────────────────────────────────────────────────────────────
-console.log('\n1. ES end-to-end (evolution strategies)');
-{
-  const frame = await runAlgo('es', {
-    algo: 'es', numEnvs: 8, speedMult: 200, episodeLen: 12,
-    esSigma: 0.1, esLr: 0.02,
-  }, 25000);
-
-  check('frame received', !!frame);
-  if (frame) {
-    check('algo tagged es', frame.algo === 'es');
-    check(`generations completed (${frame.iteration})`, frame.iteration > 1);
-    check('fitness stats finite',
-      Number.isFinite(frame.avgReturn) && Number.isFinite(frame.loss.pi) && Number.isFinite(frame.loss.v));
-    check('backend is sim-only (no gradient compute)', frame.backend === 'sim');
-    check('parameter σ reported', Array.isArray(frame.sigma) && frame.sigma[0] === 0.1);
-    check('γ not reported for ES', frame.gamma == null);
-    check(`episodes completed (${frame.episodes})`, frame.episodes > 0);
-    console.log(`  steps ${frame.totalSteps} · generations ${frame.iteration} · ` +
-                `gen mean ${frame.loss.pi.toFixed(1)} · gen best ${frame.loss.v.toFixed(1)}`);
-  }
-
+async function exportModel() {
   inbox.length = 0;
   send({ type: 'exportModel' });
   const exp = await waitFor(m => m.type === 'modelExport', 3000);
-  const m = exp && exp.model;
-  check('export is an actor-only ES model',
-    !!m && m.algo === 'es' && m.actor && !m.critic && !m.logStd &&
-    m.actor.sizes[0] === m.obsDim &&
-    m.actor.sizes[m.actor.sizes.length - 1] === m.actDim);
-  check('export weights finite', !!m && m.actor.flat.every(Number.isFinite));
+  return exp && exp.model;
 }
 
-// ── 2. PPO regression ────────────────────────────────────────────────────────
-console.log('\n2. PPO end-to-end (regression)');
+// ── 1. Mirror map unit checks ────────────────────────────────────────────────
+console.log('\n1. Mirror augmentation index map');
 {
-  const frame = await runAlgo('ppo', {
-    algo: 'ppo', numEnvs: 4, speedMult: 200, episodeLen: 15,
-    backend: 'js', threads: 1, minibatch: 128, horizon: 64, epochs: 2,
-  }, 20000);
+  const OBS = 40, ACT = 6;
+  const src = Float64Array.from({ length: OBS }, (_, i) => i + 1);
+  const dst = sim.mirrorObsInto(src, new Float64Array(OBS));
+  let ok = true;
+  for (let k = 0; k <= 10; k++) ok = ok && dst[k] === src[10 - k];        // long rays reversed
+  for (let k = 11; k <= 17; k++) ok = ok && dst[k] === src[28 - k];       // edge rays reversed
+  ok = ok && dst[18] === src[18] && dst[20] === src[20] && dst[21] === src[21]
+          && dst[22] === src[22] && dst[23] === src[23];                  // scalars kept
+  ok = ok && dst[19] === -src[19];                                        // heading error flips
+  for (let p = 0; p < 6; p++) {
+    ok = ok && dst[24 + 2 * p] === -src[24 + 2 * p];                      // probe angles flip
+    ok = ok && dst[25 + 2 * p] === src[25 + 2 * p];                       // probe slopes keep
+  }
+  for (let d = 36; d < 40; d++) ok = ok && dst[d] === src[d];             // memory kept
+  check('observation map is exactly the documented reflection', ok);
 
-  check('frame received', !!frame);
+  const back = sim.mirrorObsInto(dst, new Float64Array(OBS));
+  check('mirror is an involution (mirror∘mirror = id)',
+    back.every((v, i) => v === src[i]));
+
+  const act = Float64Array.from({ length: ACT }, (_, i) => i + 1);
+  const actM = sim.mirrorActInto(act, new Float64Array(ACT));
+  check('action map flips steer only',
+    actM[0] === -act[0] && actM.slice(1).every((v, i) => v === act[i + 1]));
+}
+
+// ── 2. Vanilla PPO regression (all mods off) ─────────────────────────────────
+console.log('\n2. Vanilla PPO (mods off)');
+{
+  const frame = await runConfig('vanilla', {
+    numEnvs: 4, speedMult: 200, episodeLen: 15,
+    backend: 'js', threads: 1, minibatch: 128, horizon: 64, epochs: 2,
+    klStop: false, mirror: false, neuronRepair: false, failRate: 0, groupSize: 1,
+  }, 15000);
   if (frame) {
     check(`updates completed (${frame.iteration})`, frame.iteration > 0);
-    check('losses finite',
-      Number.isFinite(frame.loss.pi) && Number.isFinite(frame.loss.v));
-    check('sigma reported', Array.isArray(frame.sigma) && Number.isFinite(frame.sigma[0]));
-    check(`adaptive γ reported (${frame.gamma})`,
-      Number.isFinite(frame.gamma) && frame.gamma >= 0.99 && frame.gamma <= 0.998);
+    check('losses finite', Number.isFinite(frame.loss.pi) && Number.isFinite(frame.loss.v));
+    check(`all epochs ran without KL stop (${frame.mods.epochs}/2)`, frame.mods.epochs === 2);
+    check('no mods reported active',
+      frame.mods.groupSize === 1 && !frame.mods.mirror && !frame.mods.repair && frame.mods.masked === 0);
   }
-
-  inbox.length = 0;
-  send({ type: 'exportModel' });
-  const exp = await waitFor(m => m.type === 'modelExport', 3000);
-  const m = exp && exp.model;
-  check('export is a complete PPO model',
-    !!m && m.algo === 'ppo' && m.actor && m.critic && Array.isArray(m.logStd));
+  const m = await exportModel();
+  check('export is a complete PPO model', !!m && m.algo === 'ppo' && m.actor && m.critic);
 }
 
-// ── 3. Adaptive γ rises under stagnation ─────────────────────────────────────
-//  All reward terms zeroed → every episode returns exactly 0 → the windowed
-//  average cannot improve → after GAMMA_STAGNATION_UPDATES updates the live γ
-//  must have been raised above its base.
-console.log('\n3. Adaptive γ under forced reward stagnation');
+// ── 3. KL early stop (forced) ────────────────────────────────────────────────
+console.log('\n3. KL early stop');
 {
-  const frame = await runAlgo('ppo-stagnant', {
-    algo: 'ppo', numEnvs: 4, speedMult: 200, episodeLen: 10,
-    backend: 'js', threads: 1, minibatch: 128, horizon: 64, epochs: 2,
-    progressReward: 0, lapBonus: 0, gravelPenalty: 0, wallPenalty: 0, terminalPenalty: 0,
-  }, 30000);
-
-  check('frame received', !!frame);
+  const frame = await runConfig('kl-stop', {
+    numEnvs: 4, speedMult: 200, episodeLen: 15,
+    backend: 'js', threads: 1, minibatch: 128, horizon: 64, epochs: 4,
+    klStop: true, klLimit: 1e-9,  // any movement at all must trigger the stop
+  }, 15000);
   if (frame) {
-    console.log(`  updates ${frame.iteration} · episodes ${frame.episodes} · γ ${frame.gamma.toFixed(4)}`);
-    check(`enough updates ran for the stagnation window (${frame.iteration})`, frame.iteration >= 12);
-    check(`γ rose above its 0.99 base (${frame.gamma.toFixed(4)})`, frame.gamma > 0.9905);
-    check('γ stayed below its cap', frame.gamma <= 0.998);
+    check(`updates completed (${frame.iteration})`, frame.iteration > 0);
+    check(`stopped after the first epoch (${frame.mods.epochs}/4)`, frame.mods.epochs === 1);
+    check(`KL movement measured (${frame.mods.kl.toExponential(2)})`,
+      Number.isFinite(frame.mods.kl) && frame.mods.kl > 1e-9);
   }
+}
+
+// ── 4. Agent groups (GRPO-style) ─────────────────────────────────────────────
+console.log('\n4. Agent groups ×4');
+{
+  const frame = await runConfig('groups', {
+    numEnvs: 8, speedMult: 200, episodeLen: 10,
+    backend: 'js', threads: 1, minibatch: 128, horizon: 32, epochs: 2,
+    groupSize: 4, klStop: false,
+  }, 25000);
+  if (frame) {
+    check(`group updates completed (${frame.iteration})`, frame.iteration > 0);
+    check('losses finite', Number.isFinite(frame.loss.pi) && Number.isFinite(frame.loss.v));
+    check('group size reported', frame.mods.groupSize === 4);
+    check(`episodes completed (${frame.episodes})`, frame.episodes > 0);
+  }
+  const m = await exportModel();
+  check('export still complete under group mode', !!m && m.actor.flat.every(Number.isFinite));
+}
+
+// ── 5. Mirror + failure rate + neuron repair together ────────────────────────
+console.log('\n5. Combined: mirror + 10% defect weights + neuron repair');
+{
+  const frame = await runConfig('combo', {
+    numEnvs: 4, speedMult: 200, episodeLen: 12,
+    backend: 'js', threads: 1, minibatch: 128, horizon: 64, epochs: 2,
+    mirror: true, failRate: 0.10, neuronRepair: true, klStop: true,
+  }, 25000);
+  if (frame) {
+    check(`updates completed (${frame.iteration})`, frame.iteration > 0);
+    check('losses finite', Number.isFinite(frame.loss.pi) && Number.isFinite(frame.loss.v));
+    check('every agent drives a defect-masked copy', frame.mods.masked === 4);
+    check('repair stats reported', !!frame.mods.repair &&
+      frame.mods.repair.recycled >= 0 && frame.mods.repair.splits >= 0);
+    console.log(`  updates ${frame.iteration} · epochs ${frame.mods.epochs} · ` +
+                `KL ${frame.mods.kl.toFixed(4)} · repair ♻${frame.mods.repair.recycled}/✂${frame.mods.repair.splits}`);
+  }
+  // manual repair pass must not corrupt the weights
+  send({ type: 'repairNow' });
+  await new Promise(res => setTimeout(res, 500));
+  const m = await exportModel();
+  check('weights finite after manual repair pass',
+    !!m && m.actor.flat.every(Number.isFinite) && m.critic.flat.every(Number.isFinite));
+}
+
+// ── 6. Neuron repair mechanics on a crafted network ──────────────────────────
+//  Import a model whose hidden layer contains one DEAD neuron (outgoing
+//  weights all zero → zero influence) and one OVERTUNED neuron (outgoing
+//  ×20 → influence far above the layer mean). One repair pass must recycle
+//  the dead one and split the dominant one.
+console.log('\n6. Neuron repair on a crafted network');
+{
+  const { Net } = await import('../scripts/nn-core.js');
+  const OBS = 40, ACT = 6, H = 32;
+  const actor = new Net([OBS, H, ACT], 1);
+  const critic = new Net([OBS, H, 1], 1);
+  for (let o = 0; o < ACT; o++) actor.W[1][o * H + 0] = 0;     // neuron 0: dead
+  for (let o = 0; o < ACT; o++) actor.W[1][o * H + 1] *= 20;   // neuron 1: overtuned
+  const model = {
+    algo: 'ppo', obsDim: OBS, actDim: ACT,
+    actor: { sizes: actor.sizes, flat: actor.flat() },
+    critic: { sizes: critic.sizes, flat: critic.flat() },
+    logStd: Array(ACT).fill(-0.5),
+  };
+
+  inbox.length = 0;
+  send({
+    type: 'init', track: makeTrack(), carData, model,
+    config: {
+      numEnvs: 4, speedMult: 200, episodeLen: 15,
+      backend: 'js', threads: 1, hiddenSize: H, hiddenLayers: 1,
+      neuronRepair: true, klStop: false, mirror: false, failRate: 0, groupSize: 1,
+    },
+  });
+  const ready = await waitFor(m => m.type === 'ready', 5000);
+  check('crafted model imported', !!ready);
+  send({ type: 'start' });
+  await new Promise(res => setTimeout(res, 6000));  // fill the obs reservoir
+  send({ type: 'repairNow' });
+  await new Promise(res => setTimeout(res, 1000));
+  inbox.length = 0;  // drop the run's stale frames — we want the latest stats
+  send({ type: 'getSnapshot' });
+  const frame = await waitFor(m => m.type === 'frame', 3000);
+  send({ type: 'stop' });
+  if (frame) {
+    console.log(`  repair: recycled ${frame.mods.repair.recycled} · splits ${frame.mods.repair.splits}`);
+    check('dead neuron was recycled', frame.mods.repair.recycled >= 1);
+    check('overtuned neuron was split', frame.mods.repair.splits >= 1);
+  } else {
+    check('snapshot after repair', false);
+  }
+  const m = await exportModel();
+  check('weights finite after crafted repair', !!m && m.actor.flat.every(Number.isFinite));
 }
 
 console.log(failures ? `\n${failures} CHECK(S) FAILED` : '\nall checks passed');

--- a/games/ai-trainer/test/tf-worker-check.mjs
+++ b/games/ai-trainer/test/tf-worker-check.mjs
@@ -74,7 +74,19 @@ console.log('\nPPO update round (tf cpu backend)');
   const N = 64;
   const obs = new Float32Array(N * OBS).map(() => Math.random() * 2 - 1);
   const act = new Float32Array(N * ACT).map(() => Math.random() * 2 - 1);
-  const logp = new Float32Array(N).fill(-2);
+  // genuine behavior log-probs under the initial actor — the KL-stop baseline
+  // (kl0 ≈ 0) only holds when the stored logp matches the starting policy
+  const LOG_2PI = Math.log(2 * Math.PI);
+  const logp = new Float32Array(N);
+  for (let k = 0; k < N; k++) {
+    const mu = actor.forward(obs.subarray(k * OBS, (k + 1) * OBS));
+    let lp = 0;
+    for (let d = 0; d < ACT; d++) {
+      const z = (act[k * ACT + d] - mu[d]) / Math.exp(-0.5);
+      lp += -0.5 * z * z - (-0.5) - 0.5 * LOG_2PI;
+    }
+    logp[k] = lp;
+  }
   const adv = new Float32Array(N).map(() => Math.random() * 2 - 1);
   const ret = new Float32Array(N).map(() => Math.random());
   send({
@@ -87,6 +99,18 @@ console.log('\nPPO update round (tf cpu backend)');
   check('update returns finite weights',
     r.type === 'updated' && finite(r.actorFlat) && finite(r.criticFlat) &&
     Number.isFinite(r.loss.pi) && Number.isFinite(r.loss.v));
+  check(`all epochs ran without KL stop (${r.epochs}/2)`, r.epochs === 2);
+
+  // KL early stop: with a near-zero limit any movement must end the update
+  // after the first epoch
+  send({
+    type: 'update', n: N, obs, act, logp, adv, ret,
+    hp: { clip: 0.2, entropyCoef: 0.003, vfCoef: 0.5, lr: 3e-4, klStop: true, klLimit: 1e-12 },
+    epochs: 4, minibatch: 32,
+  });
+  const r2 = await nextReply();
+  check(`KL stop ends the update after one epoch (${r2.epochs}/4, KL ${r2.kl.toExponential(2)})`,
+    r2.type === 'updated' && r2.epochs === 1 && Number.isFinite(r2.kl));
 }
 
 console.log(failures ? `\n${failures} CHECK(S) FAILED` : '\nall checks passed');

--- a/games/turborace/scripts/ppo-ai.js
+++ b/games/turborace/scripts/ppo-ai.js
@@ -6,9 +6,8 @@ import { state } from './state.js';
 //
 //  Reproduces the exact observation layout of ai-trainer/scripts/sim-worker.js
 //  (40 inputs: 11 track-edge rays, 7 wall rays, 6 state scalars, 6 centerline
-//  probes × 2, 4 memory cells) and runs the exported actor network
+//  probes × 2, 4 memory cells) and runs the exported PPO actor network
 //  deterministically (mean action, no exploration noise) on a real race Car.
-//  PPO and ES exports share the same actor shape, so both drive here.
 // ─────────────────────────────────────────────────────────────────────────────
 
 const STORAGE_KEY = 'turborace_trained_ai_model';
@@ -53,9 +52,8 @@ function raySegment(ox, oz, dx, dz, ax, az, bx, bz) {
 
 /** Throws with a human-readable message if the model can't drive here. */
 export function validateTrainedModel(model) {
-  const okAlgo = model && (model.algo === 'ppo' || model.algo === 'es');
-  if (!okAlgo || !model.actor || !Array.isArray(model.actor.sizes) || !Array.isArray(model.actor.flat)) {
-    throw new Error('Not an AI Trainer PPO/ES export');
+  if (!model || model.algo !== 'ppo' || !model.actor || !Array.isArray(model.actor.sizes) || !Array.isArray(model.actor.flat)) {
+    throw new Error('Not an AI Trainer PPO export');
   }
   const sizes = model.actor.sizes;
   if (model.obsDim !== OBS_DIM || sizes[0] !== OBS_DIM || sizes[sizes.length - 1] !== ACT_DIM) {


### PR DESCRIPTION
## Summary
- Removed ES and adaptive discount; gamma is now a constant
- Added five independently toggleable PPO modifications:
  - **Agent Groups**: GRPO-style baseline with group-relative advantage
  - **Mirror Augment**: Left/right symmetric data augmentation
  - **KL Early Stop**: Adaptive epoch skipping based on KL movement
  - **Neuron Repair**: Dead neuron recycling and overtuned neuron splitting
  - **Failure Rate**: Weight dropout for robustness training
- Comprehensive smoke and tf-worker harness tests covering all mods

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vpcg4TQUbnP6k7QpmZqwvG)_