### PR TITLE
AI trainer: make reward values directly typable

### DIFF
--- a/games/ai-trainer/index.html
+++ b/games/ai-trainer/index.html
@@ -491,27 +491,27 @@
     <div class="ctrl-row">
       <span class="ctrl-label">PROGRESS /m</span>
       <span class="ctrl-val" id="progVal">0.20</span>
-      <input type="range" id="progSlider" min="0.05" max="1" value="0.2" step="0.05" style="accent-color:#4f4;">
+      <input type="range" id="progSlider" min="0" max="2" value="0.2" step="0.05" style="accent-color:#4f4;">
     </div>
     <div class="ctrl-row">
       <span class="ctrl-label">LAP BONUS</span>
       <span class="ctrl-val" id="lapBonusVal">20</span>
-      <input type="range" id="lapBonusSlider" min="0" max="100" value="20" step="5" style="accent-color:#4f4;">
+      <input type="range" id="lapBonusSlider" min="0" max="500" value="20" step="5" style="accent-color:#4f4;">
     </div>
     <div class="ctrl-row">
       <span class="ctrl-label">GRAVEL /s</span>
       <span class="ctrl-val" id="gravelVal">1.0</span>
-      <input type="range" id="gravelSlider" min="0" max="5" value="1" step="0.1" style="accent-color:#f44;">
+      <input type="range" id="gravelSlider" min="0" max="100" value="1" step="0.5" style="accent-color:#f44;">
     </div>
     <div class="ctrl-row">
       <span class="ctrl-label">WALL /s</span>
       <span class="ctrl-val" id="wallVal">2.0</span>
-      <input type="range" id="wallSlider" min="0" max="10" value="2" step="0.5" style="accent-color:#f44;">
+      <input type="range" id="wallSlider" min="0" max="100" value="2" step="0.5" style="accent-color:#f44;">
     </div>
     <div class="ctrl-row">
       <span class="ctrl-label">CRASH-OUT</span>
       <span class="ctrl-val" id="termVal">10</span>
-      <input type="range" id="termSlider" min="0" max="50" value="10" step="1" style="accent-color:#f44;">
+      <input type="range" id="termSlider" min="0" max="200" value="10" step="1" style="accent-color:#f44;">
     </div>
   </div>
 

--- a/games/ai-trainer/scripts/trainer-app.js
+++ b/games/ai-trainer/scripts/trainer-app.js
@@ -582,17 +582,41 @@ function selectMapAndConfigure() {
 // ─────────────────────────────────────────────────────────────────────────────
 //  In-trainer controls sidebar
 // ─────────────────────────────────────────────────────────────────────────────
-function wireSlider(sliderId, valId, key, fmtFn) {
+function wireSlider(sliderId, valId, key, fmtFn, editable) {
   const sl = document.getElementById(sliderId);
   const vl = document.getElementById(valId);
   sl.value = simCfg[key];
   vl.textContent = fmtFn ? fmtFn(simCfg[key]) : simCfg[key];
-  sl.addEventListener('input', () => {
-    const v = parseFloat(sl.value);
+
+  // Apply a value from any source: store it, sync the slider (it clamps to its
+  // own min/max, but simCfg keeps the real value so typed values can exceed it).
+  const apply = (v) => {
     simCfg[key] = v;
+    sl.value = v;
     vl.textContent = fmtFn ? fmtFn(v) : v;
     if (worker) worker.postMessage({ type: 'setConfig', config: { [key]: v } });
-  });
+  };
+
+  sl.addEventListener('input', () => apply(parseFloat(sl.value)));
+
+  // Click the value to type any number directly — not limited to the slider range.
+  if (editable) {
+    vl.title = 'Click to type any value';
+    vl.contentEditable = 'true';
+    vl.addEventListener('focus', () => {
+      vl.textContent = String(simCfg[key]);
+      const r = document.createRange(); r.selectNodeContents(vl);
+      const sel = getSelection(); sel.removeAllRanges(); sel.addRange(r);
+    });
+    vl.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') { e.preventDefault(); vl.blur(); }
+    });
+    vl.addEventListener('blur', () => {
+      const v = parseFloat(vl.textContent);
+      if (isFinite(v)) apply(Math.max(0, v));
+      else vl.textContent = fmtFn ? fmtFn(simCfg[key]) : simCfg[key];
+    });
+  }
 }
 
 function initUI() {
@@ -624,11 +648,11 @@ function initUI() {
   document.getElementById('repairNowBtn').addEventListener('click', () => {
     if (worker) worker.postMessage({ type: 'repairNow' });
   });
-  wireSlider('progSlider',    'progVal',    'progressReward',  v => v.toFixed(2));
-  wireSlider('gravelSlider',  'gravelVal',  'gravelPenalty',   v => v.toFixed(1));
-  wireSlider('wallSlider',    'wallVal',    'wallPenalty',     v => v.toFixed(1));
-  wireSlider('termSlider',    'termVal',    'terminalPenalty', v => Math.round(v));
-  wireSlider('lapBonusSlider','lapBonusVal','lapBonus',        v => Math.round(v));
+  wireSlider('progSlider',    'progVal',    'progressReward',  v => v.toFixed(2), true);
+  wireSlider('gravelSlider',  'gravelVal',  'gravelPenalty',   v => v.toFixed(1), true);
+  wireSlider('wallSlider',    'wallVal',    'wallPenalty',     v => v.toFixed(1), true);
+  wireSlider('termSlider',    'termVal',    'terminalPenalty', v => Math.round(v), true);
+  wireSlider('lapBonusSlider','lapBonusVal','lapBonus',        v => Math.round(v), true);
 
   document.getElementById('loadBestBtn').addEventListener('click', () => {
     if (worker) worker.postMessage({ type: 'loadBest' });


### PR DESCRIPTION
## Summary

- Make reward values directly typable in AI trainer UI
- Improve reward configuration workflow

## Commits

- AI trainer: make reward values directly typable
- Merge pull request #320 from rcktgrl/claude/friendly-volta-v1are4
- ai-trainer: fix critic value normalization + add recurrent (GRU) PPO
- And 48 additional commits across map editor, AI training, and Free Drive improvements

---
_Generated by [Claude Code](https://claude.ai/code/session_013hNyq1RPzjSj44vRTzzRfW)_