### PR TITLE
Rename LMP to KSP for the server status indicator

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,7 +111,7 @@
 
     <div id="server-status" class="server-status">
       <span class="server-status__item">
-        <span class="status-dot" id="dot-lmp"></span> LMP
+        <span class="status-dot" id="dot-ksp"></span> KSP
       </span>
       <span class="server-status__item">
         <span class="status-dot" id="dot-matrix"></span> Matrix

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -39,12 +39,12 @@ const ocsGalleryCleanup = initOcsGallerySlider();
 
 // ---------------------------------------------------------------------------
 // Server status
-// Polls status.nele.pet and reflects the LMP/Matrix server states as dots
+// Polls status.nele.pet and reflects the KSP/Matrix server states as dots
 // in the homepage header.
 // ---------------------------------------------------------------------------
 
 const serverStatusCleanup = initServerStatus({
-  lmpDot:    document.getElementById('dot-lmp'),
+  kspDot:    document.getElementById('dot-ksp'),
   matrixDot: document.getElementById('dot-matrix'),
 });
 

--- a/scripts/server-status.js
+++ b/scripts/server-status.js
@@ -1,7 +1,7 @@
 /**
  * server-status.js
  *
- * Polls status.nele.pet for the LMP and Matrix server states and reflects
+ * Polls status.nele.pet for the KSP and Matrix server states and reflects
  * them as coloured dots in the homepage header.
  */
 
@@ -29,18 +29,18 @@ function setDotState(dotElement, isOnline) {
  * Fetch the latest status and update both dots. Falls back to offline for
  * both services if the request fails (e.g. the status host is unreachable).
  *
- * @param {HTMLElement|null} lmpDot
+ * @param {HTMLElement|null} kspDot
  * @param {HTMLElement|null} matrixDot
  */
-async function refreshServerStatus(lmpDot, matrixDot) {
+async function refreshServerStatus(kspDot, matrixDot) {
   try {
     const response = await fetch(STATUS_URL, { cache: 'no-store' });
     const data = await response.json();
 
-    setDotState(lmpDot, data.lmp === 'online');
+    setDotState(kspDot, data.ksp === 'online');
     setDotState(matrixDot, data.matrix === 'online');
   } catch {
-    setDotState(lmpDot, false);
+    setDotState(kspDot, false);
     setDotState(matrixDot, false);
   }
 }
@@ -49,15 +49,15 @@ async function refreshServerStatus(lmpDot, matrixDot) {
  * Initialise the server status indicator and return a cleanup function.
  *
  * @param {object}          options
- * @param {HTMLElement}     options.lmpDot    - Status dot for the LMP server.
+ * @param {HTMLElement}     options.kspDot    - Status dot for the KSP server.
  * @param {HTMLElement}     options.matrixDot - Status dot for the Matrix server.
  * @returns {() => void} A cleanup function that stops the polling interval.
  */
-export function initServerStatus({ lmpDot, matrixDot }) {
-  refreshServerStatus(lmpDot, matrixDot);
+export function initServerStatus({ kspDot, matrixDot }) {
+  refreshServerStatus(kspDot, matrixDot);
 
   const intervalId = setInterval(() => {
-    refreshServerStatus(lmpDot, matrixDot);
+    refreshServerStatus(kspDot, matrixDot);
   }, POLL_INTERVAL_MS);
 
   return () => {


### PR DESCRIPTION
## Changes
- Rename LMP to KSP for the server status indicator
- Includes merge of server status display feature

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4kpo1Mm7RfbQacx5YoviJ)_