### PR TITLE
Fix KSP indicator by reading correct field from status.json

### DIFF
--- a/scripts/server-status.js
+++ b/scripts/server-status.js
@@ -37,7 +37,7 @@ async function refreshServerStatus(kspDot, matrixDot) {
     const response = await fetch(STATUS_URL, { cache: 'no-store' });
     const data = await response.json();
 
-    setDotState(kspDot, data.ksp === 'online');
+    setDotState(kspDot, data.lmp === 'online');
     setDotState(matrixDot, data.matrix === 'online');
   } catch {
     setDotState(kspDot, false);


### PR DESCRIPTION
## Summary

- Fix KSP indicator by reading the correct field from status.json
- Rename LMP to KSP for the server status indicator
- Add LMP/Matrix server status indicator to homepage

---
_Generated by [Claude Code](https://claude.ai/code/session_016DBcr6WieeQg4vJ1kPLBX5)_