### PR TITLE
ai-trainer: stop the off-track containment from walling off gravel runoff

### DIFF
--- a/games/ai-trainer/scripts/sim-worker.js
+++ b/games/ai-trainer/scripts/sim-worker.js
@@ -556,7 +556,13 @@ class SimCar {
       // left the track with no pushback and no penalty at all.
     }
 
-    const dist = Math.sqrt(md), maxD = (trkData ? trkData.rw * 0.5 : 8) + 1.0;
+    // Last-resort containment for cars that got past the wall mesh (gaps where
+    // track-gen.js culled segments, or a high-speed clip-through). Bound it at
+    // the OUTER edge of the gravel runoff — the barrier line — so runoff stays
+    // drivable. Using the road edge here makes gravel act like a wall.
+    const dist = Math.sqrt(md);
+    const roadEdge = (trkData ? trkData.rw * 0.5 : 8) + 1.0;
+    const maxD = Math.max(roadEdge, this.runoffOuterEdge() + 1.0);
     if (dist > maxD) {
       const px = np.x - this.pos.x, pz = np.z - this.pos.z;
       const pl = Math.sqrt(px * px + pz * pz) || 1;
@@ -572,6 +578,32 @@ class SimCar {
     } else {
       this.stuckTimer = Math.max(0, this.stuckTimer - 0.032);
     }
+  }
+
+  // Outer edge of the gravel runoff on the car's current side, measured from
+  // the centreline — i.e. where track-gen.js places the barrier. 0 when the
+  // track has no runoff profile.
+  //
+  // The road-width fallback containment in boundary() MUST use this, not the
+  // road half-width: gravel starts at rw/2 + 1.75, which is already outside
+  // rw/2 + 1.0, so containing at the road edge walls the car off from the
+  // runoff entirely and gravel behaves like a barrier.
+  runoffOuterEdge() {
+    const profile = gravelProfile;
+    if (!profile) return 0;
+    const { pts, leftRunoff, rightRunoff, rw } = profile;
+    const n = pts.length;
+    const near = nearestIdx(this.pos.x, this.pos.z, pts, this.gravelHint, 40);
+    const ni = near.idx;
+    const p   = pts[ni];
+    const nxt = pts[(ni + 1) % n], prv = pts[(ni + n - 1) % n];
+    const tx  = nxt.x - prv.x, tz = nxt.z - prv.z;
+    const tl  = Math.hypot(tx, tz) || 1;
+    const nx  = -tz / tl, nz = tx / tl;
+    const lat = (this.pos.x - p.x) * nx + (this.pos.z - p.z) * nz;
+    const ri  = Math.min(ni, rightRunoff.length - 1);
+    const gravelW = lat >= 0 ? (rightRunoff[ri] || 0) : (leftRunoff[ri] || 0);
+    return rw / 2 + 1.75 + gravelW;
   }
 
   checkGravel() {

--- a/games/ai-trainer/test/wall-containment-check.mjs
+++ b/games/ai-trainer/test/wall-containment-check.mjs
@@ -1,19 +1,25 @@
 'use strict';
 // ─────────────────────────────────────────────────────────────────────────────
-//  wall-containment-check.mjs — regression test for the off-track containment
-//  bug in SimCar.boundary().
+//  wall-containment-check.mjs — regression tests for SimCar.boundary().
 //
-//  boundary() used to `return` unconditionally inside `if (wallPt)`. Since
-//  nearestWallPoint() returns non-null whenever that side has ANY segments, the
-//  road-width containment below it was dead code on every track with walls.
-//  track-gen.js deliberately DROPS wall segments that self-intersect or intrude
-//  into the track interior (tight corners), and in those gaps a car could leave
-//  the track entirely — no pushback, no stuckTimer, no penalty.
+//  Covers two bugs that came as a pair:
 //
-//  This builds a ring whose OUTER wall has a deliberate gap and asserts that no
-//  car ever gets further from the centerline than the road half-width allows.
-//  The inner wall stays complete so nearestWallPoint() keeps returning non-null
-//  (side.n > 0) — that is what made the old code skip containment.
+//  1. Off-track containment was unreachable. boundary() returned unconditionally
+//     inside `if (wallPt)`, and nearestWallPoint() returns non-null whenever the
+//     side has ANY segments (its own `return null` is annotated "unreachable
+//     while side.n > 0"), so the road-width check below never ran on a track
+//     with walls. track-gen.js DROPS wall segments that self-intersect or
+//     intrude into the track interior (tight corners), and in those gaps a car
+//     left the track with no pushback and no penalty.
+//
+//  2. Fixing (1) re-enabled a bound of rw/2 + 1.0 — which is INSIDE where
+//     gravel starts (rw/2 + 1.75). That pushed cars back before they could
+//     reach the runoff, so gravel behaved exactly like a wall. The fallback
+//     must bound at the OUTER edge of the runoff, where track-gen puts the
+//     barrier.
+//
+//  Track geometry here mirrors track-gen.js: road ±rw/2, gravel runoff from
+//  rw/2+1.75 outward, barrier at the outer edge of the runoff.
 //
 //  Run:  node games/ai-trainer/test/wall-containment-check.mjs
 // ─────────────────────────────────────────────────────────────────────────────
@@ -43,93 +49,120 @@ async function waitFor(pred, ms) {
 }
 
 const R = 100, HALF = 8, N = 128;
+const RUNOFF = 6;
+const GRAVEL_INNER = HALF + 1.75;              // checkGravel(): rw/2 + 1.75
+const GRAVEL_OUTER = GRAVEL_INNER + RUNOFF;    // barrier line
+const ROAD_EDGE    = HALF + 1.0;               // bound when there is no runoff
 // Outer wall missing across this index range — the "culled segments" case.
 const GAP_FROM = 30, GAP_TO = 80;
 
-function makeGappedTrack() {
+function makeTrack({ gravel }) {
   const pts = [], wallLeft = [], wallRight = [], wp = [];
   for (let i = 0; i < N; i++) {
     const a = (i / N) * 2 * Math.PI;
     pts.push({ x: Math.cos(a) * R, y: 0, z: Math.sin(a) * R });
     wp.push([Math.cos(a) * R, 0, Math.sin(a) * R]);
   }
+  // Barrier sits at the outer edge of the runoff, as track-gen.js places it.
+  const wallOff = gravel ? GRAVEL_OUTER : HALF;
   for (let i = 0; i < N; i++) {
     const j = (i + 1) % N;
     const seg = r => ({
       x0: pts[i].x / R * r, z0: pts[i].z / R * r,
       x1: pts[j].x / R * r, z1: pts[j].z / R * r,
     });
-    wallLeft.push(seg(R - HALF));                         // inner wall: complete
-    if (i < GAP_FROM || i > GAP_TO) wallRight.push(seg(R + HALF)); // outer: gapped
+    wallLeft.push(seg(R - wallOff));                             // inner: complete
+    if (i < GAP_FROM || i > GAP_TO) wallRight.push(seg(R + wallOff)); // outer: gapped
   }
-  return { pts, wallLeft, wallRight, data: { wp, rw: HALF * 2, laps: 3 } };
+  const track = { pts, wallLeft, wallRight, data: { wp, rw: HALF * 2, laps: 3 } };
+  if (gravel) {
+    track.gravelProfile = {
+      pts: pts.map(p => ({ x: p.x, y: p.y, z: p.z })),
+      leftRunoff:  new Array(N).fill(RUNOFF),
+      rightRunoff: new Array(N).fill(RUNOFF),
+      rw: HALF * 2,
+    };
+  }
+  return track;
 }
 
 const carData = { accel: 12, maxSpd: 50, brake: 25, hdl: 1.0, aiSpd: 1.0 };
-
-const track = makeGappedTrack();
-check('outer wall really has a gap (and inner wall does not)',
-  track.wallRight.length < track.wallLeft.length && track.wallRight.length > 0,
-  `${track.wallRight.length} outer vs ${track.wallLeft.length} inner segments`);
-
-inbox.length = 0;
-send({ type: 'init', track, carData, config: {
-  numEnvs: 24, randomSpawn: true, episodeLen: 30,
-  horizon: 1000000,          // no PPO update — this is a physics test
-  speedMult: 40, backend: 'js', threads: 1,
-  wallHitPenalty: 50,
-}});
-check('worker initialized on the gapped track', !!await waitFor(m => m.type === 'ready', 8000));
-
-// ── Direct boundary() probes ────────────────────────────────────────────────
-// A driving policy rarely wanders far enough out to exercise the gap, so probe
-// boundary() directly at chosen poses instead of hoping a rollout gets there.
-const maxD = HALF + 1.0;      // the bound boundary() is supposed to enforce
 const at = (idx, radius) => {
   const a = (idx / N) * 2 * Math.PI;
   return { x: Math.cos(a) * radius, z: Math.sin(a) * radius };
 };
+const offsetOf = res => Math.abs(Math.hypot(res.x, res.z) - R);
 
-// Sanity: the gap really is a hole in the outer wall — the nearest right-side
-// wall point from deep inside the gap must be far away, which is precisely the
-// condition under which the old code skipped containment.
+async function initTrack(track, cfg = {}) {
+  inbox.length = 0;
+  send({ type: 'init', track, carData, config: {
+    numEnvs: 24, randomSpawn: true, episodeLen: 30,
+    horizon: 1000000,           // no PPO update — this is a physics test
+    speedMult: 40, backend: 'js', threads: 1, wallHitPenalty: 50, ...cfg,
+  }});
+  return !!await waitFor(m => m.type === 'ready', 8000);
+}
+
+// ── Track with gravel runoff ────────────────────────────────────────────────
+const gravelTrack = makeTrack({ gravel: true });
+check('worker initialized on the gapped gravel track', await initTrack(gravelTrack));
+check('outer wall really has a gap (inner does not)',
+  gravelTrack.wallRight.length < gravelTrack.wallLeft.length && gravelTrack.wallRight.length > 0,
+  `${gravelTrack.wallRight.length} outer vs ${gravelTrack.wallLeft.length} inner segments`);
+
+// The gap is a genuine hole: nothing within WALL_STOP to stop a car there.
 {
-  const p = at((GAP_FROM + GAP_TO) / 2, R + HALF);
+  const p = at((GAP_FROM + GAP_TO) / 2, R + GRAVEL_OUTER);
   const wp = sim.nearestWallForTest(p.x, p.z, 'right');
   const d = wp ? Math.hypot(wp.x - p.x, wp.z - p.z) : Infinity;
   check('nearest outer wall from mid-gap is beyond WALL_STOP (1.2 m)',
     !!wp && d > 1.2, wp ? `${d.toFixed(1)} m away` : 'no wall point at all');
 }
 
-// The real regression: a car well outside the road, in the gap, must be pushed
-// back inside. Before the fix boundary() returned early here and did nothing.
+// REGRESSION 2 — gravel must stay drivable, in the gap and where walls exist.
 {
-  const OUT = R + HALF + 12;                       // 12 m beyond the road edge
+  let worstPush = 0, anyFlagged = false, n = 0;
+  for (const idx of [10, 40, 55, 70, 100]) {
+    for (const off of [GRAVEL_INNER + 0.5, (GRAVEL_INNER + GRAVEL_OUTER) / 2, GRAVEL_OUTER - 0.5]) {
+      const p = at(idx, R + off);
+      const res = sim.boundaryProbeForTest(p.x, p.z, 0, 30);
+      const push = Math.hypot(res.x - p.x, res.z - p.z);
+      if (push > worstPush) worstPush = push;
+      if (res.wallHit) anyFlagged = true;
+      n++;
+    }
+  }
+  check('cars on gravel runoff are NOT pushed back (gravel is not a wall)',
+    worstPush < 1e-9, `worst pushback ${worstPush.toFixed(3)} m over ${n} probes`);
+  check('cars on gravel runoff are NOT flagged as wall contact', !anyFlagged);
+}
+
+// REGRESSION 1 — past the runoff, inside the wall gap, containment must apply.
+{
+  const OUT = GRAVEL_OUTER + 10;
   let worstAfter = 0, allFlagged = true, n = 0;
   for (let idx = GAP_FROM + 5; idx <= GAP_TO - 5; idx += 5) {
-    const p = at(idx, OUT);
+    const p = at(idx, R + OUT);
     const res = sim.boundaryProbeForTest(p.x, p.z, 0, 30);
-    const after = Math.abs(Math.hypot(res.x, res.z) - R);
+    const after = offsetOf(res);
     if (after > worstAfter) worstAfter = after;
     if (!res.wallHit) allFlagged = false;
     n++;
   }
-  check(`cars ${OUT - R} m off-centre inside the gap are pushed back onto the road`,
-    worstAfter < OUT - R, `worst remaining offset ${worstAfter.toFixed(2)} m over ${n} probes`);
-  check('off-track contact is flagged for the reward (wallHit)', allFlagged);
+  check('cars past the runoff inside the gap are pulled back',
+    worstAfter < OUT, `worst remaining offset ${worstAfter.toFixed(2)} m over ${n} probes`);
+  check('that off-track contact is flagged for the reward (wallHit)', allFlagged);
 }
 
-// Control: the same probe where the outer wall EXISTS must also be contained
-// (that path always worked — this guards against the fix breaking it).
+// Control: same probe where the wall is intact (this path always worked).
 {
-  const p = at(5, R + HALF + 12);
+  const p = at(5, R + GRAVEL_OUTER + 10);
   const res = sim.boundaryProbeForTest(p.x, p.z, 0, 30);
-  const after = Math.abs(Math.hypot(res.x, res.z) - R);
   check('control: containment still works where the wall is intact',
-    after <= maxD + 0.6 && res.wallHit, `offset ${after.toFixed(2)} m`);
+    offsetOf(res) < GRAVEL_OUTER + 10 && res.wallHit, `offset ${offsetOf(res).toFixed(2)} m`);
 }
 
-// Control: a car comfortably ON the road must NOT be flagged or moved.
+// Control: a car on the centreline is untouched.
 {
   const p = at(50, R);
   const res = sim.boundaryProbeForTest(p.x, p.z, 0, 30);
@@ -138,26 +171,35 @@ const at = (idx, radius) => {
     moved < 1e-9 && !res.wallHit, `moved ${moved.toExponential(1)} m`);
 }
 
-// ── Rollout smoke: nothing escapes during real driving either ───────────────
+// ── Track WITHOUT runoff keeps the original road-width bound ────────────────
+check('worker initialized on the no-gravel track', await initTrack(makeTrack({ gravel: false })));
+{
+  const p = at(55, R + HALF + 12);
+  const res = sim.boundaryProbeForTest(p.x, p.z, 0, 30);
+  check('no-gravel track: still contained at the road edge',
+    offsetOf(res) <= ROAD_EDGE + 0.6 && res.wallHit, `offset ${offsetOf(res).toFixed(2)} m`);
+}
+
+// ── Rollout smoke on the gravel track ───────────────────────────────────────
+check('re-initialized gravel track for rollout', await initTrack(gravelTrack));
 send({ type: 'start' });
 const DEADLINE = Date.now() + 12000;
-let worst = 0, worstSeen = false;
+let worst = 0, seen = false;
 while (Date.now() < DEADLINE) {
   const f = await waitFor(m => m.type === 'frame', 3000);
   if (!f) break;
   for (const c of f.cars) {
     const d = Math.abs(Math.hypot(c.x, c.z) - R);
     if (d > worst) worst = d;
-    worstSeen = true;
+    seen = true;
   }
 }
 send({ type: 'stop' });
-
-check('saw car telemetry', worstSeen);
+check('saw car telemetry', seen);
 const TOL = 2.0;   // containment is a post-move push: allow a tick of overshoot
-check('no car escapes the road width during a rollout',
-  worst <= maxD + TOL,
-  `worst radial offset ${worst.toFixed(2)} m (bound ${maxD.toFixed(2)} + ${TOL} tol)`);
+check('no car escapes past the barrier line during a rollout',
+  worst <= GRAVEL_OUTER + 1.0 + TOL,
+  `worst radial offset ${worst.toFixed(2)} m (bound ${(GRAVEL_OUTER + 1.0).toFixed(2)} + ${TOL} tol)`);
 
 console.log(failures ? `\n${failures} CHECK(S) FAILED` : '\nall checks passed');
 process.exit(failures ? 1 : 0);

--- a/games/turborace/scripts/car.js
+++ b/games/turborace/scripts/car.js
@@ -227,7 +227,12 @@ class Car {
       // stops transferring into the game.
     }
 
-    const dist = Math.sqrt(md), maxD = state.trkData.rw * .5 + 1.0;
+    // Last-resort containment for cars that got past the wall mesh (gaps where
+    // track-gen.js culled segments, or a high-speed clip-through). Bound it at
+    // the OUTER edge of the gravel runoff — the barrier line — so runoff stays
+    // drivable. Using the road edge here makes gravel act like a wall.
+    const dist = Math.sqrt(md);
+    const maxD = Math.max(state.trkData.rw * .5 + 1.0, this.runoffOuterEdge() + 1.0);
     if (dist > maxD) {
       const px = np.x - this.pos.x, pz = np.z - this.pos.z, pl = Math.sqrt(px * px + pz * pz) || 1;
       this.pos.x += px / pl * (dist - maxD + 0.5);
@@ -244,6 +249,32 @@ class Car {
     } else {
       this.stuckTimer = Math.max(0, this.stuckTimer - 0.032);
     }
+  }
+
+  // Outer edge of the gravel runoff on the car's current side, measured from
+  // the centreline — i.e. where track-gen.js places the barrier. 0 when the
+  // track has no runoff profile. Used by boundary()'s fallback containment so
+  // the runoff stays drivable instead of behaving like a barrier.
+  // Mirrors SimCar.runoffOuterEdge() in ai-trainer/scripts/sim-worker.js.
+  runoffOuterEdge() {
+    const profile = state.gravelProfile;
+    if (!profile) return 0;
+    const { pts, leftRunoff, rightRunoff, rw } = profile;
+    const n = pts.length;
+    let md = Infinity, ni = 0;
+    for (let i = 0; i < n; i++) {
+      const d = (this.pos.x - pts[i].x) ** 2 + (this.pos.z - pts[i].z) ** 2;
+      if (d < md) { md = d; ni = i; }
+    }
+    const p = pts[ni];
+    const nxt = pts[(ni + 1) % n], prv = pts[(ni + n - 1) % n];
+    const tx = nxt.x - prv.x, tz = nxt.z - prv.z;
+    const tl = Math.hypot(tx, tz) || 1;
+    const nx = -tz / tl, nz = tx / tl;
+    const lat = (this.pos.x - p.x) * nx + (this.pos.z - p.z) * nz;
+    const runoffIdx = Math.min(ni, rightRunoff.length - 1);
+    const gravelW = lat >= 0 ? (rightRunoff[runoffIdx] || 0) : (leftRunoff[runoffIdx] || 0);
+    return rw / 2 + 1.75 + gravelW;
   }
 
   checkGravel() {


### PR DESCRIPTION
## Summary

- Fix regression from containment fix in #335 where off-track boundary was walling off gravel runoff
- Adjust containment bound to outer edge of runoff (barrier line) via new runoffOuterEdge()
- Mirror identical fix to turborace/scripts/car.js to keep trainer and game physics in sync
- Update tests to match track-gen.js patterns and verify gravel is drivable and unflagged

## Changes

- ai-trainer: new runoffOuterEdge() bound with fallback to road edge
- turborace: mirror containment fix for consistent physics
- test: comprehensive gravel drivability and containment verification

---
_Generated by [Claude Code](https://claude.ai/code/session_01H2sbCihHWakN6h19b9Rs4R)_