### PR TITLE
ai-trainer: assert the DEBUG button, not just the D key

### DIFF
--- a/games/ai-trainer/scripts/trainer-app.js
+++ b/games/ai-trainer/scripts/trainer-app.js
@@ -574,7 +574,11 @@ function dbgRender() {
   if (dbg.stepsPerSec && simCfg.numEnvs) {
     const achieved = dbg.stepsPerSec / simCfg.numEnvs / 60;
     const frac = achieved / Math.max(1, simCfg.speedMult);
-    txt('dbgSpeed', `${achieved.toFixed(0)}× of ${simCfg.speedMult}× asked`);
+    // Below 1× the integer form reads "0×", which looks like a broken readout
+    // rather than "running slower than real time" — keep a decimal down there.
+    const shown = achieved < 10 ? achieved.toFixed(achieved < 1 ? 2 : 1)
+                                : achieved.toFixed(0);
+    txt('dbgSpeed', `${shown}× of ${simCfg.speedMult}× asked`);
     cls('dbgSpeedRow', frac < 0.5 ? 'dbg-warn' : null);
     document.getElementById('dbgSpeedNote').textContent = frac < 0.9
       ? 'compute-bound below the requested multiplier — raising it changes nothing'

--- a/games/ai-trainer/test/debug-overlay-check.mjs
+++ b/games/ai-trainer/test/debug-overlay-check.mjs
@@ -87,7 +87,12 @@ await page.waitForFunction(
 check('trainer reached its first policy update', true);
 
 console.log('\n2. Overlay reports live data');
-await page.keyboard.press('d');
+// Open with the BUTTON, not the key. The first version of this panel shipped
+// with setDbg() defined and nothing calling it: the button rendered, did
+// nothing, and a keyboard-only check passed. Both paths get asserted now.
+await page.click('#dbgBtn');
+check('the DEBUG button opens the panel',
+  await page.evaluate(() => document.getElementById('dbgWrap').classList.contains('on')));
 // one profiler window, plus the next update so seconds/update has a reading
 await page.waitForFunction(
   () => (document.getElementById('dbgSpu') || {}).textContent !== '—',
@@ -122,11 +127,19 @@ check(`inference is the batched kernel, not the fallback (${ui.infer})`, ui.infe
 check(`ray casting is the kernel, not the fallback (${ui.ray})`, ui.ray === 'wasm');
 check(`no updates rejected as non-finite (${ui.rej})`, ui.rej === '0');
 
-console.log('\n4. Toggling off stops the profiler');
-await page.keyboard.press('d');
-await page.waitForTimeout(300);
-const off = await page.evaluate(() => document.getElementById('dbgWrap').classList.contains('on'));
-check('panel closes again', !off);
+console.log('\n4. Both toggles work in both directions');
+await page.keyboard.press('d');                 // key closes what the button opened
+await page.waitForTimeout(200);
+check('the D key closes the panel',
+  !await page.evaluate(() => document.getElementById('dbgWrap').classList.contains('on')));
+await page.keyboard.press('d');                 // key opens
+await page.waitForTimeout(200);
+check('the D key opens the panel',
+  await page.evaluate(() => document.getElementById('dbgWrap').classList.contains('on')));
+await page.click('#dbgBtn');                    // button closes
+await page.waitForTimeout(200);
+check('the DEBUG button closes the panel',
+  !await page.evaluate(() => document.getElementById('dbgWrap').classList.contains('on')));
 
 await browser.close();
 server.close();


### PR DESCRIPTION
- Assert the DEBUG button, not just the D key
- Stop printing "0×" for achieved speed; keep decimals under 10×
- Add comprehensive coverage for debug overlay in both keyboard and button paths

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7dhjMgS1dtHcVVqCm4n5g)_